### PR TITLE
downgrade scripting packages to 1.3.2

### DIFF
--- a/src/Dotnet.Script/project.json
+++ b/src/Dotnet.Script/project.json
@@ -24,7 +24,7 @@
 
   "dependencies": {
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",
-    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-beta3",
+    "Microsoft.CodeAnalysis.CSharp.Scripting": "1.3.2",
     "Microsoft.Extensions.CommandLineUtils": "1.0.0",
     "Microsoft.NETCore.App": {
       "type": "platform",


### PR DESCRIPTION
`2.0.0-beta3` is actually older than `1.3.2` and references older packages 😄 

Fixes #1 