### PR TITLE
Don't crash on errors

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -33,7 +33,28 @@ namespace Dotnet.Script
             "System.Collections.Generic"
         };
 
-        public static void Main(string[] args)
+        const string DebugFlagShort = "-d";
+        const string DebugFlagLong = "--debug";
+
+        public static int Main(string[] args)
+        {
+            try
+            {
+                return Wain(args);
+            }
+            catch (Exception e)
+            {
+                // Be verbose (stack trace) in debug mode otherwise brief
+                var error = args.Any(arg => arg == DebugFlagShort
+                                         || arg == DebugFlagLong)
+                          ? e.ToString()
+                          : e.GetBaseException().Message;
+                Console.Error.WriteLine(error);
+                return 0xbad;
+            }
+        }
+
+        private static int Wain(string[] args)
         {
             var commandLineApplication = new CommandLineApplication(throwOnUnexpectedArg: false);
 
@@ -41,7 +62,7 @@ namespace Dotnet.Script
 
             var scriptArgs = commandLineApplication.Option("-a |--arg <args>", "Arguments to pass to a script. Multiple values supported", CommandOptionType.MultipleValue);
             var config = commandLineApplication.Option("-c |--configuration <configuration>", "Configuration to use. Defaults to 'Release'", CommandOptionType.SingleValue);
-            var debugMode = commandLineApplication.Option("-d |--debug", "Enables debug output.", CommandOptionType.NoValue);
+            var debugMode = commandLineApplication.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
 
             commandLineApplication.HelpOption("-? | -h | --help");
             commandLineApplication.OnExecute(() =>
@@ -53,7 +74,7 @@ namespace Dotnet.Script
                 return 0;
             });
 
-            commandLineApplication.Execute(args);
+            return commandLineApplication.Execute(args);
         }
 
         private static void RunScript(string file, string config, bool debugMode, List<string> scriptArgs)


### PR DESCRIPTION
`dotnet script` _crashes_ on any error (like bad command-line arguments).

For example on Windows, assuming a script `foo.csx` in the current directory, running the following:

    dotnet script foo.csx -c

will end with a crash:

![image](https://cloud.githubusercontent.com/assets/20511/19304856/a57539ce-906e-11e6-9e59-5546b545446d.png)

and the following message on the console:

```
Specify --help for a list of available options and commands.
Unhandled Exception: Microsoft.Extensions.CommandLineUtils.CommandParsingException: Missing value for option 'configuration'
   at Microsoft.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Dotnet.Script.Program.Main(String[] args)
```

This PR fixes the issue by handling all exceptions at program entry-point level so it can terminate normally but signal an error condition to any caller with a non-zero exit code (as per convention for OS processes).
