### PR TITLE
Allow script to run in spite of warnings

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -152,7 +152,7 @@ namespace Dotnet.Script
             var script = CSharpScript.Create(code, opts, typeof(ScriptingHost), loader);
             var compilation = script.GetCompilation();
             var diagnostics = compilation.GetDiagnostics();
-            if (diagnostics.Any())
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
             {
                 foreach (var diagnostic in diagnostics)
                 {
@@ -162,6 +162,12 @@ namespace Dotnet.Script
             }
             else
             {
+                if (debugMode)
+                {
+                    foreach (var diagnostic in diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning))
+                        Console.Error.WriteLine(diagnostic);
+                }
+
                 var host = new ScriptingHost
                 {
                     ScriptDirectory = directory,


### PR DESCRIPTION
Create a script `foo.csx` with the following:

```c#
class U { public int i; }
struct S { public U u; }
Console.WriteLine("hello");
```

Run with:

    dotnet script foo.csx

Output claims script has errors when it doesn't, because it treats warnings as errors by default:

```
There is an error in the script.Field 'U.i' is never assigned to, and will always have its default value 0
There is an error in the script.Field 'S.u' is never assigned to, and will always have its default value null
```

This PR fixes this by ignoring warnings and letting the script run. Warnings are still emitted but only when the `--debug` switch is supplied:

```
(1,22): warning CS0649: Field 'U.i' is never assigned to, and will always have its default value 0
(2,21): warning CS0649: Field 'S.u' is never assigned to, and will always have its default value null
```
