### PR TITLE
Use STDERR for debug & runner output

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -53,7 +53,7 @@ namespace Dotnet.Script
 
         private static void RunScript(string file, string config, bool debugMode, List<string> scriptArgs)
         {
-            var runner = new ScriptRunner();
+            var runner = new ScriptRunner(Console.Error);
             var context = new ScriptContext(file, config, debugMode, scriptArgs);
 
             runner.Execute<object>(context).GetAwaiter().GetResult();


### PR DESCRIPTION
Debug and runner output should use `STDERR` only so that it doesn't interfere with _real_ output from script being run. For example, if the script produces a CSV, the runner will currently produced corrupted output (especially with `--debug`). This PR fixes this by exclusively using `STDERR` for the runner.