### PR TITLE
rename ScriptArgs to Args

### DIFF
--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -122,7 +122,7 @@ namespace Dotnet.Script
             {
                 ScriptDirectory = directory,
                 ScriptPath = context.FilePath,
-                ScriptArgs = context.ScriptArgs,
+                Args = context.ScriptArgs,
             };
 
             return new ScriptCompilationContext<TReturn>(compilation, script, host, sourceText, loader);

--- a/src/Dotnet.Script/ScriptingHost.cs
+++ b/src/Dotnet.Script/ScriptingHost.cs
@@ -5,7 +5,7 @@ namespace Dotnet.Script
 {
     public class ScriptingHost
     {
-        public IReadOnlyList<string> ScriptArgs { get; internal set; }
+        public IReadOnlyList<string> Args { get; internal set; }
 
         public string ScriptDirectory { get; internal set; }
 


### PR DESCRIPTION
This way, scripts that are written to run with csi.exe can be run with this app.

E.g. xBehave's build script - https://github.com/xbehave/xbehave.net/blob/dev/build.csx#L83