### PR TITLE
make ScriptingHost inherit from InteractiveScriptGlobals

### DIFF
--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Text;
@@ -118,12 +119,16 @@ namespace Dotnet.Script
                                                     diagnostics);
             }
 
-            var host = new ScriptingHost
+            var host = new ScriptingHost(Console.Out, CSharpObjectFormatter.Instance)
             {
                 ScriptDirectory = directory,
                 ScriptPath = context.FilePath,
-                Args = context.ScriptArgs,
             };
+
+            foreach (var arg in context.ScriptArgs)
+            {
+                host.Args.Add(arg);
+            }
 
             return new ScriptCompilationContext<TReturn>(compilation, script, host, sourceText, loader);
         }

--- a/src/Dotnet.Script/ScriptingHost.cs
+++ b/src/Dotnet.Script/ScriptingHost.cs
@@ -1,11 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using System.IO;
 using System.Reflection;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
 
 namespace Dotnet.Script
 {
-    public class ScriptingHost
+    public class ScriptingHost : InteractiveScriptGlobals
     {
-        public IReadOnlyList<string> Args { get; internal set; }
+        public ScriptingHost(TextWriter outputWriter, ObjectFormatter objectFormatter)
+            : base(outputWriter, objectFormatter)
+        {
+        }
 
         public string ScriptDirectory { get; internal set; }
 


### PR DESCRIPTION
This way, *any* script written for csi.exe will run in dotnet-script.