### PR TITLE
Added support for code execution + bug fixes

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -41,7 +41,7 @@ namespace Dotnet.Script
 
             app.HelpOption("-? | -h | --help");
 
-            app.Command("code", c =>
+            app.Command("eval", c =>
             {
                 c.Description = "Execute CSX code.";
                 var code = c.Argument("code", "Code to execute.");
@@ -63,6 +63,8 @@ namespace Dotnet.Script
                 {
                     RunScript(file.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), scriptArgs.HasValue() ? scriptArgs.Values : new List<string>());
                 }
+
+                app.ShowHelp();
                 return 0;
             });
 

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.CommandLineUtils;
 
 namespace Dotnet.Script
@@ -30,16 +33,31 @@ namespace Dotnet.Script
 
         private static int Wain(string[] args)
         {
-            var commandLineApplication = new CommandLineApplication(throwOnUnexpectedArg: false);
+            var app = new CommandLineApplication(throwOnUnexpectedArg: false);
+            var file = app.Argument("script", "Path to CSX script");
+            var scriptArgs = app.Option("-a |--arg <args>", "Arguments to pass to a script. Multiple values supported", CommandOptionType.MultipleValue);
+            var config = app.Option("-conf |--configuration <configuration>", "Configuration to use. Defaults to 'Release'", CommandOptionType.SingleValue);
+            var debugMode = app.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
 
-            var file = commandLineApplication.Argument("script", "Path to CSX script");
+            app.HelpOption("-? | -h | --help");
 
-            var scriptArgs = commandLineApplication.Option("-a |--arg <args>", "Arguments to pass to a script. Multiple values supported", CommandOptionType.MultipleValue);
-            var config = commandLineApplication.Option("-c |--configuration <configuration>", "Configuration to use. Defaults to 'Release'", CommandOptionType.SingleValue);
-            var debugMode = commandLineApplication.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
+            app.Command("code", c =>
+            {
+                c.Description = "Execute CSX code.";
+                var code = c.Argument("code", "Code to execute.");
+                var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for the code compiler. Defaults to current directory.", CommandOptionType.SingleValue);
 
-            commandLineApplication.HelpOption("-? | -h | --help");
-            commandLineApplication.OnExecute(() =>
+                c.OnExecute(() =>
+                {
+                    if (!string.IsNullOrWhiteSpace(code.Value))
+                    {
+                        RunCode(code.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), scriptArgs.HasValue() ? scriptArgs.Values : new List<string>(), cwd.Value());
+                    }
+                    return 0;
+                });
+            });
+
+            app.OnExecute(() =>
             {
                 if (!string.IsNullOrWhiteSpace(file.Value))
                 {
@@ -48,13 +66,33 @@ namespace Dotnet.Script
                 return 0;
             });
 
-            return commandLineApplication.Execute(args);
+            return app.Execute(args);
         }
 
         private static void RunScript(string file, string config, bool debugMode, List<string> scriptArgs)
         {
-            var context = new ScriptContext(file, config, scriptArgs);
+            if (!File.Exists(file))
+            {
+                throw new Exception($"Couldn't find file '{file}'");
+            }
 
+            var directory = Path.IsPathRooted(file) ? Path.GetDirectoryName(file) : Directory.GetCurrentDirectory();
+            var sourceText = SourceText.From(new FileStream(file, FileMode.Open), Encoding.UTF8);
+            var context = new ScriptContext(sourceText, directory, config, scriptArgs, file);
+
+            Run(debugMode, context);
+        }
+
+        private static void RunCode(string code, string config, bool debugMode, List<string> scriptArgs, string currentWorkingDirectory)
+        {
+            var sourceText = SourceText.From(code, Encoding.UTF8);
+            var context = new ScriptContext(sourceText, currentWorkingDirectory ?? Directory.GetCurrentDirectory(), config, scriptArgs);
+
+            Run(debugMode, context);
+        }
+
+        private static void Run(bool debugMode, ScriptContext context)
+        {
             var runner = debugMode ? new DebugScriptRunner(Console.Error) : new ScriptRunner(Console.Error);
             runner.Execute<object>(context).GetAwaiter().GetResult();
         }

--- a/src/Dotnet.Script/ScriptContext.cs
+++ b/src/Dotnet.Script/ScriptContext.cs
@@ -1,20 +1,27 @@
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Dotnet.Script
 {
     public class ScriptContext
     {
-        public ScriptContext(string file, string config, List<string> scriptArgs)
+        public ScriptContext(SourceText code, string workingDirectory, string config, List<string> scriptArgs, string filePath = null)
         {
-            FilePath = file;
+            Code = code;
+            WorkingDirectory = workingDirectory;
             Configuration = config;
             ScriptArgs = scriptArgs;
+            FilePath = filePath;
         }
 
-        public string FilePath { get; }
+        public SourceText Code { get; }
+
+        public string WorkingDirectory { get; }
 
         public string Configuration { get; }
 
         public List<string> ScriptArgs { get; }
+
+        public string FilePath { get; }
     }
 }

--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -50,14 +50,7 @@ namespace Dotnet.Script
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            if (!File.Exists(context.FilePath))
-            {
-                WriteLine($"Couldn't find file '{context.FilePath}'");
-                throw new Exception($"Couldn't find file '{context.FilePath}'");
-            }
-
-            var directory = Path.IsPathRooted(context.FilePath) ? Path.GetDirectoryName(context.FilePath) : Directory.GetCurrentDirectory();
-            var runtimeContext = ProjectContext.CreateContextForEachTarget(directory).First();
+            var runtimeContext = ProjectContext.CreateContextForEachTarget(context.WorkingDirectory).First();
 
             VerboseWriteLine($"Found runtime context for '{runtimeContext.ProjectFile.ProjectFilePath}'");
 
@@ -77,15 +70,16 @@ namespace Dotnet.Script
                 }
             }
 
-            //var code = File.ReadAllText(context.FilePath);
-            var sourceText = SourceText.From(new FileStream(context.FilePath, FileMode.Open), Encoding.UTF8);
-
             var opts = ScriptOptions.Default.
-                WithFilePath(context.FilePath).
                 AddImports(DefaultNamespaces).
                 AddReferences(DefaultAssemblies).
                 AddReferences(typeof(ScriptingHost).GetTypeInfo().Assembly).
-                WithSourceResolver(new RemoteFileResolver(directory));
+                WithSourceResolver(new RemoteFileResolver(context.WorkingDirectory));
+
+            if (!string.IsNullOrWhiteSpace(context.FilePath))
+            {
+                opts = opts.WithFilePath(context.FilePath);
+            }
 
             var runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
             var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x => x.FullName.ToLowerInvariant().StartsWith("system.") || x.FullName.ToLowerInvariant().StartsWith("mscorlib"));
@@ -104,7 +98,7 @@ namespace Dotnet.Script
             }
 
             var loader = new InteractiveAssemblyLoader();
-            var script = CSharpScript.Create<TReturn>(sourceText.ToString(), opts, typeof(ScriptingHost), loader);
+            var script = CSharpScript.Create<TReturn>(context.Code.ToString(), opts, typeof(ScriptingHost), loader);
             var compilation = script.GetCompilation();
             var diagnostics = compilation.GetDiagnostics();
 
@@ -121,7 +115,7 @@ namespace Dotnet.Script
 
             var host = new ScriptingHost(Console.Out, CSharpObjectFormatter.Instance)
             {
-                ScriptDirectory = directory,
+                ScriptDirectory = context.WorkingDirectory,
                 ScriptPath = context.FilePath,
             };
 
@@ -130,7 +124,7 @@ namespace Dotnet.Script
                 host.Args.Add(arg);
             }
 
-            return new ScriptCompilationContext<TReturn>(compilation, script, host, sourceText, loader);
+            return new ScriptCompilationContext<TReturn>(compilation, script, host, context.Code, loader);
         }
 
         public virtual async Task<TReturn> Execute<TReturn>(ScriptContext context)

--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -82,7 +82,10 @@ namespace Dotnet.Script
             }
 
             var runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
-            var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x => x.FullName.ToLowerInvariant().StartsWith("system.") || x.FullName.ToLowerInvariant().StartsWith("mscorlib"));
+            var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x => 
+            x.FullName.ToLowerInvariant().StartsWith("system.") ||
+            x.FullName.ToLowerInvariant().StartsWith("microsoft.codeanalysis") ||
+            x.FullName.ToLowerInvariant().StartsWith("mscorlib"));
 
             foreach (var inheritedAssemblyName in inheritedAssemblyNames)
             {
@@ -113,12 +116,7 @@ namespace Dotnet.Script
                                                     diagnostics);
             }
 
-            var host = new ScriptingHost(Console.Out, CSharpObjectFormatter.Instance)
-            {
-                ScriptDirectory = context.WorkingDirectory,
-                ScriptPath = context.FilePath,
-            };
-
+            var host = new ScriptingHost(Console.Out, CSharpObjectFormatter.Instance);
             foreach (var arg in context.ScriptArgs)
             {
                 host.Args.Add(arg);

--- a/src/Dotnet.Script/ScriptingHost.cs
+++ b/src/Dotnet.Script/ScriptingHost.cs
@@ -11,10 +11,6 @@ namespace Dotnet.Script
         {
         }
 
-        public string ScriptDirectory { get; internal set; }
-
-        public string ScriptPath { get; internal set; }
-
         public Assembly ScriptAssembly { get; internal set; }
     }
 }

--- a/src/Dotnet.Script/project.json
+++ b/src/Dotnet.Script/project.json
@@ -18,7 +18,7 @@
   },
   "buildOptions": {
     "emitEntryPoint": true,
-    "outputName": "dotnet-script",
+    //"outputName": "dotnet-script",
     "debugType": "portable"
   },
 

--- a/src/Dotnet.Script/project.json
+++ b/src/Dotnet.Script/project.json
@@ -18,7 +18,7 @@
   },
   "buildOptions": {
     "emitEntryPoint": true,
-    //"outputName": "dotnet-script",
+    "outputName": "dotnet-script",
     "debugType": "portable"
   },
 


### PR DESCRIPTION
 - added support for code execution (fileless) i.e. `dotnet script eval Console.WriteLine(\"Hi\");`. This is based on `node -e console.log(\"foo\")`
 - show help if running without any args i.e. `dotnet script`
 - fixed a bug introduced by @adamralph 😄 `c:\script-test2\foo.csx(4,5): error CS0012: The type 'InteractiveScriptGlobals' is defined in an assembly that is not referenced. You must add a reference to assembly 'Microsoft.CodeAnalysis.Scripting, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.`
 - removed everything from `ScriptingHost` except for `ScriptAssembly`