### PR TITLE
Fix to not show help at the end of script run

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -61,10 +61,13 @@ namespace Dotnet.Script
             {
                 if (!string.IsNullOrWhiteSpace(file.Value))
                 {
-                    RunScript(file.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), scriptArgs.HasValue() ? scriptArgs.Values : new List<string>());
+                    RunScript(file.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(),
+                        scriptArgs.HasValue() ? scriptArgs.Values : new List<string>());
                 }
-
-                app.ShowHelp();
+                else
+                {
+                    app.ShowHelp();
+                }
                 return 0;
             });
 


### PR DESCRIPTION
Help should display only when zero/no args were supplied but right now it's displaying unconditionally. This PR fixes ba0e4bad0f34844b23059492bc0847b2fbdc3f0b that bork this.
