### PR TITLE
Fix potential file leak & locking

### DIFF
--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -76,8 +76,8 @@ namespace Dotnet.Script
                 }
             }
 
-            //var code = File.ReadAllText(context.FilePath);
-            var sourceText = SourceText.From(new FileStream(context.FilePath, FileMode.Open), Encoding.UTF8);
+            var code = File.ReadAllBytes(context.FilePath);
+            var sourceText = SourceText.From(code, code.Length, Encoding.UTF8);
 
             var opts = ScriptOptions.Default.
                 WithFilePath(context.FilePath).


### PR DESCRIPTION
The opened `FileStream` is not closed/disposed anywhere in a deterministic fashion and in face of unclear ownership for now, it seems safest to just buffer the content.
