### PR TITLE
Fixed a bug with relative paths

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -81,7 +81,7 @@ namespace Dotnet.Script
                 throw new Exception($"Couldn't find file '{file}'");
             }
 
-            var directory = Path.IsPathRooted(file) ? Path.GetDirectoryName(file) : Directory.GetCurrentDirectory();
+            var directory = Path.IsPathRooted(file) ? Path.GetDirectoryName(file) : Path.GetDirectoryName(Path.Combine(Directory.GetCurrentDirectory(), file));
             var sourceText = SourceText.From(new FileStream(file, FileMode.Open), Encoding.UTF8);
             var context = new ScriptContext(sourceText, directory, config, scriptArgs, file);
 

--- a/src/Dotnet.Script/project.json
+++ b/src/Dotnet.Script/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.3.1-*",
+  "version": "0.4.0-*",
   "description": "Dotnet CLI tool allowing you to run C# (CSX) scripts.",
   "authors": [ "filipw" ],
   "packOptions": {


### PR DESCRIPTION
This worked:
 - `dotnet script foo.csx`
 - `dotnet script c:\foo.csx`
 - `dotnet script ~\foo.csx`

But not this:
 - `dotnet script foo\bar.csx`