### PR TITLE
Script args at tail for more intuitive usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ Hello from foo.csx
 
 ### Passing arguments to scripts
 
-You can pass arguments to the script the following way:
+All arguments after `--` are passed to the script in the following way:
 
 ```
-dotnet script foo.csx -a arg1 -a arg2 -a arg3
+dotnet script foo.csx -- arg1 arg2 arg3
 ```
 
-Then you can access the arguments in the script context using a global `ScriptArgs` collection:
+Then you can access the arguments in the script context using the global `ScriptArgs` collection:
 
 ```
 foreach (var arg in ScriptArgs)
@@ -168,6 +168,14 @@ foreach (var arg in ScriptArgs)
     Console.WriteLine(arg);
 }
 ```
+
+All arguments before `--` are processed by `dotnet script`. For example, the following command-line
+
+```
+dotnet script -d foo.csx -- -d
+```
+
+will pass the `-d` before `--` to `dotnet script` and enable the debug mode whereas the `-d` after `--` is passed to script for its own interpretation of the argument.
 
 ## Issues and problems
 

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -40,6 +40,10 @@ namespace Dotnet.Script
 
             app.HelpOption("-? | -h | --help");
 
+            var scriptArgsMarkerIndex = Array.FindIndex(args, arg => arg == "--");
+            var argCount = scriptArgsMarkerIndex >= 0 ? scriptArgsMarkerIndex : args.Length;
+            var scriptArgList = args.Skip(argCount + 1).ToList();
+
             app.Command("eval", c =>
             {
                 c.Description = "Execute CSX code.";
@@ -50,7 +54,7 @@ namespace Dotnet.Script
                 {
                     if (!string.IsNullOrWhiteSpace(code.Value))
                     {
-                        RunCode(code.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), app.RemainingArguments, cwd.Value());
+                        RunCode(code.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), scriptArgList, cwd.Value());
                     }
                     return 0;
                 });
@@ -61,7 +65,7 @@ namespace Dotnet.Script
                 if (!string.IsNullOrWhiteSpace(file.Value))
                 {
                     RunScript(file.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(),
-                        app.RemainingArguments);
+                        scriptArgList);
                 }
                 else
                 {
@@ -70,7 +74,7 @@ namespace Dotnet.Script
                 return 0;
             });
 
-            return app.Execute(args);
+            return app.Execute(args.Take(argCount).ToArray());
         }
 
         private static void RunScript(string file, string config, bool debugMode, List<string> scriptArgs)

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -35,7 +35,6 @@ namespace Dotnet.Script
         {
             var app = new CommandLineApplication(throwOnUnexpectedArg: false);
             var file = app.Argument("script", "Path to CSX script");
-            var scriptArgs = app.Option("-a |--arg <args>", "Arguments to pass to a script. Multiple values supported", CommandOptionType.MultipleValue);
             var config = app.Option("-conf |--configuration <configuration>", "Configuration to use. Defaults to 'Release'", CommandOptionType.SingleValue);
             var debugMode = app.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
 
@@ -51,7 +50,7 @@ namespace Dotnet.Script
                 {
                     if (!string.IsNullOrWhiteSpace(code.Value))
                     {
-                        RunCode(code.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), scriptArgs.HasValue() ? scriptArgs.Values : new List<string>(), cwd.Value());
+                        RunCode(code.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), app.RemainingArguments, cwd.Value());
                     }
                     return 0;
                 });
@@ -62,7 +61,7 @@ namespace Dotnet.Script
                 if (!string.IsNullOrWhiteSpace(file.Value))
                 {
                     RunScript(file.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(),
-                        scriptArgs.HasValue() ? scriptArgs.Values : new List<string>());
+                        app.RemainingArguments);
                 }
                 else
                 {


### PR DESCRIPTION
An attempt at addressing #11. I say attempt because while it worked for the script case, it didn't for the eval one & I ran out of my quantum. :)
