### PR TITLE
ScriptCompilationContext.Compilation is redundant

### DIFF
--- a/src/Dotnet.Script/ScriptCompilationContext.cs
+++ b/src/Dotnet.Script/ScriptCompilationContext.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Text;
@@ -7,15 +6,13 @@ namespace Dotnet.Script
 {
     public class ScriptCompilationContext<TReturn>
     {
-        public Compilation Compilation { get; }
         public Script<TReturn> Script { get; }
         public InteractiveScriptGlobals Host { get; }
         public SourceText SourceText { get; }
         public InteractiveAssemblyLoader Loader { get; }
 
-        public ScriptCompilationContext(Compilation compilation, Script<TReturn> script, InteractiveScriptGlobals host, SourceText sourceText, InteractiveAssemblyLoader loader)
+        public ScriptCompilationContext(Script<TReturn> script, InteractiveScriptGlobals host, SourceText sourceText, InteractiveAssemblyLoader loader)
         {
-            Compilation = compilation;
             Script = script;
             Host = host;
             SourceText = sourceText;

--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -121,7 +121,7 @@ namespace Dotnet.Script
                 host.Args.Add(arg);
             }
 
-            return new ScriptCompilationContext<TReturn>(compilation, script, host, context.Code, loader);
+            return new ScriptCompilationContext<TReturn>(script, host, context.Code, loader);
         }
 
         public virtual async Task<TReturn> Execute<TReturn>(ScriptContext context)


### PR DESCRIPTION
The `Compilation` object is available via `ScriptCompilationContext.Script.GetCompilation` so seems redundant to carry it around.