### PR TITLE
Script args on context should be read-only like rest

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -42,7 +42,7 @@ namespace Dotnet.Script
 
             var scriptArgsMarkerIndex = Array.FindIndex(args, arg => arg == "--");
             var argCount = scriptArgsMarkerIndex >= 0 ? scriptArgsMarkerIndex : args.Length;
-            var scriptArgList = args.Skip(argCount + 1).ToList();
+            var scriptArgs = args.Skip(argCount + 1);
 
             app.Command("eval", c =>
             {
@@ -54,7 +54,7 @@ namespace Dotnet.Script
                 {
                     if (!string.IsNullOrWhiteSpace(code.Value))
                     {
-                        RunCode(code.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), scriptArgList, cwd.Value());
+                        RunCode(code.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(), scriptArgs, cwd.Value());
                     }
                     return 0;
                 });
@@ -65,7 +65,7 @@ namespace Dotnet.Script
                 if (!string.IsNullOrWhiteSpace(file.Value))
                 {
                     RunScript(file.Value, config.HasValue() ? config.Value() : "Release", debugMode.HasValue(),
-                        scriptArgList);
+                        scriptArgs);
                 }
                 else
                 {
@@ -77,7 +77,7 @@ namespace Dotnet.Script
             return app.Execute(args.Take(argCount).ToArray());
         }
 
-        private static void RunScript(string file, string config, bool debugMode, List<string> scriptArgs)
+        private static void RunScript(string file, string config, bool debugMode, IEnumerable<string> args)
         {
             if (!File.Exists(file))
             {
@@ -86,15 +86,15 @@ namespace Dotnet.Script
 
             var directory = Path.IsPathRooted(file) ? Path.GetDirectoryName(file) : Path.GetDirectoryName(Path.Combine(Directory.GetCurrentDirectory(), file));
             var sourceText = SourceText.From(new FileStream(file, FileMode.Open), Encoding.UTF8);
-            var context = new ScriptContext(sourceText, directory, config, scriptArgs, file);
+            var context = new ScriptContext(sourceText, directory, config, args, file);
 
             Run(debugMode, context);
         }
 
-        private static void RunCode(string code, string config, bool debugMode, List<string> scriptArgs, string currentWorkingDirectory)
+        private static void RunCode(string code, string config, bool debugMode, IEnumerable<string> args, string currentWorkingDirectory)
         {
             var sourceText = SourceText.From(code, Encoding.UTF8);
-            var context = new ScriptContext(sourceText, currentWorkingDirectory ?? Directory.GetCurrentDirectory(), config, scriptArgs);
+            var context = new ScriptContext(sourceText, currentWorkingDirectory ?? Directory.GetCurrentDirectory(), config, args);
 
             Run(debugMode, context);
         }

--- a/src/Dotnet.Script/ScriptContext.cs
+++ b/src/Dotnet.Script/ScriptContext.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
 
@@ -5,12 +7,12 @@ namespace Dotnet.Script
 {
     public class ScriptContext
     {
-        public ScriptContext(SourceText code, string workingDirectory, string config, List<string> scriptArgs, string filePath = null)
+        public ScriptContext(SourceText code, string workingDirectory, string config, IEnumerable<string> args, string filePath = null)
         {
             Code = code;
             WorkingDirectory = workingDirectory;
             Configuration = config;
-            ScriptArgs = scriptArgs;
+            Args = new ReadOnlyCollection<string>(args.ToArray());
             FilePath = filePath;
         }
 
@@ -20,7 +22,7 @@ namespace Dotnet.Script
 
         public string Configuration { get; }
 
-        public List<string> ScriptArgs { get; }
+        public IReadOnlyList<string> Args { get; }
 
         public string FilePath { get; }
     }

--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -116,7 +116,7 @@ namespace Dotnet.Script
             }
 
             var host = new InteractiveScriptGlobals(Console.Out, CSharpObjectFormatter.Instance);
-            foreach (var arg in context.ScriptArgs)
+            foreach (var arg in context.Args)
             {
                 host.Args.Add(arg);
             }


### PR DESCRIPTION
All other properties on `ScriptContext` are read-only so seems inconsistent that the script args should be a modifiable list especially when there's no need ever to modify it. This PR renames `ScriptContext.ScriptArgs` to simply `ScriptContext.Args` & renders it read-only.