### PR TITLE
Split ScriptRunner into runner and compiler classes

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -101,7 +101,9 @@ namespace Dotnet.Script
 
         private static void Run(bool debugMode, ScriptContext context)
         {
-            var runner = debugMode ? new DebugScriptRunner(Console.Error) : new ScriptRunner(Console.Error);
+            var logger = new ScriptLogger(Console.Error, debugMode);
+            var compiler = new ScriptCompiler(logger);
+            var runner = debugMode ? new DebugScriptRunner(compiler, logger) : new ScriptRunner(compiler, logger);
             runner.Execute<object>(context).GetAwaiter().GetResult();
         }
     }

--- a/src/Dotnet.Script/ScriptCompilationContext.cs
+++ b/src/Dotnet.Script/ScriptCompilationContext.cs
@@ -7,14 +7,14 @@ namespace Dotnet.Script
     public class ScriptCompilationContext<TReturn>
     {
         public Script<TReturn> Script { get; }
-        public InteractiveScriptGlobals Host { get; }
+
         public SourceText SourceText { get; }
+
         public InteractiveAssemblyLoader Loader { get; }
 
-        public ScriptCompilationContext(Script<TReturn> script, InteractiveScriptGlobals host, SourceText sourceText, InteractiveAssemblyLoader loader)
+        public ScriptCompilationContext(Script<TReturn> script, SourceText sourceText, InteractiveAssemblyLoader loader)
         {
             Script = script;
-            Host = host;
             SourceText = sourceText;
             Loader = loader;
         }

--- a/src/Dotnet.Script/ScriptCompiler.cs
+++ b/src/Dotnet.Script/ScriptCompiler.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Dotnet.Script
+{
+    public class ScriptCompiler
+    {
+        private readonly ScriptLogger _logger;
+
+        private static readonly IEnumerable<Assembly> DefaultAssemblies = new[]
+        {
+            typeof(object).GetTypeInfo().Assembly,
+            typeof(Enumerable).GetTypeInfo().Assembly
+        };
+
+        private static readonly IEnumerable<string> DefaultNamespaces = new[]
+        {
+            "System",
+            "System.IO",
+            "System.Linq",
+            "System.Collections.Generic"
+        };
+
+        public ScriptCompiler(ScriptLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public ScriptCompilationContext<TReturn> CreateCompilationContext<TReturn, THost>(ScriptContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var runtimeContext = ProjectContext.CreateContextForEachTarget(context.WorkingDirectory).First();
+
+            _logger.Verbose($"Found runtime context for '{runtimeContext.ProjectFile.ProjectFilePath}'");
+
+            var projectExporter = runtimeContext.CreateExporter(context.Configuration);
+            var runtimeDependencies = new HashSet<string>();
+            var projectDependencies = projectExporter.GetDependencies();
+
+            foreach (var projectDependency in projectDependencies)
+            {
+                var runtimeAssemblies = projectDependency.RuntimeAssemblyGroups;
+
+                foreach (var runtimeAssembly in runtimeAssemblies.GetDefaultAssets())
+                {
+                    var runtimeAssemblyPath = runtimeAssembly.ResolvedPath;
+                    _logger.Verbose($"Discovered runtime dependency for '{runtimeAssemblyPath}'");
+                    runtimeDependencies.Add(runtimeAssemblyPath);
+                }
+            }
+
+            var opts = ScriptOptions.Default.
+                AddImports(DefaultNamespaces).
+                AddReferences(DefaultAssemblies).
+                WithSourceResolver(new RemoteFileResolver(context.WorkingDirectory));
+
+            if (!string.IsNullOrWhiteSpace(context.FilePath))
+            {
+                opts = opts.WithFilePath(context.FilePath);
+            }
+
+            var runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
+            var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x =>
+                x.FullName.ToLowerInvariant().StartsWith("system.") ||
+                x.FullName.ToLowerInvariant().StartsWith("microsoft.codeanalysis") ||
+                x.FullName.ToLowerInvariant().StartsWith("mscorlib"));
+
+            foreach (var inheritedAssemblyName in inheritedAssemblyNames)
+            {
+                _logger.Verbose("Adding reference to an inherited dependency => " + inheritedAssemblyName.FullName);
+                var assembly = Assembly.Load(inheritedAssemblyName);
+                opts = opts.AddReferences(assembly);
+            }
+
+            foreach (var runtimeDep in runtimeDependencies)
+            {
+                _logger.Verbose("Adding reference to a runtime dependency => " + runtimeDep);
+                opts = opts.AddReferences(MetadataReference.CreateFromFile(runtimeDep));
+            }
+
+            var loader = new InteractiveAssemblyLoader();
+            var script = CSharpScript.Create<TReturn>(context.Code.ToString(), opts, typeof(THost), loader);
+            var compilation = script.GetCompilation();
+            var diagnostics = compilation.GetDiagnostics();
+
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            {
+                foreach (var diagnostic in diagnostics)
+                {
+                    _logger.Log(diagnostic.ToString());
+                }
+
+                throw new CompilationErrorException("Script compilation failed due to one or more errors.",
+                    diagnostics);
+            }
+
+            return new ScriptCompilationContext<TReturn>(script, context.Code, loader);
+        }
+    }
+}

--- a/src/Dotnet.Script/ScriptLogger.cs
+++ b/src/Dotnet.Script/ScriptLogger.cs
@@ -1,0 +1,29 @@
+using System.IO;
+
+namespace Dotnet.Script
+{
+    public class ScriptLogger
+    {
+        private readonly TextWriter _writer;
+        private readonly bool _isDebug;
+
+        public ScriptLogger(TextWriter writer, bool isDebug)
+        {
+            _writer = writer ?? TextWriter.Null;
+            _isDebug = isDebug;
+        }
+
+        public void Log(string message)
+        {
+            _writer.WriteLine(message);
+        }
+
+        public void Verbose(string message)
+        {
+            if (_isDebug)
+            {
+                Log(message);
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -20,8 +20,14 @@ namespace Dotnet.Script
         public virtual async Task<TReturn> Execute<TReturn>(ScriptContext context)
         {
             var compilationContext = ScriptCompiler.CreateCompilationContext<TReturn, InteractiveScriptGlobals>(context);
+            var globals = new InteractiveScriptGlobals(Console.Out, CSharpObjectFormatter.Instance);
 
-            var scriptResult = await compilationContext.Script.RunAsync(new InteractiveScriptGlobals(Console.Out, CSharpObjectFormatter.Instance)).ConfigureAwait(false);
+            foreach (var arg in context.Args)
+            {
+                globals.Args.Add(arg);
+            }
+
+            var scriptResult = await compilationContext.Script.RunAsync(globals).ConfigureAwait(false);
             return ProcessScriptState(scriptResult);
         }
 

--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -1,134 +1,35 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Loader;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.InternalAbstractions;
-using Microsoft.DotNet.ProjectModel;
-using Microsoft.Extensions.DependencyModel;
 
 namespace Dotnet.Script
 {
     public class ScriptRunner
     {
-        private static readonly IEnumerable<Assembly> DefaultAssemblies = new[]
+        protected readonly ScriptLogger Logger;
+        protected readonly ScriptCompiler ScriptCompiler;
+
+        public ScriptRunner(ScriptCompiler scriptCompiler, ScriptLogger logger)
         {
-            typeof(object).GetTypeInfo().Assembly,
-            typeof(Enumerable).GetTypeInfo().Assembly
-        };
-
-        private static readonly IEnumerable<string> DefaultNamespaces = new[]
-        {
-            "System",
-            "System.IO",
-            "System.Linq",
-            "System.Collections.Generic"
-        };
-
-        private readonly TextWriter _stderr;
-
-        public ScriptRunner(TextWriter stderr)
-        {
-            _stderr = stderr ?? TextWriter.Null;
-        }
-
-        protected void Write(string s) => _stderr.Write(s);
-        protected void WriteLine(string s) => _stderr.WriteLine(s);
-
-        protected virtual Action<string> VerboseWriteLine => s => { };
-
-        protected ScriptCompilationContext<TReturn> GetCompilationContext<TReturn>(ScriptContext context)
-        {
-            if (context == null) throw new ArgumentNullException(nameof(context));
-
-            var runtimeContext = ProjectContext.CreateContextForEachTarget(context.WorkingDirectory).First();
-
-            VerboseWriteLine($"Found runtime context for '{runtimeContext.ProjectFile.ProjectFilePath}'");
-
-            var projectExporter = runtimeContext.CreateExporter(context.Configuration);
-            var runtimeDependencies = new HashSet<string>();
-            var projectDependencies = projectExporter.GetDependencies();
-
-            foreach (var projectDependency in projectDependencies)
-            {
-                var runtimeAssemblies = projectDependency.RuntimeAssemblyGroups;
-
-                foreach (var runtimeAssembly in runtimeAssemblies.GetDefaultAssets())
-                {
-                    var runtimeAssemblyPath = runtimeAssembly.ResolvedPath;
-                    VerboseWriteLine($"Discovered runtime dependency for '{runtimeAssemblyPath}'");
-                    runtimeDependencies.Add(runtimeAssemblyPath);
-                }
-            }
-
-            var opts = ScriptOptions.Default.
-                AddImports(DefaultNamespaces).
-                AddReferences(DefaultAssemblies).
-                WithSourceResolver(new RemoteFileResolver(context.WorkingDirectory));
-
-            if (!string.IsNullOrWhiteSpace(context.FilePath))
-            {
-                opts = opts.WithFilePath(context.FilePath);
-            }
-
-            var runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
-            var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x => 
-            x.FullName.ToLowerInvariant().StartsWith("system.") ||
-            x.FullName.ToLowerInvariant().StartsWith("microsoft.codeanalysis") ||
-            x.FullName.ToLowerInvariant().StartsWith("mscorlib"));
-
-            foreach (var inheritedAssemblyName in inheritedAssemblyNames)
-            {
-                VerboseWriteLine("Adding reference to an inherited dependency => " + inheritedAssemblyName.FullName);
-                var assembly = Assembly.Load(inheritedAssemblyName);
-                opts = opts.AddReferences(assembly);
-            }
-
-            foreach (var runtimeDep in runtimeDependencies)
-            {
-                VerboseWriteLine("Adding reference to a runtime dependency => " + runtimeDep);
-                opts = opts.AddReferences(MetadataReference.CreateFromFile(runtimeDep));
-            }
-
-            var loader = new InteractiveAssemblyLoader();
-            var script = CSharpScript.Create<TReturn>(context.Code.ToString(), opts, typeof(InteractiveScriptGlobals), loader);
-            var compilation = script.GetCompilation();
-            var diagnostics = compilation.GetDiagnostics();
-
-            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-            {
-                foreach (var diagnostic in diagnostics)
-                {
-                    WriteLine(diagnostic.ToString());
-                }
-
-                throw new CompilationErrorException("Script compilation failed due to one or more errors.",
-                                                    diagnostics);
-            }
-
-            var host = new InteractiveScriptGlobals(Console.Out, CSharpObjectFormatter.Instance);
-            foreach (var arg in context.Args)
-            {
-                host.Args.Add(arg);
-            }
-
-            return new ScriptCompilationContext<TReturn>(script, host, context.Code, loader);
+            Logger = logger;
+            ScriptCompiler = scriptCompiler;
         }
 
         public virtual async Task<TReturn> Execute<TReturn>(ScriptContext context)
         {
-            var compilationContext = GetCompilationContext<TReturn>(context);
+            var compilationContext = ScriptCompiler.CreateCompilationContext<TReturn, InteractiveScriptGlobals>(context);
 
-            var scriptResult = await compilationContext.Script.RunAsync(compilationContext.Host).ConfigureAwait(false);
+            var scriptResult = await compilationContext.Script.RunAsync(new InteractiveScriptGlobals(Console.Out, CSharpObjectFormatter.Instance)).ConfigureAwait(false);
+            return ProcessScriptState(scriptResult);
+        }
+
+        public virtual async Task<TReturn> Execute<TReturn, THost>(ScriptContext context, THost host)
+        {
+            var compilationContext = ScriptCompiler.CreateCompilationContext<TReturn, THost>(context);
+
+            var scriptResult = await compilationContext.Script.RunAsync(host).ConfigureAwait(false);
             return ProcessScriptState(scriptResult);
         }
 
@@ -136,9 +37,9 @@ namespace Dotnet.Script
         {
             if (scriptState.Exception != null)
             {
-                Write("Script execution resulted in an exception.");
-                WriteLine(scriptState.Exception.Message);
-                WriteLine(scriptState.Exception.StackTrace);
+                Logger.Log("Script execution resulted in an exception.");
+                Logger.Log(scriptState.Exception.Message);
+                Logger.Log(scriptState.Exception.StackTrace);
             }
 
             return scriptState.ReturnValue;


### PR DESCRIPTION
In preparation for #26 

The runner should only run, the compiler will only compile. This makes sense as there are use cases where we would only want to compile not run, plus it splits responsibilities.