### PR TITLE
ScriptRunner.Execute overload should delegate to virtual version

### DIFF
--- a/src/Dotnet.Script/ScriptRunner.cs
+++ b/src/Dotnet.Script/ScriptRunner.cs
@@ -17,18 +17,12 @@ namespace Dotnet.Script
             ScriptCompiler = scriptCompiler;
         }
 
-        public virtual async Task<TReturn> Execute<TReturn>(ScriptContext context)
+        public Task<TReturn> Execute<TReturn>(ScriptContext context)
         {
-            var compilationContext = ScriptCompiler.CreateCompilationContext<TReturn, InteractiveScriptGlobals>(context);
             var globals = new InteractiveScriptGlobals(Console.Out, CSharpObjectFormatter.Instance);
-
             foreach (var arg in context.Args)
-            {
                 globals.Args.Add(arg);
-            }
-
-            var scriptResult = await compilationContext.Script.RunAsync(globals).ConfigureAwait(false);
-            return ProcessScriptState(scriptResult);
+            return Execute<TReturn, InteractiveScriptGlobals>(context, globals);
         }
 
         public virtual async Task<TReturn> Execute<TReturn, THost>(ScriptContext context, THost host)


### PR DESCRIPTION
Commit e4106437912b648efd2f759789a25d0cd3de5afd introduced a new _virtual_ `Execute` overload on `ScriptRunner` and broke debugging. There should really only be one _virtual_ of `Execute` and all other (present & future) overloads should delegate to it, which is what this PR does. It removes duplicate code between the overloads, and more importantly, fixes the debug scenario. You see, `DebugScriptRunner` inherits from `ScriptRunner` and overrides `Execute`. While e4106437912b648efd2f759789a25d0cd3de5afd introduced two virtuals, [`DebugScriptRunner` overriddes just one of them](https://github.com/filipw/dotnet-script/blob/e4106437912b648efd2f759789a25d0cd3de5afd/src/Dotnet.Script/ScriptRunner.cs#L28) but [not the one the entry-points calls](https://github.com/filipw/dotnet-script/blob/e4106437912b648efd2f759789a25d0cd3de5afd/src/Dotnet.Script/Program.cs#L107).