### PR TITLE
added implicit reference to System.ValueTuple

### DIFF
--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -40,7 +40,8 @@ namespace Dotnet.Script.Core
             var opts = ScriptOptions.Default.
                 AddImports(DefaultNamespaces).
                 AddReferences(DefaultAssemblies).
-                WithSourceResolver(new RemoteFileResolver(context.WorkingDirectory));
+                WithSourceResolver(new RemoteFileResolver(context.WorkingDirectory)).
+                WithMetadataResolver(ScriptMetadataResolver.Default);
 
             if (!string.IsNullOrWhiteSpace(context.FilePath))
             {

--- a/src/Dotnet.Script.Core/project.json
+++ b/src/Dotnet.Script.Core/project.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",
-    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc2"
+    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc2",
+    "System.ValueTuple": "4.3.0" 
   },
 
   "frameworks": {


### PR DESCRIPTION
Allows us to use code like this:

```
var x = (1, 2);
Console.WriteLine(x.Item1);
Console.WriteLine(x.Item2);
```

This is inline with CSI behavior (also implicitly references `ValueTuple`)