### PR TITLE
Rank diagnostics by severity and position

### DIFF
--- a/src/Dotnet.Script.Core/DebugScriptRunner.cs
+++ b/src/Dotnet.Script.Core/DebugScriptRunner.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dotnet.Script.Core.Internal;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 

--- a/src/Dotnet.Script.Core/EnumerableExtensions.cs
+++ b/src/Dotnet.Script.Core/EnumerableExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Dotnet.Script.Core
+{
+    static class EnumerableExtensions
+    {
+        public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, Comparison<T> compare)
+        {
+            var comparer = Comparer<T>.Create(compare);
+            return source.OrderBy(t => t, comparer);
+        }
+    }
+}

--- a/src/Dotnet.Script.Core/Internal/EnumerableExtensions.cs
+++ b/src/Dotnet.Script.Core/Internal/EnumerableExtensions.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Dotnet.Script.Core
+namespace Dotnet.Script.Core.Internal
 {
-    static class EnumerableExtensions
+    internal static class EnumerableExtensions
     {
         public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, Comparison<T> compare)
         {

--- a/src/Dotnet.Script.Core/Internal/ReflectionExtensions.cs
+++ b/src/Dotnet.Script.Core/Internal/ReflectionExtensions.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Reflection;
 
-namespace Dotnet.Script.Core
+namespace Dotnet.Script.Core.Internal
 {
-    static class ReflectionExtensions
+    internal static class ReflectionExtensions
     {
         static MethodInfo RequireInstanceMethod(this TypeInfo typeInfo, string name, BindingFlags bindingFlags)
         {

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
@@ -105,17 +106,23 @@ namespace Dotnet.Script.Core
             var loader = new InteractiveAssemblyLoader();
             var script = CSharpScript.Create<TReturn>(context.Code.ToString(), opts, typeof(THost), loader);
             var compilation = script.GetCompilation();
-            var diagnostics = compilation.GetDiagnostics();
 
-            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            var diagnostics = compilation.GetDiagnostics();
+            var orderedDiagnostics = diagnostics.OrderBy((d1, d2) => 
             {
-                foreach (var diagnostic in diagnostics)
+                var severityDiff = (int)d2.Severity - (int)d1.Severity;
+                return severityDiff != 0 ? severityDiff : d1.Location.SourceSpan.Start - d2.Location.SourceSpan.Start;
+            });
+
+            if (orderedDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            {
+                foreach (var diagnostic in orderedDiagnostics)
                 {
                     _logger.Log(diagnostic.ToString());
                 }
 
                 throw new CompilationErrorException("Script compilation failed due to one or more errors.",
-                    diagnostics);
+                    orderedDiagnostics.ToImmutableArray());
             }
 
             return new ScriptCompilationContext<TReturn>(script, context.Code, loader);

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using Dotnet.Script.Core.Internal;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;


### PR DESCRIPTION
Improves the experience. Now more important diagnostics go on top. Additionally, we rank by position too. Inspired by what CSI does.

Example - instead of:

```
c:\>dotnet script c:\script-test3\foo.csx
c:\script-test3\foo.csx(7,5): error CS1002: ; expected
c:\script-test3\foo.csx(13,8): error CS1001: Identifier expected
c:\script-test3\foo.csx(13,8): error CS1002: ; expected
c:\script-test3\foo.csx(6,1): error CS0246: The type or namespace name 'dassadads' could not be found (are you missing a using directive or an assembly reference?)
c:\script-test3\foo.csx(7,5): error CS0103: The name 'test' does not exist in the current context
c:\script-test3\foo.csx(8,19): error CS0103: The name 'JsonConvert' does not exist in the current context
c:\script-test3\foo.csx(8,47): error CS0103: The name 'test' does not exist in the current context
c:\script-test3\foo.csx(10,26): error CS0246: The type or namespace name 'MapperConfiguration' could not be found (are you missing a using directive or an assembly reference?)
c:\script-test3\foo.csx(13,2): error CS0246: The type or namespace name 'dsaads' could not be found (are you missing a using directive or an assembly reference?)
c:\script-test3\foo.csx(17,20): error CS0103: The name 'ewqqwewqe' does not exist in the current context
Script compilation failed due to one or more errors.
```

We now have:

```
c:\>dotnet script c:\script-test3\foo.csx
c:\script-test3\foo.csx(6,1): error CS0246: The type or namespace name 'dassadads' could not be found (are you missing a using directive or an assembly reference?)
c:\script-test3\foo.csx(7,5): error CS1002: ; expected
c:\script-test3\foo.csx(7,5): error CS0103: The name 'test' does not exist in the current context
c:\script-test3\foo.csx(8,19): error CS0103: The name 'JsonConvert' does not exist in the current context
c:\script-test3\foo.csx(8,47): error CS0103: The name 'test' does not exist in the current context
c:\script-test3\foo.csx(10,26): error CS0246: The type or namespace name 'MapperConfiguration' could not be found (are you missing a using directive or an assembly reference?)
c:\script-test3\foo.csx(13,2): error CS0246: The type or namespace name 'dsaads' could not be found (are you missing a using directive or an assembly reference?)
c:\script-test3\foo.csx(13,8): error CS1001: Identifier expected
c:\script-test3\foo.csx(13,8): error CS1002: ; expected
c:\script-test3\foo.csx(17,20): error CS0103: The name 'ewqqwewqe' does not exist in the current context
Script compilation failed due to one or more errors.
```