### PR TITLE
do not hardcode any encodings

### DIFF
--- a/src/Dotnet.Script.Core/DebugScriptRunner.cs
+++ b/src/Dotnet.Script.Core/DebugScriptRunner.cs
@@ -34,7 +34,7 @@ namespace Dotnet.Script.Core
             {
                 // https://github.com/dotnet/roslyn/blob/version-2.0.0-beta4/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.ParsedSyntaxTree.cs#L19
                 var encodingField = syntaxTree.GetType().GetField("_encodingOpt", BindingFlags.Instance | BindingFlags.NonPublic);
-                encodingField.SetValue(syntaxTree, Encoding.UTF8);
+                encodingField.SetValue(syntaxTree, context.Code.Encoding);
 
                 // https://github.com/dotnet/roslyn/blob/version-2.0.0-beta4/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.ParsedSyntaxTree.cs#L21
                 var lazyTextField = syntaxTree.GetType().GetField("_lazyText", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -86,7 +86,7 @@ namespace Dotnet.Script
             }
 
             var directory = Path.IsPathRooted(file) ? Path.GetDirectoryName(file) : Path.GetDirectoryName(Path.Combine(Directory.GetCurrentDirectory(), file));
-            var sourceText = SourceText.From(new FileStream(file, FileMode.Open), Encoding.UTF8);
+            var sourceText = SourceText.From(new FileStream(file, FileMode.Open));
             var context = new ScriptContext(sourceText, directory, config, args, file);
 
             Run(debugMode, context);
@@ -94,7 +94,7 @@ namespace Dotnet.Script
 
         private static void RunCode(string code, string config, bool debugMode, IEnumerable<string> args, string currentWorkingDirectory)
         {
-            var sourceText = SourceText.From(code, Encoding.UTF8);
+            var sourceText = SourceText.From(code);
             var context = new ScriptContext(sourceText, currentWorkingDirectory ?? Directory.GetCurrentDirectory(), config, args);
 
             Run(debugMode, context);


### PR DESCRIPTION
Roslyn can detect encoding using BOM and some fallback mechanisms via `SourceText`.
Relying on hardcoded encoding is not a good idea.