### PR TITLE
moved RemoteFileResolver into a dedicated package

### DIFF
--- a/Dotnet.Script.sln
+++ b/Dotnet.Script.sln
@@ -7,6 +7,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Dotnet.Script", "src\Dotnet
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Dotnet.Script.Core", "src\Dotnet.Script.Core\Dotnet.Script.Core.xproj", "{684FEFEE-451B-4E68-B662-C16E3A7DA794}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Dotnet.Script.Extras", "src\Dotnet.Script.Extras\Dotnet.Script.Extras.xproj", "{BCBB3155-4463-4748-8032-EF82AE297CE1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{684FEFEE-451B-4E68-B662-C16E3A7DA794}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{684FEFEE-451B-4E68-B662-C16E3A7DA794}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{684FEFEE-451B-4E68-B662-C16E3A7DA794}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCBB3155-4463-4748-8032-EF82AE297CE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCBB3155-4463-4748-8032-EF82AE297CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCBB3155-4463-4748-8032-EF82AE297CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCBB3155-4463-4748-8032-EF82AE297CE1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -179,27 +179,6 @@ Hello from bar.csx
 Hello from foo.csx
 ```
 
-### Referencing an HTTP-based script from a script
-
-Even better, `Dotnet.Script` supports loading CSX references over HTTP too. You could now modify the `foo.csx` accordingly:
-
-```csharp
-#load "https://gist.githubusercontent.com/filipw/9a79bb00e4905dfb1f48757a3ff12314/raw/adbfe5fade49c1b35e871c49491e17e6675dd43c/foo.csx"
-#load "bar.csx"
-
-Console.WriteLine("Hello from foo.csx");
-```
-
-In this case, the first dependency is loaded as `string` and parsed from an HTTP source - in this case a [gist](https://gist.githubusercontent.com/filipw/9a79bb00e4905dfb1f48757a3ff12314/raw/adbfe5fade49c1b35e871c49491e17e6675dd43c/foo.csx) I set up beforehand.
-
-Running `dotnet script foo.csx` now, will produce:
-
-```shell
-Hello from a gist
-Hello from bar.csx
-Hello from foo.csx
-```
-
 ### Passing arguments to scripts
 
 All arguments after `--` are passed to the script in the following way:
@@ -224,6 +203,31 @@ dotnet script -d foo.csx -- -d
 ```
 
 will pass the `-d` before `--` to `dotnet script` and enable the debug mode whereas the `-d` after `--` is passed to script for its own interpretation of the argument.
+
+## Extras
+
+Beyond the standard scripting dialect support (compatible with `csi.exe`), `Dotnet.Script` provides some extra features, located in the `Dotnet.Script.Extras` package.
+
+### Referencing an HTTP-based script from a script
+
+Even better, `Dotnet.Script` supports loading CSX references over HTTP too. You could now modify the `foo.csx` accordingly:
+
+```csharp
+#load "https://gist.githubusercontent.com/filipw/9a79bb00e4905dfb1f48757a3ff12314/raw/adbfe5fade49c1b35e871c49491e17e6675dd43c/foo.csx"
+#load "bar.csx"
+
+Console.WriteLine("Hello from foo.csx");
+```
+
+In this case, the first dependency is loaded as `string` and parsed from an HTTP source - in this case a [gist](https://gist.githubusercontent.com/filipw/9a79bb00e4905dfb1f48757a3ff12314/raw/adbfe5fade49c1b35e871c49491e17e6675dd43c/foo.csx) I set up beforehand.
+
+Running `dotnet script foo.csx` now, will produce:
+
+```shell
+Hello from a gist
+Hello from bar.csx
+Hello from foo.csx
+```
 
 ## Issues and problems
 

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -48,7 +48,7 @@ namespace Dotnet.Script.Core
             var opts = ScriptOptions.Default.
                 AddImports(ImportedNamespaces).
                 AddReferences(ReferencedAssemblies).
-                WithSourceResolver(new RemoteFileResolver(context.WorkingDirectory)).
+                WithSourceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, context.WorkingDirectory)).
                 WithMetadataResolver(ScriptMetadataResolver.Default);
 
             if (!string.IsNullOrWhiteSpace(context.FilePath))

--- a/src/Dotnet.Script.Extras/Dotnet.Script.Extras.xproj
+++ b/src/Dotnet.Script.Extras/Dotnet.Script.Extras.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>bcbb3155-4463-4748-8032-ef82ae297ce1</ProjectGuid>
+    <RootNamespace>Dotnet.Script.Extras</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Dotnet.Script.Extras/Properties/AssemblyInfo.cs
+++ b/src/Dotnet.Script.Extras/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Dotnet.Script.Extras")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bcbb3155-4463-4748-8032-ef82ae297ce1")]

--- a/src/Dotnet.Script.Extras/RemoteFileResolver.cs
+++ b/src/Dotnet.Script.Extras/RemoteFileResolver.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Net.Http;
 using Microsoft.CodeAnalysis;
 
-namespace Dotnet.Script.Core
+namespace Dotnet.Script.Extras
 {
     public class RemoteFileResolver : SourceReferenceResolver
     {

--- a/src/Dotnet.Script.Extras/project.json
+++ b/src/Dotnet.Script.Extras/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": "0.1.0-*",
+  "description": "Extensions and add ons to C# scripting",
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc4"
+  },
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}


### PR DESCRIPTION
Created a package `Dotnet.Script.Extras` for non-CSI compatible features.

Related to #55 