### PR TITLE
Paket PoC

### DIFF
--- a/Dotnet.Script.sln
+++ b/Dotnet.Script.sln
@@ -9,6 +9,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Dotnet.Script.Core", "src\D
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Dotnet.Script.Extras", "src\Dotnet.Script.Extras\Dotnet.Script.Extras.xproj", "{BCBB3155-4463-4748-8032-EF82AE297CE1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{61E3CEE0-3954-486F-AD1A-E5EE66DEED62}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Dotnet.Script.Extras.Demos", "examples\Dotnet.Script.Extras.Demos\Dotnet.Script.Extras.Demos.xproj", "{522E8334-72C1-43F4-AFF3-3D504EE46DFE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,8 +31,15 @@ Global
 		{BCBB3155-4463-4748-8032-EF82AE297CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BCBB3155-4463-4748-8032-EF82AE297CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BCBB3155-4463-4748-8032-EF82AE297CE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{522E8334-72C1-43F4-AFF3-3D504EE46DFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{522E8334-72C1-43F4-AFF3-3D504EE46DFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{522E8334-72C1-43F4-AFF3-3D504EE46DFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{522E8334-72C1-43F4-AFF3-3D504EE46DFE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{522E8334-72C1-43F4-AFF3-3D504EE46DFE} = {61E3CEE0-3954-486F-AD1A-E5EE66DEED62}
 	EndGlobalSection
 EndGlobal

--- a/examples/Dotnet.Script.Extras.Demos/Dotnet.Script.Extras.Demos.xproj
+++ b/examples/Dotnet.Script.Extras.Demos/Dotnet.Script.Extras.Demos.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>522e8334-72c1-43f4-aff3-3d504ee46dfe</ProjectGuid>
+    <RootNamespace>Dotnet.Script.Extras.Demos</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/examples/Dotnet.Script.Extras.Demos/Program.cs
+++ b/examples/Dotnet.Script.Extras.Demos/Program.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace Dotnet.Script.Extras.Demos
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var code = File.ReadAllText("test.csx");
+
+            var resolver = new PaketScriptMetadataResolver(code);
+            var opts = resolver.CreateScriptOptions(ScriptOptions.Default);
+
+            CSharpScript.RunAsync(code, opts).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/examples/Dotnet.Script.Extras.Demos/Properties/AssemblyInfo.cs
+++ b/examples/Dotnet.Script.Extras.Demos/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Dotnet.Script.Extras.Demos")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("522e8334-72c1-43f4-aff3-3d504ee46dfe")]

--- a/examples/Dotnet.Script.Extras.Demos/project.json
+++ b/examples/Dotnet.Script.Extras.Demos/project.json
@@ -1,0 +1,22 @@
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "publishOptions": {
+    "includeFiles": [ "test.csx", ".paket/paket.exe" ]
+  },
+  "dependencies": {
+    "Dotnet.Script.Extras": "0.1.0-*",
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.3"
+    },
+    "System.Runtime.Serialization.Primitives": "4.3.0"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/examples/Dotnet.Script.Extras.Demos/test.csx
+++ b/examples/Dotnet.Script.Extras.Demos/test.csx
@@ -1,0 +1,11 @@
+﻿#r "paket: nuget Newtonsoft.Json"
+
+using System;
+using Newtonsoft.Json;
+
+class Foo
+{
+    public string Bar { get; set; }
+}
+
+Console.WriteLine(JsonConvert.SerializeObject(new Foo { Bar = "hi" }));

--- a/src/Dotnet.Script.Extras/PaketScriptMetadataResolver.cs
+++ b/src/Dotnet.Script.Extras/PaketScriptMetadataResolver.cs
@@ -25,12 +25,12 @@ namespace Dotnet.Script.Extras
         public PaketScriptMetadataResolver(string code, string workingDirectory = null, string paketPath = ".paket/paket.exe", string tfm = "netstandard16")
         {
             workingDirectory = workingDirectory ?? Directory.GetCurrentDirectory();
-            _inner = ScriptMetadataResolver.Default;
+            _inner = ScriptMetadataResolver.Default.WithBaseDirectory(workingDirectory);
 
             var requiredReferences = GetReferenceDefinitions(code).Where(x => x.StartsWith(PaketPrefix));
             foreach (var requiredReference in requiredReferences)
             {
-                _paketDependencies.AppendLine(requiredReference.Replace(PaketPrefix, "nuget "));
+                _paketDependencies.AppendLine(requiredReference.Replace(PaketPrefix, string.Empty));
             }
 
             File.WriteAllText(Path.Combine(workingDirectory, PaketDependencies), _paketDependencies.ToString());

--- a/src/Dotnet.Script.Extras/PaketScriptMetadataResolver.cs
+++ b/src/Dotnet.Script.Extras/PaketScriptMetadataResolver.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace Dotnet.Script.Extras
+{
+    public class PaketScriptMetadataResolver : MetadataReferenceResolver
+    {
+        private readonly StringBuilder _paketDependencies = new StringBuilder().AppendLine("source https://api.nuget.org/v3/index.json");
+        private static readonly string Tfm = "netstandard16";
+        private static readonly string PaketPrefix = "paket: ";
+        private readonly ScriptMetadataResolver _inner;
+        private readonly HashSet<string> _resolvedReferences = new HashSet<string>();
+        private static readonly CSharpParseOptions _parseOptions = CSharpParseOptions.Default.WithKind(SourceCodeKind.Script);
+
+        public PaketScriptMetadataResolver(string code, string workingDirectory = null)
+        {
+            workingDirectory = workingDirectory ?? Directory.GetCurrentDirectory();
+            _inner = ScriptMetadataResolver.Default;
+
+            var syntaxTree = CSharpSyntaxTree.ParseText(code, _parseOptions);
+            var refs = syntaxTree.GetCompilationUnitRoot().GetReferenceDirectives().Select(x => x.File.ToString().Replace("\"", string.Empty)).Where(x => x.StartsWith(PaketPrefix));
+            foreach (var reference in refs)
+            {
+                _paketDependencies.AppendLine(reference.Replace(PaketPrefix, "nuget "));
+            }
+
+            File.WriteAllText(Path.Combine(workingDirectory, "paket.dependencies"), _paketDependencies.ToString());
+            var processStartInfo = new ProcessStartInfo(@".paket/paket.exe", $"install --generate-load-scripts load-script-framework {Tfm}")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                WorkingDirectory = _inner.BaseDirectory
+            };
+            using (var process = new Process() { StartInfo = processStartInfo })
+            {
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    Console.WriteLine(e.Data);
+                };
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    Console.Error.WriteLine(e.Data);
+                };
+                process.Start();
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+
+                process.WaitForExit();
+            }
+
+            var restoredDefs = File.ReadAllText(Path.Combine(workingDirectory, $".paket/load/{Tfm}/main.group.csx"));
+            var restoredDefsSyntaxTree = CSharpSyntaxTree.ParseText(restoredDefs, _parseOptions);
+            var restoredRefs = restoredDefsSyntaxTree.GetCompilationUnitRoot().GetReferenceDirectives().Select(x => x.File.ToString().Replace("\"", string.Empty));
+            foreach (var restoredRef in restoredRefs)
+            {
+                if (restoredRef.StartsWith(".."))
+                {
+                    _resolvedReferences.Add(Path.Combine(workingDirectory, $".paket/load/{Tfm}", restoredRef));
+                }
+                else
+                {
+                    //skip GAC by design
+                }
+            }
+        }
+
+        public ScriptOptions CreateScriptOptions(ScriptOptions scriptOptions)
+        {
+            return scriptOptions.
+                WithMetadataResolver(this).
+                WithReferences(_resolvedReferences.Select(x => MetadataReference.CreateFromFile(x)));
+        }
+
+        public override bool Equals(object other)
+        {
+            return _inner.Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return _inner.GetHashCode();
+        }
+
+        public override bool ResolveMissingAssemblies => true;
+
+        public override PortableExecutableReference ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity)
+        {
+            return _inner.ResolveMissingAssembly(definition, referenceIdentity);
+        }
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)
+        {
+            if (reference.StartsWith(PaketPrefix))
+            {
+                // dummy reference
+                // this needs to return somehting or the compiler will complain
+                return ImmutableArray.Create(MetadataReference.CreateFromFile(typeof(PaketScriptMetadataResolver).GetTypeInfo().Assembly.Location));
+            }
+            else
+            {
+                return _inner.ResolveReference(reference, baseFilePath, properties);
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script.Extras/project.json
+++ b/src/Dotnet.Script.Extras/project.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc4",
-    "system.diagnostics.process": "4.3.0" 
+    "System.Diagnostics.Process": "4.3.0"  
   },
   "frameworks": {
     "netstandard1.6": {

--- a/src/Dotnet.Script.Extras/project.json
+++ b/src/Dotnet.Script.Extras/project.json
@@ -3,7 +3,8 @@
   "description": "Extensions and add ons to C# scripting",
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc4"
+    "Microsoft.CodeAnalysis.CSharp.Scripting": "2.0.0-rc4",
+    "system.diagnostics.process": "4.3.0" 
   },
   "frameworks": {
     "netstandard1.6": {


### PR DESCRIPTION
Paket integration done using `#r` extensibility in Roslyn. 

Given a script like this:

```
#r "paket: nuget Newtonsoft.Json"

using System;
using Newtonsoft.Json;

class Foo
{
    public string Bar { get; set; }
}

Console.WriteLine(JsonConvert.SerializeObject(new Foo { Bar = "hi" }));
```

This happens:

<img width="941" alt="screenshot 2017-02-27 16 46 41" src="https://cloud.githubusercontent.com/assets/1710369/23368019/aa6d3494-fd0c-11e6-86ea-74e79d598580.png">
