### PR TITLE
Compare runtime assembly names without GC allocation

### DIFF
--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -86,12 +86,10 @@ namespace Dotnet.Script.Core
             var opts = CreateScriptOptions(context);
 
             var runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
-            var inheritedAssemblyNames =
-                from an in DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId)
-                where an.FullName.StartsWith("system.", StringComparison.OrdinalIgnoreCase)
-                   || an.FullName.StartsWith("microsoft.codeanalysis", StringComparison.OrdinalIgnoreCase)
-                   || an.FullName.StartsWith("mscorlib", StringComparison.OrdinalIgnoreCase)
-                select an;
+            var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x =>
+                x.FullName.StartsWith("system.", StringComparison.OrdinalIgnoreCase) ||
+                x.FullName.StartsWith("microsoft.codeanalysis", StringComparison.OrdinalIgnoreCase) ||
+                x.FullName.StartsWith("mscorlib", StringComparison.OrdinalIgnoreCase));
 
             foreach (var inheritedAssemblyName in inheritedAssemblyNames)
             {

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -86,10 +86,12 @@ namespace Dotnet.Script.Core
             var opts = CreateScriptOptions(context);
 
             var runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
-            var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x =>
-                x.FullName.ToLowerInvariant().StartsWith("system.") ||
-                x.FullName.ToLowerInvariant().StartsWith("microsoft.codeanalysis") ||
-                x.FullName.ToLowerInvariant().StartsWith("mscorlib"));
+            var inheritedAssemblyNames =
+                from an in DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId)
+                where an.FullName.StartsWith("system.", StringComparison.OrdinalIgnoreCase)
+                   || an.FullName.StartsWith("microsoft.codeanalysis", StringComparison.OrdinalIgnoreCase)
+                   || an.FullName.StartsWith("mscorlib", StringComparison.OrdinalIgnoreCase)
+                select an;
 
             foreach (var inheritedAssemblyName in inheritedAssemblyNames)
             {


### PR DESCRIPTION
Small optimization to do a case-insensitive check directly instead of causing GC allocations via `ToLowerInvariant` on each iteration through `where`. 

Yeah, I know, it's a small optimization in the grand scheme of things, but hey, I saw it in passing & the fix was quick. Took less than a minute anyway (less than it's taking me to write this comment 😏). And I hear, no PR is too small. :wink: 