### PR TITLE
infer encoding from SourceText

### DIFF
--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -51,7 +51,8 @@ namespace Dotnet.Script.Core
                 .AddReferences(ReferencedAssemblies)
                 .WithSourceResolver(SourceFileResolver.Default)
                 .WithMetadataResolver(ScriptMetadataResolver.Default)
-                .WithEmitDebugInformation(context.DebugMode);            
+                .WithEmitDebugInformation(context.DebugMode)
+                .WithFileEncoding(context.Code.Encoding);
 
             if (!string.IsNullOrWhiteSpace(context.FilePath))
             {


### PR DESCRIPTION
Since we don't use the `Stream` based APIs, we need to infer encoding from `SourceText` (which came from `Stream` in the first place :-)