### PR TITLE
Always emit symbols

### DIFF
--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -56,7 +56,7 @@ namespace Dotnet.Script.Core
                 .AddReferences(ReferencedAssemblies)
                 .WithSourceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, context.WorkingDirectory))
                 .WithMetadataResolver(new NuGetMetadataReferenceResolver(ScriptMetadataResolver.Default))
-                .WithEmitDebugInformation(context.DebugMode)
+                .WithEmitDebugInformation(true)
                 .WithFileEncoding(context.Code.Encoding);
 
             if (!string.IsNullOrWhiteSpace(context.FilePath))

--- a/src/Dotnet.Script.Core/ScriptRunner.cs
+++ b/src/Dotnet.Script.Core/ScriptRunner.cs
@@ -35,7 +35,7 @@ namespace Dotnet.Script.Core
 
         public virtual async Task<TReturn> Execute<TReturn, THost>(ScriptCompilationContext<TReturn> compilationContext, THost host)
         {
-            var scriptResult = await compilationContext.Script.RunAsync(host).ConfigureAwait(false);
+            var scriptResult = await compilationContext.Script.RunAsync(host, ex => true).ConfigureAwait(false);
             return ProcessScriptState(scriptResult);
         }
 


### PR DESCRIPTION
This is aligned with CSI which also has this feature enabled by default.
It will be easier to attach debugger (no need to run with debug flag and see all the junky output)

Also, this should give us line numbers in stack trace on exceptions, although it doesn't work at the moment - it will have to be checked in the future