### PR TITLE
Some more bug fixes - this time to make sure nuget resolver installs correctly

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -13,8 +13,6 @@
     <PackageLicenseUrl>https://github.com/filipw/dotnet-script/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>    
@@ -27,13 +25,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="$(OutputPath)\Microsoft*.dll">
-      <PackagePath>lib/netstandard1.6/</PackagePath>
-      <Pack>true</Pack>
-    </Content>    
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -94,7 +94,7 @@ namespace Dotnet.Script.Core
             {
                 _logger.Verbose("Unable to find project context for CSX files. Will default to non-context usage.");
                 var scriptProjectProvider = ScriptProjectProvider.Create(new LoggerFactory());
-                var scriptProjectInfo = scriptProjectProvider.CreateProject(context.WorkingDirectory, "netcoreapp1.0");
+                var scriptProjectInfo = scriptProjectProvider.CreateProject(context.WorkingDirectory, "netcoreapp1.1");
                 runtimeContext = ProjectContext.CreateContextForEachTarget(scriptProjectInfo.PathToProjectJson).FirstOrDefault();
             }
 

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -55,7 +55,7 @@ namespace Dotnet.Script.Core
             var opts = ScriptOptions.Default.AddImports(ImportedNamespaces)
                 .AddReferences(ReferencedAssemblies)
                 .WithSourceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, context.WorkingDirectory))
-                .WithMetadataResolver(new NuGetMetadataReferenceResolver(ScriptMetadataResolver.Default))
+                .WithMetadataResolver(new NuGetMetadataReferenceResolver(ScriptMetadataResolver.Default.WithBaseDirectory(context.WorkingDirectory)))
                 .WithEmitDebugInformation(true)
                 .WithFileEncoding(context.Code.Encoding);
 

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -4,7 +4,7 @@
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
     <VersionPrefix>0.11.0</VersionPrefix>
     <Authors>filipw</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>dotnet-script</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -80,12 +80,13 @@ namespace Dotnet.Script
                 throw new Exception($"Couldn't find file '{file}'");
             }
 
-            var directory = Path.IsPathRooted(file) ? Path.GetDirectoryName(file) : Path.GetDirectoryName(Path.Combine(Directory.GetCurrentDirectory(), file));
+            var absoluteFilePath = Path.IsPathRooted(file) ? file : Path.Combine(Directory.GetCurrentDirectory(), file);
+            var directory = Path.GetDirectoryName(absoluteFilePath);
 
-            using (var filestream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var filestream = new FileStream(absoluteFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var sourceText = SourceText.From(filestream);
-                var context = new ScriptContext(sourceText, directory, config, args, file, debugMode);
+                var context = new ScriptContext(sourceText, directory, config, args, absoluteFilePath, debugMode);
                 Run(debugMode, context);
             }
         }


### PR DESCRIPTION
 - bump everything to netcoreapp1.1 (fixes #89)
 - removed package fallback (looks like this caused https://github.com/seesharper/Dotnet.Script.NuGetMetadataResolver/issues/2)
 - removed implicit net standard reference (not needed)
 - removed unneeded csproj config (not used)