### PR TITLE
Added support for csharp 7.1

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts from a project.json dependency definition file and with support for debugging. Based on Roslyn.</Description>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 using Dotnet.Script.NuGetMetadataResolver;
 using Microsoft.Extensions.Logging;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Dotnet.Script.Core
 {
@@ -48,6 +49,12 @@ namespace Dotnet.Script.Core
         public ScriptCompiler(ScriptLogger logger)
         {
             _logger = logger;
+
+            // reset default scripting mode to latest language version to enable C# 7.1 features
+            // this is not needed once https://github.com/dotnet/roslyn/pull/21331 ships
+            var csharpScriptCompilerType = typeof(CSharpScript).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.CSharp.Scripting.CSharpScriptCompiler");
+            var parseOptionsField = csharpScriptCompilerType?.GetField("s_defaultOptions", BindingFlags.Static | BindingFlags.NonPublic);
+            parseOptionsField?.SetValue(null, new CSharpParseOptions(LanguageVersion.Latest, kind: SourceCodeKind.Script));
         }
 
         public virtual ScriptOptions CreateScriptOptions(ScriptContext context)

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
Roslyn has this change already merged in, but it will take a while before it's released as stable on nuget.
In the meantime, we can set latest C# version with reflection.

Omnisharp also already has support for latest C# in scripts (see https://github.com/OmniSharp/omnisharp-roslyn/pull/935)