### PR TITLE
line numbers on exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ paket-files/
 *.sln.iml
 /*.DS_Store
 /src/.DS_Store
+project.json

--- a/src/Dotnet.Script.Core/Internal/ScriptExtensions.cs
+++ b/src/Dotnet.Script.Core/Internal/ScriptExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Dotnet.Script.Core.Internal;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace Dotnet.Script.Core.Internal
+{
+    internal static class ScriptExtensions
+    {
+        public static IEnumerable<Diagnostic> GetDiagnostics<T>(this Script<T> script, IEnumerable<string> suppressedDiagnosticIds)
+        {
+            var compilation = script.GetCompilation();
+            var diagnostics = compilation.GetDiagnostics().Where(d => !suppressedDiagnosticIds.Contains(d.Id));
+            var orderedDiagnostics = diagnostics.OrderBy((d1, d2) =>
+            {
+                var severityDiff = (int)d2.Severity - (int)d1.Severity;
+                return severityDiff != 0 ? severityDiff : d1.Location.SourceSpan.Start - d2.Location.SourceSpan.Start;
+            });
+
+            return orderedDiagnostics;
+        }
+    }
+}

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
-using Dotnet.Script.Core.Internal;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
@@ -12,10 +11,11 @@ using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.Extensions.DependencyModel;
 using System.Runtime.InteropServices;
-using Dotnet.Script.NuGetMetadataResolver;
 using Microsoft.Extensions.Logging;
 using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
+using Dotnet.Script.Core.Internal;
+using Dotnet.Script.NuGetMetadataResolver;
 
 namespace Dotnet.Script.Core
 {
@@ -144,14 +144,7 @@ namespace Dotnet.Script.Core
 
             var loader = new InteractiveAssemblyLoader();
             var script = CSharpScript.Create<TReturn>(context.Code.ToString(), opts, typeof(THost), loader);
-            var compilation = script.GetCompilation();
-
-            var diagnostics = compilation.GetDiagnostics().Where(d => !SuppressedDiagnosticIds.Contains(d.Id));
-            var orderedDiagnostics = diagnostics.OrderBy((d1, d2) => 
-            {
-                var severityDiff = (int)d2.Severity - (int)d1.Severity;
-                return severityDiff != 0 ? severityDiff : d1.Location.SourceSpan.Start - d2.Location.SourceSpan.Start;
-            });
+            var orderedDiagnostics = script.GetDiagnostics(SuppressedDiagnosticIds);
 
             if (orderedDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
             {

--- a/src/Dotnet.Script.Tests/ProcessHelper.cs
+++ b/src/Dotnet.Script.Tests/ProcessHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Dotnet.Script.Tests
+{
+    public static class ProcessHelper
+    {
+        public static string RunAndCaptureOutput(string fileName, string[] arguments, string workingDirectory = null)
+        {
+            var startInfo = new ProcessStartInfo(fileName, string.Join(" ", arguments))
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                //UseShellExecute = false,
+                WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory()
+            };
+
+            var process = new Process
+            {
+                StartInfo = startInfo
+            };
+
+            try
+            {
+                process.Start();
+            }
+            catch
+            {
+                Console.WriteLine($"Failed to launch '{fileName}' with args, '{arguments}'");
+                return null;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            output += process.StandardError.ReadToEnd();
+
+            process.WaitForExit();
+
+            return output.Trim();
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/ProcessHelper.cs
+++ b/src/Dotnet.Script.Tests/ProcessHelper.cs
@@ -13,7 +13,7 @@ namespace Dotnet.Script.Tests
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true,
-                //UseShellExecute = false,
+                UseShellExecute = false,
                 WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory()
             };
 

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -19,6 +19,13 @@ namespace Dotnet.Script.Tests
             Assert.Contains("AutoMapper.MapperConfiguration", result);
         }
 
+        [Fact]
+        public void ShouldIncludeExceptionLineNumberAndFile()
+        {
+            var result = Execute(Path.Combine("Exception", "Error.csx"));
+            Assert.Contains("Error.csx:line 1", result);
+        }
+
         private static string Execute(string fixture)
         {
             var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments(Path.Combine("..", "..", "..", "TestFixtures", fixture)));

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Xunit;
 
 namespace Dotnet.Script.Tests
@@ -7,19 +8,26 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldExecuteHelloWorld()
         {
-            Execute(@"..\..\..\TestFixtures\HelloWorld\HelloWorld.csx");
+            var result = Execute(Path.Combine("HelloWorld", "HelloWorld.csx"));
+            Assert.Contains("Hello World", result);
         }
 
         [Fact]
         public void ShouldExecuteScriptWithInlineNugetPackage()
         {
-            Execute(@"..\..\..\TestFixtures\InlineNugetPackage\InlineNugetPackage.csx");
+            var result = Execute(Path.Combine("InlineNugetPackage", "InlineNugetPackage.csx"));
+            Assert.Contains("AutoMapper.MapperConfiguration", result);
         }
 
-        private static void Execute(string fixture)
+        private static string Execute(string fixture)
         {
-            var exitCode = Program.Main(new[] { fixture });
-            Assert.Equal(0, exitCode);
+            var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments(Path.Combine("..", "..", "..", "TestFixtures", fixture)));
+            return result;
+        }
+
+        private static string[] GetDotnetScriptArguments(string fixture)
+        {
+            return new[] { "exec", Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", "Debug", "netcoreapp1.1", "dotnet-script.dll"), fixture };
         }
     }
 }

--- a/src/Dotnet.Script.Tests/TestFixtures/Exception/Error.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Exception/Error.csx
@@ -1,0 +1,1 @@
+﻿throw new Exception("die!");

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -15,7 +15,6 @@
     <PackageLicenseUrl>https://github.com/filipw/dotnet-script/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
-    <RuntimeFrameworkVersion>1.0.3</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>


### PR DESCRIPTION
Make use of the feature to show line numbers on exceptions.
Also changed the tests to run over external process (to better control output capturing) and fixed the paths to work on unix.