### PR TITLE
Fixed path to dotnet-script.dll according to debug/release configuration

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -34,7 +34,13 @@ namespace Dotnet.Script.Tests
 
         private static string[] GetDotnetScriptArguments(string fixture)
         {
-            return new[] { "exec", Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", "Debug", "netcoreapp1.1", "dotnet-script.dll"), fixture };
+            string configuration;
+#if DEBUG
+            configuration = "Debug";
+#else
+            configuration = "Release";
+#endif
+            return new[] { "exec", Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", configuration, "netcoreapp1.1", "dotnet-script.dll"), fixture };
         }
     }
 }


### PR DESCRIPTION
Discovered this when I tried to run the tests in release mode