### PR TITLE
Removed dotnet command suffix (.exe) and changed to lowercase

### DIFF
--- a/build/DotNet.csx
+++ b/build/DotNet.csx
@@ -6,21 +6,21 @@ public static class DotNet
     public static void Test(string pathToProjectFolder)
     {
         string pathToTestProject = FindProjectFile(pathToProjectFolder);
-        Command.Execute("dotnet.exe","test " + pathToTestProject + " --configuration Release");   
+        Command.Execute("dotnet","test " + pathToTestProject + " --configuration Release");   
     }
     
     public static void Pack(string pathToProjectFolder, string pathToPackageOutputFolder)
     {
         string pathToProjectFile = FindProjectFile(pathToProjectFolder);
-        Command.Execute("dotnet.exe",$"pack {pathToProjectFile} --configuration Release --output {pathToPackageOutputFolder} ");   
+        Command.Execute("dotnet",$"pack {pathToProjectFile} --configuration Release --output {pathToPackageOutputFolder} ");   
     }
 
     public static void Build(string pathToProjectFolder)
     {
         string pathToProjectFile = FindProjectFile(pathToProjectFolder);
-        Command.Execute("dotnet.exe","--version");
-        Command.Execute("dotnet.exe","restore " + pathToProjectFile);        
-        Command.Execute("dotnet.exe","build " + pathToProjectFile + " --configuration Release");   
+        Command.Execute("dotnet","--version");
+        Command.Execute("dotnet","restore " + pathToProjectFile);        
+        Command.Execute("dotnet","build " + pathToProjectFile + " --configuration Release");   
     }
 
     private static string FindProjectFile(string pathToProjectFolder)


### PR DESCRIPTION
The dotnet command need to be lower case and without the .exe suffix in order to run on *nix