### PR TITLE
Downgrade tool to netcoreapp1.0

### DIFF
--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -4,7 +4,7 @@
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
     <VersionPrefix>0.13.0</VersionPrefix>
     <Authors>filipw</Authors>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>dotnet-script</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -18,7 +18,7 @@
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>      
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,7 +29,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-     
+
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
.NET Core tools are still `netcoreapp1.0` so using *dotnet-script* as a tool today will fail during restore

Example this csproj 
```xml
<Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
   <TargetFramework>netcoreapp1.1</TargetFramework>
 </PropertyGroup>
   <ItemGroup>
      <DotNetCliToolReference Include="Dotnet.Script" Version="0.12.0-beta" />
    </ItemGroup>
</Project>
```
will fail wit the error
```diff
+ > dotnet restore .\hello.csproj --source C:\temp\dev\gh\devlead\dotnet-script\nuget
-  error NU1202: Package Dotnet.Script 0.12.0-beta is not compatible with netcoreapp1.0 (.NETCoreApp,Version=v1.0).
-  Package Dotnet.Script 0.12.0-beta supports: netcoreapp1.1 (.NETCoreApp,Version=v1.1)
```

Adjusting the tool target framework seems to do the trick (tested with dotnet build/test/pack to local folder and that folder used as source)
```diff
+ > dotnet restore .\hello.csproj --source C:\temp\dev\gh\devlead\dotnet-script\nuget
+   Restoring packages for C:\temp\dotnet-script-test\hello.csproj...
+   Restoring packages for C:\temp\dotnet-script-test\hello.csproj...
+   Installing Dotnet.Script 0.13.0.
+   Generating MSBuild file C:\temp\dotnet-script-test\obj\hello.csproj.nuget.g.props.
+   Restore completed in 814,17 ms for C:\temp\dotnet-script-test\hello.csproj.
+   Restore completed in 862,33 ms for C:\temp\dotnet-script-test\hello.csproj.
+ C:\temp\dotnet-script-test> dotnet script .\hello.csx
+ Hello
```