### PR TITLE
Add RuntimeDependency ToString() override

### DIFF
--- a/src/Dotnet.Script.Core/Metadata/RuntimeDependency.cs
+++ b/src/Dotnet.Script.Core/Metadata/RuntimeDependency.cs
@@ -25,5 +25,11 @@ namespace Dotnet.Script.Core.Metadata
             var other = (RuntimeDependency)obj;
             return other.Name == Name && other.Path == Path;
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{nameof(Name)}: {Name}, {nameof(Path)}: {Path}";
+        }
     }
 }


### PR DESCRIPTION
Currently RuntimeDepencies are logged as when running with the `-d` switch.
```diff
- Adding reference to a runtime dependency => Dotnet.Script.Core.Metadata.RuntimeDependency
- Adding reference to a runtime dependency => Dotnet.Script.Core.Metadata.RuntimeDependency
- Adding reference to a runtime dependency => Dotnet.Script.Core.Metadata.RuntimeDependency
- Adding reference to a runtime dependency => Dotnet.Script.Core.Metadata.RuntimeDependency
- ...etc.
```
added a ToString() override so it's logged as
```diff
+ Adding reference to a runtime dependency => Name: Microsoft.CodeAnalysis.Common, Path: C:\Users\MattiasKarlsson\.nuget\packages\microsoft.codeanalysis.common/1.3.0\lib/netstandard1.3/Microsoft.CodeAnalysis.dll
+ Adding reference to a runtime dependency => Name: Microsoft.CodeAnalysis.CSharp, Path: C:\Users\MattiasKarlsson\.nuget\packages\microsoft.codeanalysis.csharp/1.3.0\lib/netstandard1.3/Microsoft.CodeAnalysis.CSharp.dll
+ Adding reference to a runtime dependency => Name: Microsoft.CodeAnalysis.VisualBasic, Path: C:\Users\MattiasKarlsson\.nuget\packages\microsoft.codeanalysis.visualbasic/1.3.0\lib/netstandard1.3/Microsoft.CodeAnalysis.VisualBasic.dll
+ Adding reference to a runtime dependency => Name: Microsoft.CSharp, Path: C:\Users\MattiasKarlsson\.nuget\packages\microsoft.csharp/4.3.0\lib/netstandard1.3/Microsoft.CSharp.dll
+ ...etc.
```