### PR TITLE
Updated build scripts to 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ project.json
 
 # Archive files
 *.zip
+/build/dotnet-script

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - ulimit -n4096
   - ./install-dotnet-script.sh  
 script:  
-  - dotnet dotnet-script/publish/dotnet-script.dll Build.csx
+  - dotnet dotnet-script/dotnet-script.dll Build.csx

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,5 @@
 <configuration>
 <packageSources>
  <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
- <add key="Roslyn3.0-alpha" value="build" />
 </packageSources>
 </configuration>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,6 @@ build_script:
 
     .\install-dotnet-script.ps1
 - cmd:
-    dotnet .\dotnet-script\publish\dotnet-script.dll build.csx
+    dotnet .\dotnet-script\dotnet-script.dll build.csx
 
 test: off

--- a/build/install-dotnet-script.ps1
+++ b/build/install-dotnet-script.ps1
@@ -1,6 +1,6 @@
 $client = New-Object "System.Net.WebClient"
-$url = "https://github.com/filipw/dotnet-script/releases/download/0.11.0-beta/dotnet-script.0.11.0-beta.zip"
+$url = "https://github.com/filipw/dotnet-script/releases/download/0.12.0-beta/dotnet-script.0.12.0-beta.zip"
 $file = "$pwd/dotnet-script.zip"
 $client.DownloadFile($url,$file)
-Expand-Archive $file -DestinationPath $pwd\dotnet-script -Force
+Expand-Archive $file -DestinationPath $pwd -Force
 

--- a/build/install-dotnet-script.sh
+++ b/build/install-dotnet-script.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-curl -L https://github.com/filipw/dotnet-script/releases/download/0.11.0-beta/dotnet-script.0.11.0-beta.zip > dotnet-script.zip
-unzip -o dotnet-script.zip -d dotnet-script
+curl -L https://github.com/filipw/dotnet-script/releases/download/0.12.0-beta/dotnet-script.0.12.0-beta.zip > dotnet-script.zip
+unzip -o dotnet-script.zip -d .

--- a/build/install-dotnet-script.sh
+++ b/build/install-dotnet-script.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 curl -L https://github.com/filipw/dotnet-script/releases/download/0.12.0-beta/dotnet-script.0.12.0-beta.zip > dotnet-script.zip
-unzip -o dotnet-script.zip -d .
+unzip -o dotnet-script.zip -d ./

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "src" ],
     "sdk": {
-            "version": "1.0.0"
+            "version": "1.0.4"
     }
 }

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <RuntimeFrameworkVersion>1.0.3</RuntimeFrameworkVersion>  
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
Unfortunately I managed to mess up the paths in the released ZIP (we used to have everything in a `publish` folder and now it's in `dotnet-script`) so I needed to update the paths too. 