### PR TITLE
Added support for simple scaffolding

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -20,10 +20,16 @@
 
   <ItemGroup>
     <None Remove="Templates\csproj.template" />
+    <None Remove="Templates\helloworld.csx.template" />
+    <None Remove="Templates\launch.json.template" />
+    <None Remove="Templates\omnisharp.json.template" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Templates\csproj.template" />
+    <EmbeddedResource Include="Templates\helloworld.csx.template" />
+    <EmbeddedResource Include="Templates\launch.json.template" />
+    <EmbeddedResource Include="Templates\omnisharp.json.template" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -5,7 +5,7 @@ using Dotnet.Script.Core.Templates;
 
 namespace Dotnet.Script.Core
 {
-    public class Skaffolder
+    public class Scaffolder
     {
         public void InitializerFolder()
         {
@@ -19,7 +19,7 @@ namespace Dotnet.Script.Core
             string pathToLaunchFile = Path.Combine(vsCodeDirectory, "launch.json");
             if (!File.Exists(pathToLaunchFile))
             {
-                string baseDirectory = Path.GetDirectoryName(new Uri(typeof(Skaffolder).GetTypeInfo().Assembly.CodeBase).LocalPath);
+                string baseDirectory = Path.GetDirectoryName(new Uri(typeof(Scaffolder).GetTypeInfo().Assembly.CodeBase).LocalPath);
                 string csxPath = Path.Combine(baseDirectory, "dotnet-script.dll").Replace(@"\", "/");
                                 
                 string lauchFileTemplate = TemplateLoader.ReadTemplate("launch.json.template");

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Dotnet.Script.Core.Templates;
+
+namespace Dotnet.Script.Core
+{
+    public class Skaffolder
+    {
+        public void InitializerFolder()
+        {
+            string currentDirectory = Directory.GetCurrentDirectory();
+            string vsCodeDirectory = Path.Combine(currentDirectory, ".vscode");
+            if (!Directory.Exists(vsCodeDirectory))
+            {
+                Directory.CreateDirectory(vsCodeDirectory);
+            }
+
+            string pathToLaunchFile = Path.Combine(vsCodeDirectory, "launch.json");
+            if (!File.Exists(pathToLaunchFile))
+            {
+                string baseDirectory = Path.GetDirectoryName(new Uri(typeof(Skaffolder).GetTypeInfo().Assembly.CodeBase).LocalPath);
+                string csxPath = Path.Combine(baseDirectory, "dotnet-script.dll").Replace(@"\", "/");
+                                
+                string lauchFileTemplate = TemplateLoader.ReadTemplate("launch.json.template");
+
+                string launchFileContent = lauchFileTemplate.Replace("PATH_TO_DOTNET-SCRIPT", csxPath);
+                WriteFile(pathToLaunchFile, launchFileContent);
+            }
+            
+            string pathToOmniSharpJson = Path.Combine(currentDirectory, "omnisharp.json");
+            if (!File.Exists(pathToOmniSharpJson))
+            {
+                var omniSharpFileTemplate = TemplateLoader.ReadTemplate("omnisharp.json.template");
+                WriteFile(pathToOmniSharpJson, omniSharpFileTemplate);
+            }
+
+            CreateNewScriptFile("helloworld.csx");
+        }
+
+        public void CreateNewScriptFile(string file)
+        {
+            string currentDirectory = Directory.GetCurrentDirectory();
+            var pathToScriptFile = Path.Combine(currentDirectory, file);
+            if (!File.Exists(pathToScriptFile))
+            {
+                var scriptFileTemplate = TemplateLoader.ReadTemplate("helloworld.csx.template");
+                WriteFile(pathToScriptFile, scriptFileTemplate);
+            }
+        }
+
+        private void WriteFile(string path, string content)
+        {
+            using (var fileStream = new FileStream(path, FileMode.Create))
+            {
+                using (var streamWriter = new StreamWriter(fileStream))
+                {
+                    streamWriter.Write(content);
+                }
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script.Core/Templates/helloworld.csx.template
+++ b/src/Dotnet.Script.Core/Templates/helloworld.csx.template
@@ -1,0 +1,4 @@
+﻿#! "netcoreapp1.1"
+#r "nuget:NetStandard.Library,1.6.1"
+
+Console.WriteLine("Hello world!");

--- a/src/Dotnet.Script.Core/Templates/launch.json.template
+++ b/src/Dotnet.Script.Core/Templates/launch.json.template
@@ -1,0 +1,18 @@
+﻿{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Script Debug",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+              "exec", 
+              "PATH_TO_DOTNET-SCRIPT", 
+              "${file}"
+            ],
+            "cwd": "${workspaceRoot}",
+            "stopAtEntry": true
+        }
+    ]
+}

--- a/src/Dotnet.Script.Core/Templates/omnisharp.json.template
+++ b/src/Dotnet.Script.Core/Templates/omnisharp.json.template
@@ -1,0 +1,5 @@
+﻿{
+  "script": {
+    "enableScriptNuGetReferences": true
+  }
+}

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using Xunit;
+
+namespace Dotnet.Script.Tests
+{
+    public class ScaffoldingTests
+    {
+        [Fact]
+        public void ShouldInitializeScriptFolder()
+        {            
+            var tempFolder = CreateTempFolder();
+            var result = Execute("init", tempFolder);
+            Assert.Equal(0, result.exitCode);
+            Assert.Contains(Path.Combine(tempFolder, "helloworld.csx"), Directory.GetFiles(tempFolder));
+            Assert.Contains(Path.Combine(tempFolder, "omnisharp.json"), Directory.GetFiles(tempFolder));
+            Assert.Contains(Path.Combine(tempFolder, ".vscode/launch.json"), Directory.GetFiles(tempFolder));
+            Directory.Delete(tempFolder,true);
+        }
+
+        [Fact]
+        public void ShouldCreateNewScript()
+        {
+            //var result = ExecuteInProcess("new", "script.csx");
+            var tempFolder = CreateTempFolder();
+            var result = Execute("new script.csx", tempFolder);
+            Assert.Equal(0, result.exitCode);
+            Assert.Contains(Path.Combine(tempFolder, "script.csx"), Directory.GetFiles(tempFolder));            
+            Directory.Delete(tempFolder, true);
+        }
+
+
+        private static string CreateTempFolder()
+        {
+            var userTempFolder = Path.GetTempPath();
+            var tempFile = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
+            var tempFolder = Path.Combine(userTempFolder, tempFile);
+            Directory.CreateDirectory(tempFolder);
+            return tempFolder;
+        }
+
+        /// <summary>
+        /// Use this if you need to debug.
+        /// </summary>        
+        private static int ExecuteInProcess(params string[] args)
+        {            
+            return Program.Main(args);
+        }
+
+        private static (string output, int exitCode) Execute(string args, string workingDirectory)
+        {
+            var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments(args), workingDirectory);
+            return result;
+        }
+
+        private static string[] GetDotnetScriptArguments(string args)
+        {
+            string configuration;
+#if DEBUG
+            configuration = "Debug";
+#else
+            configuration = "Release";
+#endif
+            return new[] { "exec", Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", configuration, "netcoreapp1.1", "dotnet-script.dll"), args };
+        }
+    }
+
+}

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -11,20 +11,19 @@ namespace Dotnet.Script.Tests
             var tempFolder = CreateTempFolder();
             var result = Execute("init", tempFolder);
             Assert.Equal(0, result.exitCode);
-            Assert.Contains(Path.Combine(tempFolder, "helloworld.csx"), Directory.GetFiles(tempFolder));
-            Assert.Contains(Path.Combine(tempFolder, "omnisharp.json"), Directory.GetFiles(tempFolder));
-            Assert.Contains(Path.Combine(tempFolder, ".vscode/launch.json"), Directory.GetFiles(tempFolder));
+            Assert.True(File.Exists(Path.Combine(tempFolder, "helloworld.csx")));
+            Assert.True(File.Exists(Path.Combine(tempFolder, "omnisharp.json")));
+            Assert.True(File.Exists(Path.Combine(tempFolder, ".vscode","launch.json")));            
             Directory.Delete(tempFolder,true);
         }
 
         [Fact]
         public void ShouldCreateNewScript()
         {
-            //var result = ExecuteInProcess("new", "script.csx");
             var tempFolder = CreateTempFolder();
             var result = Execute("new script.csx", tempFolder);
             Assert.Equal(0, result.exitCode);
-            Assert.Contains(Path.Combine(tempFolder, "script.csx"), Directory.GetFiles(tempFolder));            
+            Assert.True(File.Exists(Path.Combine(tempFolder, "script.csx")));
             Directory.Delete(tempFolder, true);
         }
 

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -76,7 +76,7 @@ namespace Dotnet.Script
                 c.Description = "Creates a sample script along with the launch.json file needed to launch and debug the script.";
                 c.OnExecute(() =>
                 {
-                    var skaffolder = new Skaffolder();
+                    var skaffolder = new Scaffolder();
                     skaffolder.InitializerFolder();
                     return 0;
                 });
@@ -88,7 +88,7 @@ namespace Dotnet.Script
                 var fileNameArgument = c.Argument("filename", "The script file name");
                 c.OnExecute(() =>
                 {
-                    var skaffolder = new Skaffolder();
+                    var skaffolder = new Scaffolder();
                     if (fileNameArgument.Value == null)
                     {
                         c.ShowHelp();

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -71,6 +71,34 @@ namespace Dotnet.Script
                 return 0;
             });
 
+            app.Command("init", c =>
+            {
+                c.Description = "Creates a sample script along with the launch.json file needed to launch and debug the script.";
+                c.OnExecute(() =>
+                {
+                    var skaffolder = new Skaffolder();
+                    skaffolder.InitializerFolder();
+                    return 0;
+                });
+            });
+
+            app.Command("new", c =>
+            {
+                c.Description = "Creates a new script file";
+                var fileNameArgument = c.Argument("filename", "The script file name");
+                c.OnExecute(() =>
+                {
+                    var skaffolder = new Skaffolder();
+                    if (fileNameArgument.Value == null)
+                    {
+                        c.ShowHelp();
+                        return 0;
+                    }
+                    skaffolder.CreateNewScriptFile(fileNameArgument.Value);
+                    return 0;
+                });
+            });
+
             return app.Execute(args.Except(new[] { "--" }).ToArray());
         }
 


### PR DESCRIPTION
This PR adds two new commands to the cli that helps the user getting started.

The purpose of this is to get the user up and running real fast without needing to copy and edit launch configurations.

```
Usage:  [arguments] [options] [command]

Arguments:
  script  Path to CSX script

Options:
  -conf |--configuration <configuration>  Configuration to use. Defaults to 'Release'
  -d | --debug                            Enables debug output.
  -? | -h | --help                        Show help information

Commands:
  eval  Execute CSX code.
  init  Creates a sample script along with the launch.json file needed to launch and debug the script.
  new   Creates a new script file

Use " [command] --help" for more information about a command.
```

### dotnet script init

Initializes the current directory with the following structure

```
.vscode
   launch.json
omnisharp.json
helloworld.csx
```

The launch.json is then configured and pointing to the dotnet-script.dll

The flow would then be 
```
dotnet script init
code .
```
Set breakpoint and hit F5

### dotnet new 

Simply creates a new script file