### PR TITLE
Added version option

### DIFF
--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
     <VersionPrefix>0.13.0</VersionPrefix>
+    <VersionSuffix>beta</VersionSuffix>
     <Authors>filipw</Authors>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>portable</DebugType>
@@ -18,7 +19,7 @@
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>      
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -43,7 +43,7 @@ namespace Dotnet.Script
 
             app.HelpOption("-? | -h | --help");
 
-            app.VersionOption("-v | --version", () => $"{typeof(Program).GetTypeInfo().Assembly.GetName().Version.ToString(3)}-beta");
+            app.VersionOption("-v | --version", GetVersionInfo);
 
             app.Command("eval", c =>
             {
@@ -137,6 +137,12 @@ namespace Dotnet.Script
             var compiler = new ScriptCompiler(logger, new ScriptProjectProvider(new ScriptParser(logger), logger));
             var runner = new ScriptRunner(compiler, logger);
             runner.Execute<object>(context).GetAwaiter().GetResult();
+        }
+
+        private static string GetVersionInfo()
+        {
+            var versionAttribute = typeof(Program).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().SingleOrDefault();            
+            return versionAttribute?.InformationalVersion;
         }
     }
 

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Dotnet.Script.Core;
 using Dotnet.Script.Core.ProjectSystem;
@@ -41,6 +42,8 @@ namespace Dotnet.Script
             var debugMode = app.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
 
             app.HelpOption("-? | -h | --help");
+
+            app.VersionOption("-v | --version", () => $"{typeof(Program).GetTypeInfo().Assembly.GetName().Version.ToString(3)}-beta");
 
             app.Command("eval", c =>
             {


### PR DESCRIPTION
This PR adds support for displaying the version number. 
I've added the beta suffix to the actual version number for now.

```
dotnet script -v|--version
0.13.0-beta
```