### PR TITLE
Feature/chocolatey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+build/*.nuspec
+build/.vscode
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,3 +9,14 @@ build_script:
     dotnet .\dotnet-script\dotnet-script.dll build.csx
 
 test: off
+artifacts:
+- path: /**/Dotnet.Script*.nupkg
+  name: Chocolatey Packages
+deploy:
+  provider: Chocolatey  
+  api_key:
+    secure: [Your API key goes here]
+  skip_symbols: false  
+  artifact: /.*\.nupkg/
+  on:
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,12 @@ test: off
 artifacts:
 - path: /**/Dotnet.Script*.nupkg
   name: Chocolatey Packages
-deploy:
-  provider: Chocolatey  
-  api_key:
-    secure: [Your API key goes here]
-  skip_symbols: false  
-  artifact: /.*\.nupkg/
-  on:
-    appveyor_repo_tag: true
+# Uncomment this to enable deploy on repo tagging
+# deploy:
+#   provider: Chocolatey  
+#   api_key:
+#     secure: [Your API key goes here]
+#   skip_symbols: false  
+#   artifact: /.*\.nupkg/
+#   on:
+#     appveyor_repo_tag: true

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,8 +1,16 @@
 #! "netcoreapp1.1"
 #r "nuget:NetStandard.Library,1.6.1"
 #load "DotNet.csx"
+#load "Choco.csx"
+
+using System.Runtime.InteropServices;
 
 DotNet.Build(@"../src/Dotnet.Script");
 DotNet.Build(@"../src/Dotnet.Script.Tests");
 DotNet.Test(@"../src/Dotnet.Script.Tests");
+DotNet.Publish(@"../src/Dotnet.Script");
 
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+{
+    Choco.Pack(@"../src/Dotnet.Script","Chocolatey");
+}

--- a/build/Choco.csx
+++ b/build/Choco.csx
@@ -1,0 +1,85 @@
+#load "FileUtils.csx"
+#load "DotNet.csx"
+#load "Command.csx"
+
+using System.Xml.Linq;
+
+public static class Choco
+{    
+    /// <summary>
+    /// Creates a Chocolatey package based on a "csproj" project file. 
+    /// </summary>
+    /// <param name="pathToProjectFolder">The path to the project folder.</param>
+    /// <param name="outputFolder">The path to the output folder (*.nupkg)</param>
+    public static void Pack(string pathToProjectFolder, string outputFolder)
+    {        
+        DotNet.Publish(pathToProjectFolder);        
+        Directory.CreateDirectory(outputFolder);
+        var pathToPublishFolder = FileUtils.FindDirectory(Path.Combine(pathToProjectFolder, @"bin\Release"),"publish");        
+        string pathToProjectFile = FileUtils.FindFile(pathToProjectFolder, "*.csproj");
+        CreateSpecificationFromProject(pathToProjectFile, pathToPublishFolder);        
+        Command.Execute("choco.exe", $@"pack Chocolatey\chocolatey.nuspec  --outputdirectory {outputFolder}");      
+    }
+
+    private static void CreateSpecificationFromProject(string pathToProjectFile, string pathToPublishFolder)
+    {
+        var projectFile = XDocument.Load(pathToProjectFile);
+        var authors = projectFile.Descendants("Authors").SingleOrDefault()?.Value;
+        var packageId = projectFile.Descendants("PackageId").SingleOrDefault()?.Value;
+        var description = projectFile.Descendants("Description").SingleOrDefault()?.Value;
+        var versionPrefix = projectFile.Descendants("VersionPrefix").SingleOrDefault()?.Value;
+        var versionSuffix = projectFile.Descendants("VersionSuffix").SingleOrDefault()?.Value;
+        
+        string version;
+        if (versionSuffix != null)
+        {
+            version = $"{versionPrefix}-{versionSuffix}";            
+        }
+        else
+        {
+            version = versionPrefix;
+        }
+        var tags = projectFile.Descendants("PackageTags").SingleOrDefault()?.Value;
+        var iconUrl = projectFile.Descendants("PackageIconUrl").SingleOrDefault()?.Value;   
+        var projectUrl = projectFile.Descendants("PackageProjectUrl").SingleOrDefault()?.Value;  
+        var licenseUrl = projectFile.Descendants("PackageLicenseUrl").SingleOrDefault()?.Value;
+        var repositoryUrl = projectFile.Descendants("RepositoryUrl").SingleOrDefault()?.Value;
+
+        var packageElement = new XElement("package");
+        var metadataElement = new XElement("metadata");      
+        packageElement.Add(metadataElement);
+        
+        // Package id should be lower case
+        // https://chocolatey.org/docs/create-packages#naming-your-package  
+        metadataElement.Add(new XElement("id", packageId.ToLower()));    
+        metadataElement.Add(new XElement("version", version));                
+        metadataElement.Add(new XElement("authors", authors));        
+        metadataElement.Add(new XElement("licenseUrl", licenseUrl));
+        metadataElement.Add(new XElement("projectUrl", projectUrl));
+        metadataElement.Add(new XElement("iconUrl", iconUrl));
+        metadataElement.Add(new XElement("description", description));                
+        metadataElement.Add(new XElement("tags", repositoryUrl));
+        
+        var filesElement = new XElement("files");
+        packageElement.Add(filesElement);
+
+        // Add the tools folder that contains "ChocolateyInstall.ps1"
+        filesElement.Add(CreateFileElement(@"tools\*.*",@"Dotnet.Script\tools"));    
+        var srcFolder = Path.Combine("../",pathToPublishFolder).WithWindowsSlashes();
+        var srcGlobPattern = $@"{srcFolder}\**\*";
+        filesElement.Add(CreateFileElement(srcGlobPattern,packageId));
+                                
+        using (var fileStream = new FileStream("Chocolatey/chocolatey.nuspec",FileMode.Create))
+        {
+            new XDocument(packageElement).Save(fileStream);
+        }
+    }
+
+    private static XElement CreateFileElement(string src, string target)
+    {        
+        var srcAttribute = new XAttribute("src", src);
+        var targetAttribute = new XAttribute("target", target);
+        return new XElement("file", srcAttribute, targetAttribute);
+    }
+
+}

--- a/build/Chocolatey/chocolatey.nuspec
+++ b/build/Chocolatey/chocolatey.nuspec
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>dotnet.script</id>
+    <version>0.13.0-beta</version>
+    <authors>filipw</authors>
+    <licenseUrl>https://github.com/filipw/dotnet-script/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/filipw/dotnet-script</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/filipw/Strathweb.TypedRouting.AspNetCore/master/strathweb.png</iconUrl>
+    <description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</description>
+    <tags>https://github.com/filipw/dotnet-script.git</tags>
+  </metadata>
+  <files>
+    <file src="tools\*.*" target="Dotnet.Script\tools" />
+    <file src="..\..\src\Dotnet.Script\bin\Release\netcoreapp1.1\publish\**\*" target="Dotnet.Script" />
+  </files>
+</package>

--- a/build/Chocolatey/tools/ChocolateyInstall.ps1
+++ b/build/Chocolatey/tools/ChocolateyInstall.ps1
@@ -1,0 +1,3 @@
+# Add the binary folder to the users PATH environment variable.
+$pathToBinaries = Join-Path -Path $($env:ChocolateyPackageFolder) -ChildPath $($env:ChocolateyPackageName )
+Install-ChocolateyPath -PathToInstall "$pathToBinaries"

--- a/build/DotNet.csx
+++ b/build/DotNet.csx
@@ -23,6 +23,13 @@ public static class DotNet
         Command.Execute("dotnet","build " + pathToProjectFile + " --configuration Release");   
     }
 
+    public static void Publish(string pathToProjectFolder)
+    {
+         string pathToProjectFile = FindProjectFile(pathToProjectFolder);
+         Command.Execute("dotnet","publish " + pathToProjectFile + " --configuration Release");   
+    }
+
+
     private static string FindProjectFile(string pathToProjectFolder)
     {
         return FileUtils.FindFile(pathToProjectFolder, "*.csproj");

--- a/build/FileUtils.csx
+++ b/build/FileUtils.csx
@@ -3,6 +3,12 @@
 using System.Text.RegularExpressions;
 
 
+public static string WithWindowsSlashes(this string path)
+{
+    return path.Replace("/", @"\");
+}
+
+
 public static class FileUtils
 {
     public static void ReplaceInFile(string pattern, string value, string pathToFile)
@@ -57,10 +63,17 @@ public static class FileUtils
         return pathsToFile[0];
     }
 
-    public static string FindDirectory(string path, string filePattern)
-    {
+    public static string ResolveDirectory(string path, string filePattern)
+    {                
         string pathToFile = FindFile(path, filePattern);
         return Path.GetDirectoryName(pathToFile);
+    }
+
+    
+
+    public static string FindDirectory(string path, string searchPattern)
+    {
+        return Directory.GetDirectories(path,searchPattern,SearchOption.AllDirectories).SingleOrDefault();
     }
 
     public static void RemoveDirectory(string path)


### PR DESCRIPTION
This PR adds support for building a Chocolatey package for Dotnet-Script.

The nuspec file for creating the package is created automatically based on Dotnet.Script.csproj to ensure a single source of truth with regards to package description, version and so on. 

I have modified the appveyor.yml file to upload the artifacts and also added a section that adds deploy on repo tagging. What is left for you to do here is to create the Chocolatey deploy provider and fill in your secure key for Chocolatey.org
