### PR TITLE
renamed choco package to dotnet-script

### DIFF
--- a/build/Build.csx
+++ b/build/Build.csx
@@ -9,7 +9,7 @@ var root = Args.FirstOrDefault() ?? "..";
 
 DotNet.Build($"{root}/src/Dotnet.Script");
 DotNet.Build($"{root}/src/Dotnet.Script.Tests");
-// DotNet.Test($"{root}/src/Dotnet.Script.Tests");
+DotNet.Test($"{root}/src/Dotnet.Script.Tests");
 DotNet.Publish($"{root}/src/Dotnet.Script");
 
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/build/Choco.csx
+++ b/build/Choco.csx
@@ -26,7 +26,7 @@ public static class Choco
     {
         var projectFile = XDocument.Load(pathToProjectFile);
         var authors = projectFile.Descendants("Authors").SingleOrDefault()?.Value;
-        var packageId = projectFile.Descendants("PackageId").SingleOrDefault()?.Value;
+        var packageId = "dotnet-script";
         var description = projectFile.Descendants("Description").SingleOrDefault()?.Value;
         var versionPrefix = projectFile.Descendants("VersionPrefix").SingleOrDefault()?.Value;
         var versionSuffix = projectFile.Descendants("VersionSuffix").SingleOrDefault()?.Value;


### PR DESCRIPTION
This comes in a little late, but I suddenly realized that the choco package was named `dotnet.script`. IMHO a better name would be `dotnet-script` since that is sort of the name of the "product". It is actually recommended to use hyphen rather than dots. 

I simply want to avoid the possible confusion of having a different name for the product and the choco package. 

https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package

On a side note, it is strange that the validation process did not complain about this. 

I should have thought about this before pushing to Chocolatey, but we simply unlist dotnet.script and push dotnet-script instead. It is now or never :)
