### PR TITLE
fixes #129

### DIFF
--- a/build/Build.csx
+++ b/build/Build.csx
@@ -9,7 +9,7 @@ var root = Args.FirstOrDefault() ?? "..";
 
 DotNet.Build($"{root}/src/Dotnet.Script");
 DotNet.Build($"{root}/src/Dotnet.Script.Tests");
-// DotNet.Test($"{root}/src/Dotnet.Script.Tests");
+DotNet.Test($"{root}/src/Dotnet.Script.Tests");
 DotNet.Publish($"{root}/src/Dotnet.Script");
 
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Dotnet.Script.Core/Metadata/RuntimeDependency.cs
+++ b/src/Dotnet.Script.Core/Metadata/RuntimeDependency.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.CodeAnalysis;
 
 namespace Dotnet.Script.Core.Metadata
 {
@@ -6,11 +8,13 @@ namespace Dotnet.Script.Core.Metadata
     {
         public string Name { get; }
         public string Path { get; }
+        public AssemblyName AssemblyName {get;}
 
         public RuntimeDependency(string name, string path)
         {
             Name = name;
-            Path = path;           
+            Path = path;
+            AssemblyName = AssemblyLoadContext.GetAssemblyName(path);
         }
 
         /// <inheritdoc />

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -7,11 +7,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
-using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.Extensions.DependencyModel;
-using System.Runtime.InteropServices;
-
 using System.IO;
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis.CSharp;
@@ -127,10 +124,10 @@ namespace Dotnet.Script.Core
             foreach (var runtimeDep in runtimeDependencies)
             {
                 _logger.Verbose("Adding reference to a runtime dependency => " + runtimeDep);
-                opts = opts.AddReferences(MetadataReference.CreateFromFile(runtimeDep.Path));
+                opts = opts.AddReferences(MetadataReference.CreateFromFile(runtimeDep.Path));                
             }
 
-            var loader = new InteractiveAssemblyLoader();
+            var loader = new InteractiveAssemblyLoader();            
             var script = CSharpScript.Create<TReturn>(context.Code.ToString(), opts, typeof(THost), loader);
             var orderedDiagnostics = script.GetDiagnostics(SuppressedDiagnosticIds);
 
@@ -147,14 +144,18 @@ namespace Dotnet.Script.Core
 
             return new ScriptCompilationContext<TReturn>(script, context.Code, loader);
         }
-
+       
         private Assembly MapUnresolvedAssemblyToRuntimeLibrary(IList<RuntimeDependency> runtimeDependencies, AssemblyLoadContext loadContext, AssemblyName assemblyName)
-        {
+        {                      
             var runtimeDependency = runtimeDependencies.SingleOrDefault(r => r.Name == assemblyName.Name);
             if (runtimeDependency != null)
             {
-                _logger.Verbose($"Unresolved assembly {assemblyName}. Loading from resolved runtime dependencies at path: {runtimeDependency.Path}");
-                return loadContext.LoadFromAssemblyPath(runtimeDependency.Path);
+                if (runtimeDependency.AssemblyName.Version != assemblyName.Version)
+                {
+                    _logger.Verbose(
+                        $"Unresolved assembly {assemblyName}. Loading from resolved runtime dependencies at path: {runtimeDependency.Path}");
+                    return loadContext.LoadFromAssemblyPath(runtimeDependency.Path);
+                }
             }
             return null;
         }       

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -34,10 +34,18 @@ namespace Dotnet.Script.Tests
             Assert.Contains("Connection successful", result.output);
         }
         
+        [Fact]
         public static void ShouldReturnNonZeroExitCodeWhenScriptFails()
         {
             var result = Execute(Path.Combine("Exception", "Error.csx"));
             Assert.NotEqual(0, result.exitCode);
+        }
+
+        [Fact]
+        public static void ShouldHandleIssue129()
+        {
+            var result = Execute(Path.Combine("Issue129", "Issue129.csx"));    
+            Assert.Contains("Bad HTTP authentication header", result.output);
         }
 
         private static (string output, int exitCode) Execute(string fixture)

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue129/Issue129.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue129/Issue129.csx
@@ -1,0 +1,8 @@
+﻿#r "nuget:Newtonsoft.Json, 10.0.2"
+#r "nuget:Auth0.ManagementApi,4.4.0"
+using Newtonsoft.Json;
+using Auth0.ManagementApi;
+
+var client = new ManagementApiClient("token", new Uri("https://foo.auth0.com/api/v2/"));
+
+Console.WriteLine(await client.Connections.GetAllAsync("auth0"));


### PR DESCRIPTION
This PR fixes issue #129 . More specifically we now only try to redirect an assembly if the request assembly version is different from what we have already resolved as a runtime dependency.

We will receive more of these issues and I think the only sane way to go about this is to create tests that pretty much does exactly the same as the example provided in the issues. It would take us forever if we should try to recreate the particularities of a given package. If a package gets unlisted for some reason, we will know about it and can take action accordingly.  👍 

  