### PR TITLE
Quote path in cmd in case of spaces

### DIFF
--- a/src/Dotnet.Script/dotnet-script.cmd
+++ b/src/Dotnet.Script/dotnet-script.cmd
@@ -1,2 +1,2 @@
 @echo off
-dotnet exec %~dp0/dotnet-script.dll %*
+dotnet exec "%~dp0/dotnet-script.dll" %*


### PR DESCRIPTION
Since we are on the topic of improving the `cmd`, as in 27b179626b1d8d730aac66994690bccbd551d9dd, this PR quotes the path to `dotnet-script.dll` correctly in the event that there's a directory in the path with a space in its name, like `Program Files`.