### PR TITLE
Add quotes to project file path when running dotnet restore on it

### DIFF
--- a/src/Dotnet.Script.Core/Metadata/DependencyResolver.cs
+++ b/src/Dotnet.Script.Core/Metadata/DependencyResolver.cs
@@ -113,7 +113,7 @@ namespace Dotnet.Script.Core.Metadata
         private void Restore(string pathToProjectFile)
         {
             var runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
-            _commandRunner.Execute("dotnet", $"restore {pathToProjectFile} -r {runtimeId}");
+            _commandRunner.Execute("dotnet", $"restore \"{pathToProjectFile}\" -r {runtimeId}");
             //_commandRunner.Execute("DotNet", $"restore {pathToProjectFile}");
         }
 


### PR DESCRIPTION
Dotnet restore command fails on runtime context if the project path contains spaces. Fixing it by adding quotes around project path.