### PR TITLE
Use install script for dotnet sdk on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ matrix:
   include:
     - os: osx
       osx_image: xcode9      
-      sudo: required      
-      dotnet: 2.0.0    
+      sudo: required        
 before_install:
   - brew update
+  - curl https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+  - chmod +x dotnet-install.sh
+  - ./dotnet-install.sh --channel 2.0
 install:
   - ulimit -n4096  
 script:  
-  - dotnet test src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+  - ~/.dotnet/dotnet test src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ before_install:
 install:
   - ulimit -n4096  
 script:  
-  - ~/.dotnet/dotnet test src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+  - chmod +x build.sh
+  - ./build.sh
+  

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 DOTNET_SCRIPT="$SCRIPT_DIR/build/dotnet-script"
 if [ ! -d "$DOTNET_SCRIPT" ]; then
     echo "Downloading dotnet-script..."
-    curl -L https://github.com/filipw/dotnet-script/releases/download/0.14.0/dotnet-script.0.13.0.zip > "$SCRIPT_DIR/build/dotnet-script.zip"
+    curl -L https://github.com/filipw/dotnet-script/releases/download/0.14.0/dotnet-script.0.14.0.zip > "$SCRIPT_DIR/build/dotnet-script.zip"
     unzip -o "$SCRIPT_DIR/build/dotnet-script.zip" -d "$SCRIPT_DIR/build/"
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading dotnet-script"

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,11 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 DOTNET_SCRIPT="$SCRIPT_DIR/build/dotnet-script"
 if [ ! -d "$DOTNET_SCRIPT" ]; then
     echo "Downloading dotnet-script..."
-    curl -L https://github.com/filipw/dotnet-script/releases/download/0.13.0/dotnet-script.0.13.0.zip > "$SCRIPT_DIR/build/dotnet-script.zip"
+    curl -L https://github.com/filipw/dotnet-script/releases/download/0.14.0/dotnet-script.0.13.0.zip > "$SCRIPT_DIR/build/dotnet-script.zip"
     unzip -o "$SCRIPT_DIR/build/dotnet-script.zip" -d "$SCRIPT_DIR/build/"
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading dotnet-script"
         exit 1
     fi
 fi
-dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/build.csx" -- "$SCRIPT_DIR"
+~/.dotnet/dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/build.csx" -- "$SCRIPT_DIR"

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -11,18 +11,17 @@ var root = Path.GetFullPath(rootArg);
 DotNet.Build(Path.Combine(root, "src","Dotnet.Script"));
 
 DotNet.Test($"{root}/src/Dotnet.Script.Tests");
-DotNet.Test($"{root}/src/Dotnet.Script.DependencyModel.Tests");
-
-string packagesOutputFolder = Path.Combine(root, "build", "NuGet"); 
-DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script"), packagesOutputFolder);
-DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script.Core"), packagesOutputFolder);
-DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script.DependencyModel"), packagesOutputFolder);
-DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script.DependencyModel.NuGet"), packagesOutputFolder);
 
 
-DotNet.Publish($"{root}/src/Dotnet.Script");
-
+// We only publish packages from Windows/AppVeyor
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {
+    string packagesOutputFolder = Path.Combine(root, "build", "NuGet"); 
+    DotNet.Test($"{root}/src/Dotnet.Script.DependencyModel.Tests");
+    DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script"), packagesOutputFolder);
+    DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script.Core"), packagesOutputFolder);
+    DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script.DependencyModel"), packagesOutputFolder);
+    DotNet.Pack(Path.Combine(root, "src" , "Dotnet.Script.DependencyModel.NuGet"), packagesOutputFolder);
+    DotNet.Publish($"{root}/src/Dotnet.Script");
     Choco.Pack($"{root}/src/Dotnet.Script","Chocolatey");
 }


### PR DESCRIPTION
This PR fixes the Travis build by installing the dotnet sdk according to this document.

https://github.com/dotnet/cli/blob/master/Documentation/specs/cli-installation-scenarios.md#installation-script

Related:
https://github.com/travis-ci/travis-ci/issues/8552
