### PR TITLE
fixes #143

### DIFF
--- a/src/Dotnet.Script/dotnet-script.sh
+++ b/src/Dotnet.Script/dotnet-script.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 dotnet exec $DIR/dotnet-script.dll "$@"


### PR DESCRIPTION
This PR adds support for a more symlink friendly version of the bash script (`dotnet-script.sh`) we use for extending the `dotnet cli`

Creating a symlink from your typical `bin` folder to the `lib` folder, did not work because it failed to find the `dotnet-script.dll`

```
dotnet exec needs a managed .dll or .exe extension. The application specified was '/usr/local/bin/dotnet-script.dll'
```

It uses the location of the symlink to resolve the path to `dotnet-script.dll`

We now use the actual location of `dotnet-script.sh` to resolve `dotnet-script.dll`

Links 
https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within

