### PR TITLE
warmup CSharpScript

### DIFF
--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -8,16 +8,13 @@ using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.Extensions.DependencyModel;
-using System.Runtime.Loader;
 using Microsoft.CodeAnalysis.CSharp;
 using Dotnet.Script.Core.Internal;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.NuGet;
 using Dotnet.Script.DependencyModel.Runtime;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 using System.Threading.Tasks;
-using System.Threading;
 
 namespace Dotnet.Script.Core
 {


### PR DESCRIPTION
This change introduces a dummy script to be started on the background thread as early as possible.
This will warmup `ReferenceManager` and other things `CSharpScript` needs to build up just once.

The result is a simple hello world, on my machine improves from ~2.5-3s to ~1.5s.

Our 9 integration tests that run scripts, before the change took about 25 seconds:

```
[16/10/17 14:34:29 Informational] ------ Run test started ------
[16/10/17 14:34:30 Informational] [xUnit.net 00:00:00.5100418]   Starting:    Dotnet.Script.Tests
[16/10/17 14:34:53 Informational] [xUnit.net 00:00:23.0786841]   Finished:    Dotnet.Script.Tests
[16/10/17 14:34:53 Informational] ========== Run test finished: 9 run (0:00:24.003002) ==========
[16/10/17 14:36:39 Informational] ------ Run test started ------
[16/10/17 14:36:40 Informational] [xUnit.net 00:00:00.5362879]   Starting:    Dotnet.Script.Tests
[16/10/17 14:37:07 Informational] [xUnit.net 00:00:27.1670723]   Finished:    Dotnet.Script.Tests
[16/10/17 14:37:07 Informational] ========== Run test finished: 9 run (0:00:27.9130044) ==========
```

After the change, they take about 17 seconds (so almost a second per test less):

```
[16/10/17 14:33:35 Informational] ------ Run test started ------
[16/10/17 14:33:37 Informational] [xUnit.net 00:00:00.5119101]   Starting:    Dotnet.Script.Tests
[16/10/17 14:33:53 Informational] [xUnit.net 00:00:17.2107716]   Finished:    Dotnet.Script.Tests
[16/10/17 14:33:53 Informational] ========== Run test finished: 9 run (0:00:17.8560755) ==========
[16/10/17 14:39:00 Informational] ------ Run test started ------
[16/10/17 14:39:01 Informational] [xUnit.net 00:00:00.5126304]   Starting:    Dotnet.Script.Tests
[16/10/17 14:39:17 Informational] [xUnit.net 00:00:16.7022036]   Finished:    Dotnet.Script.Tests
[16/10/17 14:39:17 Informational] ========== Run test finished: 9 run (0:00:17.3640025) ==========
```