### PR TITLE
Feature/windows install

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -21,14 +21,3 @@ $paths += Join-Path $installationFolder "dotnet-script"
 $path = $paths -join ";"
 
 [System.Environment]::SetEnvironmentVariable("path", $path, [System.EnvironmentVariableTarget]::User)
-
-
-
-
-
-
-
-
-
-
-

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,0 +1,33 @@
+# Create a temporary folder to download to.
+$tempFolder = Join-Path $env:TEMP "dotnet-script"
+New-Item $tempFolder -ItemType Directory -Force
+
+# Download the zip
+$client = New-Object "System.Net.WebClient"
+$url = "https://github.com/filipw/dotnet-script/releases/download/0.14.0/dotnet-script.0.14.0.zip"
+$zipFile = Join-Path $tempFolder "dotnet-script.zip"
+$client.DownloadFile($url,$zipFile)
+
+$installationFolder = Join-Path $env:ProgramData "dotnet-script"
+Expand-Archive $zipFile -DestinationPath $installationFolder -Force
+
+$path = [System.Environment]::GetEnvironmentVariable("path", [System.EnvironmentVariableTarget]::User);
+# Get all paths except paths to old dotnet.script installations. 
+$paths = $path.Split(";") -inotlike "*dotnet.script*" 
+# Add the installation folder to the path
+$paths += Join-Path $installationFolder "dotnet-script"
+# Create the new path string
+$path = $paths -join ";"
+
+[System.Environment]::SetEnvironmentVariable("path", $path, [System.EnvironmentVariableTarget]::User)
+
+
+
+
+
+
+
+
+
+
+

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -10,6 +10,7 @@ $client.DownloadFile($url,$zipFile)
 
 $installationFolder = Join-Path $env:ProgramData "dotnet-script"
 Expand-Archive $zipFile -DestinationPath $installationFolder -Force
+Remove-Item $tempFolder -Recurse -Force
 
 $path = [System.Environment]::GetEnvironmentVariable("path", [System.EnvironmentVariableTarget]::User);
 # Get all paths except paths to old dotnet.script installations. 


### PR DESCRIPTION
This PR adds support for installing `dotnet.script` using a PowerShell install script. 
This would be the Windows counterpart of `install.sh`

Should probably not replace the Chocolatey package, but provided as an alternative way of installing. 

Try it out from PowerShell 

```Powershell
(new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/filipw/dotnet-script/feature/windows-install/install/install.ps1") | iex
``` 