### PR TITLE
fixed handling of UNC paths

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
@@ -58,6 +58,12 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             if (pathRoot.Length > 0 && RuntimeHelper.IsWindows())
             {
                 var driveLetter = pathRoot.Substring(0, 1);
+                if (driveLetter == "\\")
+                {
+                    targetDirectoryWithoutRoot = targetDirectoryWithoutRoot.TrimStart(new char[] { '\\' });
+                    driveLetter = "UNC";
+                }
+
                 targetDirectoryWithoutRoot = Path.Combine(driveLetter, targetDirectoryWithoutRoot);
             }
             var pathToProjectDirectory = Path.Combine(tempDirectory, "scripts", targetDirectoryWithoutRoot);


### PR DESCRIPTION
At the moment, for UNC paths, `script.proj` is created in the current directory.

Fixes #149 