### PR TITLE
Support for local NuGet.Config

### DIFF
--- a/src/Dotnet.Script.DependencyModel.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.DependencyModel.Tests/ScriptProjectProviderTests.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using System.Runtime.Serialization;
+using Dotnet.Script.DependencyModel.ProjectSystem;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dotnet.Script.DependencyModel.Tests
+{
+    public class ScriptProjectProviderTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public ScriptProjectProviderTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void ShouldCopyLocalNuGetConfig()
+        {
+            var provider = CreateProvider();
+            var pathToProjectFile = provider.CreateProject("../../../../Dotnet.Script.Tests/TestFixtures/LocalNuGetConfig", "netcoreapp2.0", true);
+            var pathToProjectFileFolder = Path.GetDirectoryName(pathToProjectFile);
+            Assert.True(File.Exists(Path.Combine(pathToProjectFileFolder,"NuGet.Config")));
+        }
+
+        private ScriptProjectProvider CreateProvider()
+        {
+            ScriptProjectProvider provider = new ScriptProjectProvider(type => ((level, message) =>
+            {
+                _testOutputHelper.WriteLine($"{level}:{message ?? ""}");
+            }));
+
+            return provider;
+        }
+    }
+}

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.Logging;
 
@@ -47,7 +48,19 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
             projectFile.Save(pathToProjectFile);
             _logger.Debug($"Project file saved to {pathToProjectFile}");
+            CopyNuGetConfigFile(targetDirectory, Path.GetDirectoryName(pathToProjectFile));
             return pathToProjectFile;
+        }
+
+        private void CopyNuGetConfigFile(string targetDirectory, string pathToProjectFileFolder)
+        {
+            var pathToNuGetConfigFile = Path.Combine(targetDirectory, "NuGet.Config");
+            if (File.Exists(pathToNuGetConfigFile))
+            {
+                var pathToDestinationNuGetConfigFile = Path.Combine(pathToProjectFileFolder, "NuGet.Config");
+                _logger.Debug($"Copying {pathToNuGetConfigFile} to {pathToDestinationNuGetConfigFile}");
+                File.Copy(pathToNuGetConfigFile, Path.Combine(pathToProjectFileFolder, "NuGet.Config"), true);
+            }
         }
 
         private static string GetPathToProjectFile(string targetDirectory)

--- a/src/Dotnet.Script.Tests/TestFixtures/LocalNuGetConfig/LocalNuGetConfig.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/LocalNuGetConfig/LocalNuGetConfig.csx
@@ -1,0 +1,1 @@
+﻿Console.WriteLine("Hello World");

--- a/src/Dotnet.Script.Tests/TestFixtures/LocalNuGetConfig/NuGet.Config
+++ b/src/Dotnet.Script.Tests/TestFixtures/LocalNuGetConfig/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
This PR adds support for providing a local `NuGet.Config` file that lets the user specify NuGet configuration without modifying the global `NuGet.Config` file

See #157 for details