### PR TITLE
uses fully qualified name for Expand-Archive

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -16,7 +16,7 @@ $zipFile = Join-Path $tempFolder "dotnet-script.zip"
 $client.DownloadFile($url,$zipFile)
 
 $installationFolder = Join-Path $env:ProgramData "dotnet-script"
-Expand-Archive $zipFile -DestinationPath $installationFolder -Force
+Microsoft.PowerShell.Archive\Expand-Archive $zipFile -DestinationPath $installationFolder -Force
 Remove-Item $tempFolder -Recurse -Force
 
 $path = [System.Environment]::GetEnvironmentVariable("path", [System.EnvironmentVariableTarget]::User);


### PR DESCRIPTION
uses Microsoft.PowerShell.Archive\Expand-Archive to resolve a problem of running
the install script on a user's machine that has PSCX installed, which also exposes
Expand-Archive