### PR TITLE
Upgraded to dotnetcore 2.0.0 baseimage, more explisit readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A Dockerfile for running dotnet-script in a Linux container is available. Build:
 
 ```shell
 cd build
-docker build -t dotnet-script ..
+docker build -t dotnet-script -f Dockerfile ..
 ```
 
 And run:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,11 @@
-FROM microsoft/dotnet:1.1-sdk 
+FROM microsoft/dotnet:2.0.0-sdk 
 COPY . /dotnet-script
 WORKDIR /dotnet-script
 
 RUN dotnet restore
 RUN dotnet test src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj 
-RUN dotnet publish 
+RUN dotnet publish src/Dotnet.Script/Dotnet.Script.csproj -f netcoreapp2.0
 
 WORKDIR /scripts
 
-ENTRYPOINT ["dotnet", "/dotnet-script/src/Dotnet.Script/bin/Debug/netcoreapp1.1/publish/dotnet-script.dll"] 
+ENTRYPOINT ["dotnet", "/dotnet-script/src/Dotnet.Script/bin/Debug/netcoreapp2.0/publish/dotnet-script.dll"] 


### PR DESCRIPTION
I used the `microsoft/dotnet:2.0.0-sdk` base image, `microsoft/dotnet:2.0-sdk ` will give the latest `2.0` build. Any preferences here? 