### PR TITLE
make sure we install machine wide

### DIFF
--- a/build/Chocolatey/tools/ChocolateyInstall.ps1
+++ b/build/Chocolatey/tools/ChocolateyInstall.ps1
@@ -1,3 +1,3 @@
 # Add the binary folder to the users PATH environment variable.
 $pathToBinaries = Join-Path -Path $($env:ChocolateyPackageFolder) -ChildPath $($env:ChocolateyPackageName )
-Install-ChocolateyPath -PathToInstall "$pathToBinaries"
+Install-ChocolateyPath -PathToInstall "$pathToBinaries" -PathType 'Machine'


### PR DESCRIPTION
When rolling out new servers with Ansible or similar provisioning software we often need to be machine wide for all users to be able to use dotnet-script. 