### PR TITLE
Dump project file content when logging in debug mode

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
@@ -37,9 +37,18 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             projectFile.SetTargetFramework(parseresult.TargetFramework ?? defaultTargetFramework);
 
             projectFile.Save(pathToProjectFile);
-            _logger.Debug($"Project file saved to {pathToProjectFile}");
+
+            LogProjectFileInfo(pathToProjectFile);
+
             CopyNuGetConfigFile(targetDirectory, Path.GetDirectoryName(pathToProjectFile));
             return pathToProjectFile;
+        }
+
+        private void LogProjectFileInfo(string pathToProjectFile)
+        {
+            _logger.Debug($"Project file saved to {pathToProjectFile}");
+            var content = File.ReadAllText(pathToProjectFile);
+            _logger.Debug(content);
         }
 
         public string CreateProject(string targetDirectory, string defaultTargetFramework = "net46", bool enableNuGetScriptReferences = false)
@@ -66,7 +75,9 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             projectFile.SetTargetFramework(parseresult.TargetFramework ?? defaultTargetFramework);
 
             projectFile.Save(pathToProjectFile);
-            _logger.Debug($"Project file saved to {pathToProjectFile}");
+
+            LogProjectFileInfo(pathToProjectFile);
+
             CopyNuGetConfigFile(targetDirectory, Path.GetDirectoryName(pathToProjectFile));
             return pathToProjectFile;
         }

--- a/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using Dotnet.Script.DependencyModel.ProjectSystem;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,6 +22,18 @@ namespace Dotnet.Script.Tests
             var pathToProjectFile = provider.CreateProject(TestPathUtils.GetFullPathToTestFixture("LocalNuGetConfig"), "netcoreapp2.0", true);
             var pathToProjectFileFolder = Path.GetDirectoryName(pathToProjectFile);
             Assert.True(File.Exists(Path.Combine(pathToProjectFileFolder,"NuGet.Config")));
+        }
+
+        [Fact]
+        public void ShouldLogProjectFileContent()
+        {
+            StringBuilder log = new StringBuilder();            
+            var provider = new ScriptProjectProvider(type => ((level, message) => log.AppendLine(message)));
+
+            provider.CreateProject(TestPathUtils.GetFullPathToTestFixture("Helloworld"), "netcoreapp2.0", true);
+            var output = log.ToString();
+
+            Assert.Contains("<Project Sdk=\"Microsoft.NET.Sdk\">",output);
         }
 
         private ScriptProjectProvider CreateProvider()


### PR DESCRIPTION
This PR adds support for dumping the content of the temporary `csproj` file generated when resolving dependencies. fixes #167 