### PR TITLE
Better errors

### DIFF
--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -103,6 +103,13 @@ namespace Dotnet.Script.Core
                     _globals.Print(_scriptState.ReturnValue);
                 }
             }
+            catch (CompilationErrorException e)
+            {
+                foreach (var diagnostic in e.Diagnostics)
+                {
+                    Console.WritePrettyError(diagnostic.ToString());
+                }
+            }
             catch (Exception e)
             {
                 Console.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(e));

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -143,11 +143,6 @@ namespace Dotnet.Script.Core
 
             if (orderedDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
             {
-                foreach (var diagnostic in orderedDiagnostics)
-                {
-                    Logger.Log(diagnostic.ToString());
-                }
-
                 throw new CompilationErrorException("Script compilation failed due to one or more errors.",
                     orderedDiagnostics.ToImmutableArray());
             }

--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -16,7 +16,7 @@ namespace Dotnet.Script.Core
         public virtual void WritePrettyError(string value)
         {
             Console.ForegroundColor = ConsoleColor.Red;
-            Error.WriteLine(value);
+            Error.WriteLine(value.TrimEnd(System.Environment.NewLine.ToCharArray()));
             Console.ResetColor();
         }
 

--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -16,7 +16,7 @@ namespace Dotnet.Script.Core
         public virtual void WritePrettyError(string value)
         {
             Console.ForegroundColor = ConsoleColor.Red;
-            Error.Write(value);
+            Error.WriteLine(value);
             Console.ResetColor();
         }
 

--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -16,7 +16,7 @@ namespace Dotnet.Script.Core
         public virtual void WritePrettyError(string value)
         {
             Console.ForegroundColor = ConsoleColor.Red;
-            Error.WriteLine(value.TrimEnd(System.Environment.NewLine.ToCharArray()));
+            Error.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
             Console.ResetColor();
         }
 

--- a/src/Dotnet.Script.Core/ScriptRunner.cs
+++ b/src/Dotnet.Script.Core/ScriptRunner.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting;
@@ -58,10 +57,8 @@ namespace Dotnet.Script.Core
         {
             if (scriptState.Exception != null)
             {
-                Logger.Log("Script execution resulted in an exception.");
-                Logger.Log(scriptState.Exception.Message);
-                Logger.Log(scriptState.Exception.StackTrace);
-                throw scriptState.Exception;
+                ScriptConsole.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(scriptState.Exception));
+                throw new ScriptRuntimeException("Script execution resulted in an exception.", scriptState.Exception);
             }
 
             return scriptState.ReturnValue;

--- a/src/Dotnet.Script.Core/ScriptRunner.cs
+++ b/src/Dotnet.Script.Core/ScriptRunner.cs
@@ -11,7 +11,6 @@ namespace Dotnet.Script.Core
         protected ScriptCompiler ScriptCompiler;
         protected ScriptConsole ScriptConsole;
 
-
         public ScriptRunner(ScriptCompiler scriptCompiler, ScriptLogger logger, ScriptConsole scriptConsole)
         {
             Logger = logger;
@@ -57,7 +56,9 @@ namespace Dotnet.Script.Core
         {
             if (scriptState.Exception != null)
             {
-                ScriptConsole.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(scriptState.Exception));
+                // once Roslyn ships with this, we can format he exception using CSharpObjectFormatter
+                // https://github.com/dotnet/roslyn/blob/4175350b87f928e136cbb14c2668b7cb3338d5a1/src/Scripting/Core/Hosting/CommonMemberFilter.cs#L18
+                ScriptConsole.WritePrettyError(scriptState.Exception.ToString());
                 throw new ScriptRuntimeException("Script execution resulted in an exception.", scriptState.Exception);
             }
 

--- a/src/Dotnet.Script.Core/ScriptRuntimeException.cs
+++ b/src/Dotnet.Script.Core/ScriptRuntimeException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Dotnet.Script.Core
+{
+    public class ScriptRuntimeException : Exception
+    {
+        public ScriptRuntimeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
@@ -66,6 +66,22 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public async Task Exception()
+        {
+            var commands = new[]
+            {
+                "foo",
+                "#exit"
+            };
+
+            var ctx = GetRunner(commands);
+            await ctx.Runner.RunLoop(false);
+
+            var result = ctx.Console.Error.ToString();
+            Assert.Contains("(1,1): error CS0103: The name 'foo' does not exist in the current context", result);
+        }
+
+        [Fact]
         public async Task Multiline()
         {
             var commands = new[]

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -41,10 +41,18 @@ namespace Dotnet.Script.Tests
         }
         
         [Fact]
-        public static void ShouldReturnExitCodeOneWhenScriptFails()
+        public static void ShouldReturnExitCodeFromExceptionWhenScriptFails()
         {
             var result = Execute(Path.Combine("Exception", "Error.csx"));
             Assert.Equal(-2146233088, result.exitCode);
+        }
+
+        [Fact]
+        public static void ShouldReturnStackTraceInformationWhenScriptFails()
+        {
+            var result = Execute(Path.Combine("Exception", "Error.csx"));
+            Assert.Contains("die!", result.output);
+            Assert.Contains("Error.csx:line 1", result.output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -44,7 +44,7 @@ namespace Dotnet.Script.Tests
         public static void ShouldReturnExitCodeOneWhenScriptFails()
         {
             var result = Execute(Path.Combine("Exception", "Error.csx"));
-            Assert.Equal(1, result.exitCode);
+            Assert.Equal(-2146233088, result.exitCode);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -41,10 +41,10 @@ namespace Dotnet.Script.Tests
         }
         
         [Fact]
-        public static void ShouldReturnExitCodeFromExceptionWhenScriptFails()
+        public static void ShouldReturnExitCodeOnenWhenScriptFails()
         {
             var result = Execute(Path.Combine("Exception", "Error.csx"));
-            Assert.Equal(-2146233088, result.exitCode);
+            Assert.Equal(1, result.exitCode);
         }
 
         [Fact]

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using Dotnet.Script.Core;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Runtime;
+using Microsoft.CodeAnalysis.Scripting;
 
 namespace Dotnet.Script
 {
@@ -22,6 +23,17 @@ namespace Dotnet.Script
             try
             {
                 return Wain(args);
+            }
+            catch (CompilationErrorException)
+            {
+                // no need to write out anything as the upstream services will report that
+                return 0x1;
+            }
+            catch (ScriptRuntimeException scriptRuntimeEx)
+            {
+                // no need to write out anything as the upstream services will report that
+                // also, CSI return exception HResult for script runtime exceptions
+                return scriptRuntimeEx.HResult;
             }
             catch (Exception e)
             {

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -31,17 +31,10 @@ namespace Dotnet.Script
                     e = aggregateEx.Flatten().InnerException;
                 }
 
-                if (e is CompilationErrorException)
+                if (e is CompilationErrorException || e is ScriptRuntimeException)
                 {
                     // no need to write out anything as the upstream services will report that
                     return 0x1;
-                }
-
-                if (e is ScriptRuntimeException)
-                {
-                    // no need to write out anything as the upstream services will report that
-                    // also, CSI return exception HResult for script runtime exceptions
-                    return e.HResult;
                 }
 
                 // Be verbose (stack trace) in debug mode otherwise brief

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -164,7 +164,7 @@ namespace Dotnet.Script
         private static Task<int> Run(bool debugMode, ScriptContext context)
         {
             var compiler = GetScriptCompiler(debugMode);
-            var runner = new ScriptRunner(compiler, compiler.Logger);
+            var runner = new ScriptRunner(compiler, compiler.Logger, ScriptConsole.Default);
             return runner.Execute<int>(context);
         }
 

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -24,22 +24,24 @@ namespace Dotnet.Script
             {
                 return Wain(args);
             }
-            catch (CompilationErrorException)
-            {
-                // no need to write out anything as the upstream services will report that
-                return 0x1;
-            }
-            catch (ScriptRuntimeException scriptRuntimeEx)
-            {
-                // no need to write out anything as the upstream services will report that
-                // also, CSI return exception HResult for script runtime exceptions
-                return scriptRuntimeEx.HResult;
-            }
             catch (Exception e)
             {
                 if (e is AggregateException aggregateEx)
                 {
                     e = aggregateEx.Flatten().InnerException;
+                }
+
+                if (e is CompilationErrorException)
+                {
+                    // no need to write out anything as the upstream services will report that
+                    return 0x1;
+                }
+
+                if (e is ScriptRuntimeException)
+                {
+                    // no need to write out anything as the upstream services will report that
+                    // also, CSI return exception HResult for script runtime exceptions
+                    return e.HResult;
                 }
 
                 // Be verbose (stack trace) in debug mode otherwise brief


### PR DESCRIPTION
 - we don't drop a full stacktrace in REPL anymore, instead we use the same formatter as CSI to provide a nice single-line message
 - errors in REPL, as well as compilation+runtime errors in scripts are printed into the console in red color
 - if a runtime error happens in a script, the runner exit code is set to the `HResult` of the exception (this is a recent change in CSI which will likely go out in 2.6.0). COmpilation errors still result in exit code 1