### PR TITLE
Added Microsoft.DotNet.PlatformAbstractions to Build.csx

### DIFF
--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,5 +1,6 @@
 #! "netcoreapp2.0"
 #r "nuget:NetStandard.Library,2.0.0"
+#r "nuget:Microsoft.DotNet.PlatformAbstractions, 2.0.3"
 #load "DotNet.csx"
 #load "Choco.csx"
 #load "NuGet.csx"


### PR DESCRIPTION
This PR adds the the Microsoft.DotNet.PlatformAbstractions NuGet package to the `Build.csx` file. This is needed from now on since we don't get this through the inherited assemblies anymore.  
Does not change anything, it just prepares us for when we start building with 0.16.0.

Last PR from me before 0.16.0 😄 
