### PR TITLE
align the behavior between REPL, REPL seeded with a script and script

### DIFF
--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -56,13 +56,13 @@ namespace Dotnet.Script.Core
 
         public virtual async Task RunLoopWithSeed(bool debugMode, ScriptContext scriptContext)
         {
-            await RunFirstScript(scriptContext);
+            await HandleScriptErrors(async () => await RunFirstScript(scriptContext));
             await RunLoop(debugMode);
         }
 
         protected virtual async Task Execute(string input, bool debugMode)
         {
-            try
+            await HandleScriptErrors(async () =>
             {
                 if (_scriptState == null)
                 {
@@ -92,28 +92,7 @@ namespace Dotnet.Script.Core
 
                     _scriptState = await _scriptState.ContinueWithAsync(input, _scriptOptions, ex => true);
                 }
-
-                if (_scriptState?.Exception != null)
-                {
-                    Console.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(_scriptState.Exception));
-                }
-
-                if (_scriptState?.ReturnValue != null)
-                {
-                    _globals.Print(_scriptState.ReturnValue);
-                }
-            }
-            catch (CompilationErrorException e)
-            {
-                foreach (var diagnostic in e.Diagnostics)
-                {
-                    Console.WritePrettyError(diagnostic.ToString());
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(e));
-            }
+            });
         }
 
         public virtual void Reset()
@@ -129,6 +108,9 @@ namespace Dotnet.Script.Core
 
         private async Task RunFirstScript(ScriptContext scriptContext)
         {
+            foreach (var arg in scriptContext.Args)
+                _globals.Args.Add(arg);
+
             var compilationContext = ScriptCompiler.CreateCompilationContext<object, InteractiveScriptGlobals>(scriptContext);
             _scriptState = await compilationContext.Script.RunAsync(_globals, ex => true).ConfigureAwait(false);
             _scriptOptions = compilationContext.ScriptOptions;
@@ -155,6 +137,34 @@ namespace Dotnet.Script.Core
             }
 
             return input.ToString();
+        }
+
+        private async Task HandleScriptErrors(Func<Task> doWork)
+        {
+            try
+            {
+                await doWork();
+                if (_scriptState?.Exception != null)
+                {
+                    Console.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(_scriptState.Exception));
+                }
+
+                if (_scriptState?.ReturnValue != null)
+                {
+                    _globals.Print(_scriptState.ReturnValue);
+                }
+            }
+            catch (CompilationErrorException e)
+            {
+                foreach (var diagnostic in e.Diagnostics)
+                {
+                    Console.WritePrettyError(diagnostic.ToString());
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(e));
+            }
         }
     }
 }

--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -72,8 +72,7 @@ namespace Dotnet.Script.Core
                 }
                 else
                 {
-                    var lineRuntimeDependencies =
-                        ScriptCompiler.RuntimeDependencyResolver.GetDependenciesFromCode(CurrentDirectory, input).ToArray();
+                    var lineRuntimeDependencies = ScriptCompiler.RuntimeDependencyResolver.GetDependenciesFromCode(CurrentDirectory, input).ToArray();
                     var lineDependencies = lineRuntimeDependencies.SelectMany(rtd => rtd.Assemblies).Distinct();
 
                     var scriptMap = lineRuntimeDependencies.ToDictionary(rdt => rdt.Name, rdt => rdt.Scripts);

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -99,11 +99,11 @@ namespace Dotnet.Script.Core
             var platformIdentifier = RuntimeHelper.GetPlatformIdentifier();
             Logger.Verbose($"Current runtime is '{platformIdentifier}'.");
 
-            IList<RuntimeDependency> runtimeDependencies =
-                RuntimeDependencyResolver.GetDependencies(context.WorkingDirectory).ToList();
+            var runtimeDependencies = context.FilePath != null
+                ? RuntimeDependencyResolver.GetDependencies(context.WorkingDirectory)
+                : RuntimeDependencyResolver.GetDependenciesFromCode(context.WorkingDirectory, context.Code.ToString());
 
-
-            var opts = CreateScriptOptions(context, runtimeDependencies);
+            var opts = CreateScriptOptions(context, runtimeDependencies.ToList());
 
             var runtimeId = RuntimeHelper.GetRuntimeIdentifier();
             var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x =>                

--- a/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
@@ -51,7 +51,6 @@ namespace Dotnet.Script.DependencyModel.Runtime
             return GetDependenciesInternal(pathToProjectFile);
         }
 
-
         public IEnumerable<RuntimeDependency> GetDependencies(string targetDirectory)
         {
             var pathToProjectFile = _scriptProjectProvider.CreateProject(targetDirectory, "netcoreapp2.0", true);

--- a/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
@@ -248,5 +248,40 @@ namespace Dotnet.Script.Tests
             var errResult = ctx.Console.Error.ToString();
             Assert.Contains("error CS0103: The name 'x' does not exist in the current context", errResult);
         }
+
+        [Fact]
+        public async Task NugetPackageReferenceAsTheFirstLine()
+        {
+            var commands = new[]
+            {
+                @"#r ""nuget: Automapper, 6.1.1""",
+                "using AutoMapper;",
+                "typeof(MapperConfiguration)",
+                "#exit"
+            };
+
+            var ctx = GetRunner(commands);
+            await ctx.Runner.RunLoop(false);
+
+            var result = ctx.Console.Out.ToString();
+            Assert.Contains("[AutoMapper.MapperConfiguration]", result);
+        }
+
+        [Fact]
+        public async Task ScriptPackageReferenceAsTheFirstLine()
+        {
+            var commands = new[]
+            {
+                @"#load ""nuget: simple-targets-csx, 6.0.0""",
+                "using static SimpleTargets;",
+                "typeof(TargetDictionary)",
+                "#exit"
+            };
+
+            var ctx = GetRunner(commands);
+            await ctx.Runner.RunLoop(false);
+            var result = ctx.Console.Out.ToString();
+            Assert.Contains("[Submission#0+SimpleTargets+TargetDictionary]", result);
+        }
     }
 }

--- a/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using System.IO;
 using System.Text;
 using System;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Dotnet.Script.Tests
 {
@@ -66,7 +67,7 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
-        public async Task Exception()
+        public async Task RuntimeException()
         {
             var commands = new[]
             {
@@ -79,6 +80,41 @@ namespace Dotnet.Script.Tests
 
             var result = ctx.Console.Error.ToString();
             Assert.Contains("(1,1): error CS0103: The name 'foo' does not exist in the current context", result);
+        }
+
+        [Fact]
+        public async Task ValueFromSeededFile()
+        {
+            var commands = new[]
+            {
+                "x+x",
+                "#exit"
+            };
+
+            var ctx = GetRunner(commands);
+            await ctx.Runner.RunLoopWithSeed(false, new ScriptContext(SourceText.From(@"var x = 1;"), Directory.GetCurrentDirectory(), new string[0]));
+
+            var result = ctx.Console.Out.ToString();
+            Assert.Contains("2", result);
+        }
+
+        [Fact]
+        public async Task RuntimeExceptionFromSeededFile()
+        {
+            var commands = new[]
+            {
+                "var x = 1;",
+                "x+x",
+                "#exit"
+            };
+
+            var ctx = GetRunner(commands);
+            await ctx.Runner.RunLoopWithSeed(false, new ScriptContext(SourceText.From(@"throw new Exception(""die!"");"), Directory.GetCurrentDirectory(), new string[0]));
+
+            var errorResult = ctx.Console.Error.ToString();
+            var result = ctx.Console.Out.ToString();
+            Assert.Contains("2", result);
+            Assert.Contains("die!", errorResult);
         }
 
         [Fact]


### PR DESCRIPTION
We support running a script + dropping you into the REPL using `dotnet script foo.csx -i` start up arguments.
This PR aligns how the output (errors, return values) are dumped into the console when running a REPL with seed vs just running a script.

It also ensures that in such "seed" cases, the arguments are correctly surfaced to the script.