### PR TITLE
Added support specifying version when installing on *nix

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1,5 +1,19 @@
+#!/bin/bash
 mkdir /tmp/dotnet-script
-version=$(curl https://api.github.com/repos/filipw/dotnet-script/releases/latest | grep -Eo "\"tag_name\":\s*\"(.*)\"" | cut -d'"' -f4)
+if [[ -z $1 ]]; then
+    version=$(curl https://api.github.com/repos/filipw/dotnet-script/releases/latest | grep -Eo "\"tag_name\":\s*\"(.*)\"" | cut -d'"' -f4)
+else
+    version=$1
+fi    
+currentVersion=$(dotnet script -v | tr -d '\n') 
+
+if [[ $? -eq 0 ]]; then
+    if [ "$version" == "$currentVersion" ]; then
+        echo $version already installed
+        exit 0
+    fi   
+fi
+
 echo "Installing $version..."
 curl -L https://github.com/filipw/dotnet-script/releases/download/$version/dotnet-script.$version.zip > /tmp/dotnet-script/dotnet-script.zip
 unzip -o /tmp/dotnet-script/dotnet-script.zip -d /usr/local/lib
@@ -7,3 +21,4 @@ chmod +x /usr/local/lib/dotnet-script/dotnet-script.sh
 cd /usr/local/bin
 ln -sfn /usr/local/lib/dotnet-script/dotnet-script.sh dotnet-script
 rm -rf /tmp/dotnet-script
+echo Installation Finished


### PR DESCRIPTION
This PR adds support for specifying the version to install on *nix (`install.sh`).

We also skip installation if the target version is already installed.

The default has not changed which is to install the latest version. 

See #200 for more details

Credits to @andmos for helping out with the bash stuff 