### PR TITLE
Added support for binding redirect and highest version selection

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -116,6 +116,12 @@ namespace Dotnet.Script.Tests
             Assert.Contains("42", result.output);
         }
 
+        [Fact]
+        public static void ShouldHandleIssue198()
+        {         
+            var result = Execute(Path.Combine("Issue198", "Issue198.csx"));
+            Assert.Contains("NuGet.Client", result.output);
+        }
 
         private static (string output, int exitCode) Execute(string fixture, params string[] arguments)
         {

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue198/Issue198.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue198/Issue198.csx
@@ -1,0 +1,14 @@
+﻿#! "netcoreapp2.0"
+#r "nuget:NuGet.Client,*"
+#r "nuget:NuGet.Configuration,*"
+
+using System.Linq;
+using NuGet;
+using NuGet.Configuration;
+using NuGet.Repositories;
+
+var repo = new NuGetv3LocalRepository(SettingsUtility.GetGlobalPackagesFolder(Settings.LoadDefaultSettings(null)));
+var packages = repo.FindPackagesById("NuGet.Client");
+var pkg = packages.Last();
+var nuspec = pkg.Nuspec;
+Write(nuspec.GetId());


### PR DESCRIPTION
This PR adds support for redirecting a request for an assembly to the corresponding assembly from the dependency context. 

Also improved the logic around adding references to runtime assemblies where we now ensure that we load the assembly with the highest version number in the case where the dependency contexts contains multiple versions of the same runtime assembly. 

This PR also fixes #198 