### PR TITLE
Bugfix/core assemblies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - chmod +x dotnet-install.sh
   - ./dotnet-install.sh --channel 2.0
 install:
-  - ulimit -n4096  
+  - ulimit -n8192  
 script:  
   - chmod +x build.sh
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: csharp
 dotnet: 2.0.0
+mono:
+ -latest
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: csharp
+mono: none
+dotnet: 2.0.0
 matrix:
   include:
+    - os: linux
+      dist: trusty      
+      sudo: false
     - os: osx
       osx_image: xcode9      
-      sudo: required        
-before_install:
-  - brew update
-  - curl https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
-  - chmod +x dotnet-install.sh
-  - ./dotnet-install.sh --channel 2.0
-install:
-  - ulimit -n8192  
+      sudo: required               
 script:  
+  - ulimit -n8192  
   - chmod +x build.sh
   - ./build.sh
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: csharp
-mono: none
 dotnet: 2.0.0
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 dotnet: 2.0.0
 mono:
- -latest
+ - latest
 matrix:
   include:
     - os: linux

--- a/README.md
+++ b/README.md
@@ -59,17 +59,15 @@ docker run -it dotnet-script --version
 Our typical `helloworld.csx` might look like this
 
 ```
-#! "netcoreapp1.1"
-#r "nuget:NetStandard.Library,1.6.1"
-
+#! "netcoreapp2.0"
 Console.WriteLine("Hello world!");
 ```
 
 Let us take a quick look at what is going on here.
 
-`#! "netcoreapp1.1"` tells OmniSharp to resolve metadata in the context of a`netcoreapp1.1` application.
+`#! "netcoreapp2.0"` tells OmniSharp to resolve metadata in the context of a`netcoreapp2.0` application.
 
-`#r "nuget:NetStandard.Library,1.6.1"` brings in the the [NetStandard.Library 1.6.1](https://www.nuget.org/packages/NETStandard.Library/1.6.1) from NuGet.
+This will bring in all assemblies from [Microsoft.NETCore.App](https://www.nuget.org/packages/Microsoft.NETCore.App/2.0.0) and should cover most scripting needs. 
 
 That is all it takes and we can execute the script
 
@@ -250,13 +248,13 @@ Using Roslyn syntax parsing, we also support multiline REPL mode. This means tha
 
 Aside from the regular C# script code, you can invoke the following commands (directives) from within the REPL:
 
-Command | Description
------------|-------------
-`#load`| Load a script into the REPL (same as `#load` usage in CSX)
-`#r`| Load an assembly into the REPL (same as `#r` usage in CSX)
-`#reset`| Reset the REPL back to initial state (without restarting it)
-`#cls`| Clear the console screen without resetting the REPL state
-`#exit`| Exits the REPL
+| Command  | Description                              |
+| -------- | ---------------------------------------- |
+| `#load`  | Load a script into the REPL (same as `#load` usage in CSX) |
+| `#r`     | Load an assembly into the REPL (same as `#r` usage in CSX) |
+| `#reset` | Reset the REPL back to initial state (without restarting it) |
+| `#cls`   | Clear the console screen without resetting the REPL state |
+| `#exit`  | Exits the REPL                           |
 
 ### Seeding REPL with a script
 
@@ -361,7 +359,7 @@ Once that is done we should see out breakpoint being hit.
 
 * [Bernhard Richter](https://github.com/seesharper) ([@bernhardrichter](https://twitter.com/bernhardrichter))
 * [Filip W](https://github.com/filipw) ([@filip_woj](https://twitter.com/filip_woj))
- 
+
 ## License 
 
 [MIT License](https://github.com/filipw/dotnet-script/blob/master/LICENSE)

--- a/build.sh
+++ b/build.sh
@@ -11,4 +11,4 @@ if [ ! -d "$DOTNET_SCRIPT" ]; then
         exit 1
     fi
 fi
-dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/build.csx" -- "$SCRIPT_DIR"
+dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/Build.csx" -- "$SCRIPT_DIR"

--- a/build.sh
+++ b/build.sh
@@ -11,4 +11,4 @@ if [ ! -d "$DOTNET_SCRIPT" ]; then
         exit 1
     fi
 fi
-~/.dotnet/dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/build.csx" -- "$SCRIPT_DIR"
+dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/build.csx" -- "$SCRIPT_DIR"

--- a/src/Dotnet.Script.Core/Templates/helloworld.csx.template
+++ b/src/Dotnet.Script.Core/Templates/helloworld.csx.template
@@ -1,4 +1,3 @@
 ﻿#! "netcoreapp2.0"
-#r "nuget:NetStandard.Library,2.0.0"
 
 Console.WriteLine("Hello world!");

--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Process;
 
@@ -17,8 +18,9 @@ namespace Dotnet.Script.DependencyModel.Context
 
         public void Restore(string pathToProjectFile)
         {
-            _logger.Debug($"Restoring {pathToProjectFile} using the dotnet cli.");            
-            var exitcode = _commandRunner.Execute("dotnet", $"restore \"{pathToProjectFile}\"");
+            _logger.Debug($"Restoring {pathToProjectFile} using the dotnet cli.");
+            var runtimeIdentifier = RuntimeHelper.GetRuntimeIdentifier();
+            var exitcode = _commandRunner.Execute("dotnet", $"restore \"{pathToProjectFile}\" -r {runtimeIdentifier}");
             if (exitcode != 0)
             {
                 // We must throw here, otherwise we may incorrectly run with the old 'project.assets.json'

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>0.3.0</Version>    
+    <Version>0.3.1</Version>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
@@ -51,6 +51,11 @@ namespace Dotnet.Script.DependencyModel.Environment
 
         public static string GetRuntimeIdentifier()
         {            
+            var platformIdentifier = GetPlatformIdentifier();
+            if (platformIdentifier == "osx")
+            {
+                return $"{platformIdentifier}-{GetProcessArchitecture()}";
+            }
             return RuntimeEnvironment.GetRuntimeIdentifier();            
         }
 

--- a/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
@@ -110,7 +110,7 @@ namespace Dotnet.Script.DependencyModel.Runtime
 
             var runtimeAssemblyGroup =
                 runtimeLibrary.RuntimeAssemblyGroups.FirstOrDefault(rag =>
-                    rag.Runtime == RuntimeHelper.GetPlatformIdentifier());
+                    rag.Runtime == RuntimeHelper.GetRuntimeIdentifier());
 
             if (runtimeAssemblyGroup == null)
             {

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -5,6 +5,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+ 
+ 
+
   
 
   <ItemGroup>

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using Dotnet.Script.DependencyModel.Environment;
 using Xunit;
 
@@ -122,6 +123,15 @@ namespace Dotnet.Script.Tests
             var result = Execute(Path.Combine("Issue198", "Issue198.csx"));
             Assert.Contains("NuGet.Client", result.output);
         }
+
+
+        [Fact]
+        public static void ShouldHandleIssue204()
+        {            
+            var result = Execute(Path.Combine("Issue204", "Issue204.csx"));
+            Assert.Contains("System.Net.WebProxy", result.output);
+        }
+
 
         private static (string output, int exitCode) Execute(string fixture, params string[] arguments)
         {

--- a/src/Dotnet.Script.Tests/ScriptPackages/WithSubFolder/contentFiles/csx/netstandard2.0/Foo.csx
+++ b/src/Dotnet.Script.Tests/ScriptPackages/WithSubFolder/contentFiles/csx/netstandard2.0/Foo.csx
@@ -1,3 +1,3 @@
-﻿#load "SubFolder/Bar.csx"
+﻿#load "SubFolder/bar.csx"
 
 SayHelloFromBar();

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -131,18 +131,22 @@ namespace Dotnet.Script.Tests
             RemoveDirectory(pathToPackagesOutputFolder);
             Directory.CreateDirectory(pathToPackagesOutputFolder);
             var specFiles = GetSpecFiles();
+            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            var pathtoNuget430 = Path.Combine("../../../../Dotnet.Script.DependencyModel/NuGet/NuGet430.exe");
             foreach (var specFile in specFiles)
             {
                 string command;
                 if (RuntimeHelper.IsWindows())
-                {
-                    command = "nuget";
+                {                    
+                    command = pathtoNuget430;
+                    var result = ProcessHelper.RunAndCaptureOutput(command, new[] { $"pack {specFile}", $"-OutputDirectory {pathToPackagesOutputFolder}" });
                 }
                 else
                 {
-                    command = ProcessHelper.RunAndCaptureOutput("which", new string[] { "nuget" }).output;
+                    command = "mono"; 
+                    var result = ProcessHelper.RunAndCaptureOutput(command, new[] { $"{pathtoNuget430} pack {specFile}", $"-OutputDirectory {pathToPackagesOutputFolder}" });
                 }
-                var result = ProcessHelper.RunAndCaptureOutput(command, new[] { $"pack {specFile}", $"-OutputDirectory {pathToPackagesOutputFolder}" });
+                
             }
         }
 

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -117,8 +117,8 @@ namespace Dotnet.Script.Tests
 
         private void ClearGlobalPackagesFolder()
         {
-            var pathToGlobalPackagesFolder = GetPathToGlobalPackagesFolder();
-            var scriptPackageFolders = Directory.GetDirectories(pathToGlobalPackagesFolder, "ScriptPackage*");
+            var pathToGlobalPackagesFolder = GetPathToGlobalPackagesFolder();            
+            var scriptPackageFolders = Directory.GetDirectories(pathToGlobalPackagesFolder).Select(f => f.ToLower()).Where(f => f.Contains("scriptpackage"));            
             foreach (var scriptPackageFolder in scriptPackageFolders)
             {
                 RemoveDirectory(scriptPackageFolder);

--- a/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
@@ -30,7 +30,7 @@ namespace Dotnet.Script.Tests
             StringBuilder log = new StringBuilder();            
             var provider = new ScriptProjectProvider(type => ((level, message) => log.AppendLine(message)));
 
-            provider.CreateProject(TestPathUtils.GetFullPathToTestFixture("Helloworld"), "netcoreapp2.0", true);
+            provider.CreateProject(TestPathUtils.GetFullPathToTestFixture("HelloWorld"), "netcoreapp2.0", true);
             var output = log.ToString();
 
             Assert.Contains("<Project Sdk=\"Microsoft.NET.Sdk\">",output);

--- a/src/Dotnet.Script.Tests/TestFixtures/Arguments/Arguments.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Arguments/Arguments.csx
@@ -1,5 +1,4 @@
 ﻿#! "netcoreapp1.1"
-#r "nuget:NetStandard.Library,1.6.1"
 
 foreach (var arg in Args)
 {

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue166/Issue166.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue166/Issue166.csx
@@ -1,5 +1,4 @@
 ﻿#! "netcoreapp2.0"
-#r "nuget:NetStandard.Library,2.0.0"
 #r "nuget:System.Data.SqlClient, 4.4.0"
 
 using System.Data.SqlClient;

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue181/Issue181.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue181/Issue181.csx
@@ -1,8 +1,6 @@
 ﻿#! "netcoreapp2.0"
 
-
 #r "nuget: Microsoft.CodeAnalysis.Scripting, 2.4.0"
-#r "nuget: NetStandard.Library, 2.0.0"
 
 List<string> list = new List<string>(new[] { "42" });
 Write(list.FirstOrDefault());

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue204/Issue204.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue204/Issue204.csx
@@ -1,0 +1,5 @@
+﻿#! "netcoreapp2.0"
+
+using System;
+using System.Net;
+Console.WriteLine(typeof(WebProxy));

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>0.16.0</VersionPrefix>   
+    <VersionPrefix>0.16.1</VersionPrefix>   
     <Authors>filipw</Authors>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
This PR fixes #204 and now ensures that we load all runtime assemblies from NetCoreApp2.0

The template for `dotnet script init` has been updated so that it does not include the NuGet reference to `NetStandard.Library`