### PR TITLE
Updated dependencies

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -31,8 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -14,6 +14,6 @@
     <Company>dotnet-script</Company>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.1" />
    </ItemGroup>
 </Project>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.3" />   
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />   
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
+++ b/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -133,6 +133,13 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public static void ShouldHandleIssue214()
+        {
+            var result = Execute(Path.Combine("Issue214", "Issue214.csx"));
+            Assert.Contains("Hello World!", result.output);
+        }
+
+        [Fact]
         public void ShouldHandleCSharp72()
         {
             var result = Execute(Path.Combine("CSharp72", "CSharp72.csx"));

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue214/Issue214.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue214/Issue214.csx
@@ -1,0 +1,12 @@
+﻿#! "netcoreapp2.0"
+#r "nuget: NodaTime, 2.0.0"
+#r "nuget: NodaTime.Serialization.JsonNet, 2.0.0"
+#r "nuget: Newtonsoft.Json, 10.0.3"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NodaTime;
+using NodaTime.Serialization.JsonNet;
+
+var converter = NodaConverters.InstantConverter;
+Console.WriteLine("Hello World!");

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates `Microsoft.Extensions.DependencyModel` from `2.0.3` to `2.0.4` and updates the scripting libraries to `2.6.1`. It also adds an explicit NuGet reference to `Newtonsoft.Json` with version `10.0.3`  which solves #214 because `Microsoft.Extensions.DependencyModel` pulls in version `9.0.1` which is too low in many cases. `Newtonsoft.Json` is one of the few dependencies that we indirectly rely on via `Microsoft.Extensions.DependencyModel` and hence we need to pull in the latest here. 