### PR TITLE
Feature/218

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,33 @@ Simply create a folder somewhere on your system and issue the following command.
 dotnet script init
 ```
 
-This will create `Helloworld.csx` along with the launch configuration needed to debug the script in VS Code.
+This will create `main.csx` along with the launch configuration needed to debug the script in VS Code.
 
 ```shell
 .
 ├── .vscode
 │   └── launch.json
-├── helloworld.csx
+├── main.csx
 └── omnisharp.json
 ```
+
+We can also initialize a folder using a custom filename.
+
+```shell
+dotnet script init custom.csx
+```
+
+Instead of `main.csx` which is the default, we now have a file named `custom.csx`.
+
+```shell
+.
+├── .vscode
+│   └── launch.json
+├── custom.csx
+└── omnisharp.json
+```
+
+> Note: Executing `dotnet script init` inside a folder that already contains one or more script files will not create the `main.csx` file.
 
 ### Passing arguments to scripts
 

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Dotnet.Script.Core.Templates;
 
@@ -7,7 +8,7 @@ namespace Dotnet.Script.Core
 {
     public class Scaffolder
     {
-        public void InitializerFolder()
+        public void InitializerFolder(string fileName)
         {
             string currentDirectory = Directory.GetCurrentDirectory();
             string vsCodeDirectory = Path.Combine(currentDirectory, ".vscode");
@@ -35,7 +36,13 @@ namespace Dotnet.Script.Core
                 WriteFile(pathToOmniSharpJson, omniSharpFileTemplate);
             }
 
-            CreateNewScriptFile("helloworld.csx");
+            if (Directory.GetFiles(currentDirectory, "*.csx", SearchOption.AllDirectories).Any()
+                && string.IsNullOrWhiteSpace(fileName))
+            {
+                return;
+            }
+
+            CreateNewScriptFile(fileName ?? "main.csx");
         }
 
         public void CreateNewScriptFile(string file)

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -36,7 +36,7 @@ namespace Dotnet.Script.Core
                 WriteFile(pathToOmniSharpJson, omniSharpFileTemplate);
             }
 
-            if (Directory.GetFiles(currentDirectory, "*.csx", SearchOption.AllDirectories).Any()
+            if (Directory.GetFiles(currentDirectory, "*.csx").Any()
                 && string.IsNullOrWhiteSpace(fileName))
             {
                 return;

--- a/src/Dotnet.Script.Tests/DisposableFolder.cs
+++ b/src/Dotnet.Script.Tests/DisposableFolder.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+
+namespace Dotnet.Script.Tests
+{
+    public class DisposableFolder : IDisposable
+    {
+        public DisposableFolder()
+        {
+            var tempFolder = System.IO.Path.GetTempPath();
+            this.Path = System.IO.Path.Combine(tempFolder, System.IO.Path.GetFileNameWithoutExtension(System.IO.Path.GetTempFileName()));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            FileUtils.RemoveDirectory(Path);
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/FileUtils.cs
+++ b/src/Dotnet.Script.Tests/FileUtils.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+
+namespace Dotnet.Script.Tests
+{
+    public class FileUtils
+    {
+        public static void RemoveDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
+            NormalizeAttributes(path);
+
+            foreach (string directory in Directory.GetDirectories(path))
+            {
+                RemoveDirectory(directory);
+            }
+
+            try
+            {
+                Directory.Delete(path, true);
+            }
+            catch (IOException)
+            {
+                Directory.Delete(path, true);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Directory.Delete(path, true);
+            }
+
+            void NormalizeAttributes(string directoryPath)
+            {
+                string[] filePaths = Directory.GetFiles(directoryPath);
+                string[] subdirectoryPaths = Directory.GetDirectories(directoryPath);
+
+                foreach (string filePath in filePaths)
+                {
+                    File.SetAttributes(filePath, FileAttributes.Normal);
+                }
+                foreach (string subdirectoryPath in subdirectoryPaths)
+                {
+                    NormalizeAttributes(subdirectoryPath);
+                }
+                File.SetAttributes(directoryPath, FileAttributes.Normal);
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -8,33 +8,47 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldInitializeScriptFolder()
         {
-            var tempFolder = CreateTempFolder();            
-            var result = Execute("init", tempFolder);
-            Assert.Equal(0, result.exitCode);
-            Assert.True(File.Exists(Path.Combine(tempFolder, "helloworld.csx")));
-            Assert.True(File.Exists(Path.Combine(tempFolder, "omnisharp.json")));
-            Assert.True(File.Exists(Path.Combine(tempFolder, ".vscode", "launch.json")));
-            Directory.Delete(tempFolder,true);
+            using (var scriptFolder = new DisposableFolder())
+            {                
+                var result = Execute("init", scriptFolder.Path);
+                Assert.Equal(0, result.exitCode);
+                Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "main.csx")));
+                Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "omnisharp.json")));
+                Assert.True(File.Exists(Path.Combine(scriptFolder.Path, ".vscode", "launch.json")));                
+            }
         }
 
         [Fact]
         public void ShouldCreateNewScript()
         {
-            var tempFolder = CreateTempFolder();
-            var result = Execute("new script.csx", tempFolder);
-            Assert.Equal(0, result.exitCode);
-            Assert.True(File.Exists(Path.Combine(tempFolder, "script.csx")));
-            Directory.Delete(tempFolder, true);
+            using (var scriptFolder = new DisposableFolder())
+            {
+                var result = Execute("new script.csx", scriptFolder.Path);
+                Assert.Equal(0, result.exitCode);
+                Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "script.csx")));
+            }
         }
 
-
-        private static string CreateTempFolder()
+        [Fact]
+        public void ShouldInitFolderWithCustomFileNAme()
         {
-            var userTempFolder = Path.GetTempPath();
-            var tempFile = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
-            var tempFolder = Path.Combine(userTempFolder, tempFile);
-            Directory.CreateDirectory(tempFolder);
-            return tempFolder;
+            using (var scriptFolder = new DisposableFolder())
+            {
+                var result = Execute("init custom.csx", scriptFolder.Path);
+                Assert.Equal(0, result.exitCode);
+                Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "custom.csx")));
+            }
+        }
+
+        [Fact]
+        public void ShouldNotCreateDefaultFileForFolderWithExistingScriptFiles()
+        {
+            using (var scriptFolder = new DisposableFolder())
+            {
+                Execute("init custom.csx", scriptFolder.Path);
+                Execute("init", scriptFolder.Path);
+                Assert.False(File.Exists(Path.Combine(scriptFolder.Path, "main.csx")));
+            }
         }
 
         /// <summary>

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -88,7 +88,7 @@ namespace Dotnet.Script
             app.Command("init", c =>
             {
                 c.Description = "Creates a sample script along with the launch.json file needed to launch and debug the script.";
-                var fileName = c.Argument("filename", "The name of the sample script file to be created during initialization.");
+                var fileName = c.Argument("filename", "(Optional) The name of the sample script file to be created during initialization. Defaults to 'main.csx'");
                 c.OnExecute(() =>
                 {
                     var scaffolder = new Scaffolder();

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -88,10 +88,11 @@ namespace Dotnet.Script
             app.Command("init", c =>
             {
                 c.Description = "Creates a sample script along with the launch.json file needed to launch and debug the script.";
+                var fileName = c.Argument("filename", "The name of the sample script file to be created during initialization.");
                 c.OnExecute(() =>
                 {
                     var scaffolder = new Scaffolder();
-                    scaffolder.InitializerFolder();
+                    scaffolder.InitializerFolder(fileName.Value);
                     return 0;
                 });
             });


### PR DESCRIPTION
This PR adds support for passing a custom filename during initialization.

```
dotnet script init custom.csx
```

This create a initialized folder with a script file named `custom.csx` 

```
dotnet script init
```

This will now create a file named `main.csx` instead of the old `HelloWorld.csx` file.