### PR TITLE
Remove Global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-    "projects": [ "src" ],
-    "sdk": {
-            "version": "2.0.0"
-    }
-}


### PR DESCRIPTION
 Global.json is no longer used with csproj's. Causes compatibility issues with users that only have SDK 2.1.4 installed, making it so you can't resolve back to 2.0.0 so you can't build.