### PR TITLE
Remove dependency on System.Runtime.Loader.

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -36,7 +36,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
@@ -134,8 +133,8 @@ namespace Dotnet.Script.Core
                 }
             }
 
-            AssemblyLoadContext.Default.Resolving +=
-                (assemblyLoadContext, assemblyName) => MapUnresolvedAssemblyToRuntimeLibrary(dependencyMap, assemblyLoadContext, assemblyName);
+            AppDomain.CurrentDomain.AssemblyResolve += 
+                (sender, args) => MapUnresolvedAssemblyToRuntimeLibrary(dependencyMap, args);
 
             // when processing raw code, make sure we inject new lines after preprocessor directives
             string code;
@@ -164,14 +163,15 @@ namespace Dotnet.Script.Core
             return new ScriptCompilationContext<TReturn>(script, context.Code, loader, opts);
         }
 
-        private Assembly MapUnresolvedAssemblyToRuntimeLibrary(IDictionary<string, RuntimeAssembly> dependencyMap, AssemblyLoadContext loadContext, AssemblyName assemblyName)
+        private Assembly MapUnresolvedAssemblyToRuntimeLibrary(IDictionary<string, RuntimeAssembly> dependencyMap, ResolveEventArgs args)
         {
+            var assemblyName = new AssemblyName(args.Name);
             if (dependencyMap.TryGetValue(assemblyName.Name, out var runtimeAssembly))
             {
                 if (runtimeAssembly.Name.Version > assemblyName.Version)
                 {
                     Logger.Log($"Redirecting {assemblyName} to {runtimeAssembly.Name}");                    
-                    return loadContext.LoadFromAssemblyPath(runtimeAssembly.Path);
+                    return Assembly.LoadFile(runtimeAssembly.Path);
                 }
             }
 


### PR DESCRIPTION
Fixes runtime error when running on net framework
Unable to load System.Runtime.Loader

I don't know if this has any side effects :?