### PR TITLE
Feature/release configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,22 @@ This now gives us a chance to attach the debugger before stepping into the scrip
 
 Once that is done we should see out breakpoint being hit.
 
+## Configuration(Debug/Release)
+
+By default, scripts will be compiled using the `debug` configuration. This is to ensure that we can debug a script in VS Code as well as attaching a debugger for long running scripts.
+
+There are however situations where we might need to execute a script that is compiled with the `release` configuration. For instance, running benchmarks using [BenchmarkDotNet](http://benchmarkdotnet.org/) is not possible unless the script is compiled with the `release` configuration.
+
+We can specify this when executing the script.
+
+```shell
+dotnet script -c release foo.csx 
+```
+
+
+
+
+
 ## Team
 
 * [Bernhard Richter](https://github.com/seesharper) ([@bernhardrichter](https://twitter.com/bernhardrichter))

--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -38,9 +38,9 @@ namespace Dotnet.Script.Core
             _globals = new InteractiveScriptGlobals(Console.Out, CSharpObjectFormatter.Instance);
         }
 
-        public virtual async Task RunLoop(bool debugMode)
+        public virtual async Task RunLoop()
         {
-            while (true && !_shouldExit)
+            while (!_shouldExit)
             {
                 Console.Out.Write("> ");
                 var input = ReadInput();
@@ -51,24 +51,24 @@ namespace Dotnet.Script.Core
                     continue;
                 }
 
-                await Execute(input, debugMode);
+                await Execute(input);
             }
         }
 
-        public virtual async Task RunLoopWithSeed(bool debugMode, ScriptContext scriptContext)
+        public virtual async Task RunLoopWithSeed(ScriptContext scriptContext)
         {
             await HandleScriptErrors(async () => await RunFirstScript(scriptContext));
-            await RunLoop(debugMode);
+            await RunLoop();
         }
 
-        protected virtual async Task Execute(string input, bool debugMode)
+        protected virtual async Task Execute(string input)
         {
             await HandleScriptErrors(async () =>
             {
                 if (_scriptState == null)
                 {
                     var sourceText = SourceText.From(input);
-                    var context = new ScriptContext(sourceText, CurrentDirectory, Enumerable.Empty<string>(), debugMode: debugMode, scriptMode: ScriptMode.REPL);
+                    var context = new ScriptContext(sourceText, CurrentDirectory, Enumerable.Empty<string>(),scriptMode: ScriptMode.REPL);
                     await RunFirstScript(context);
                 }
                 else

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -80,7 +80,8 @@ namespace Dotnet.Script.Core
                 .WithSourceResolver(new NuGetSourceReferenceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, context.WorkingDirectory),scriptMap))
                 .WithMetadataResolver(new NuGetMetadataReferenceResolver(ScriptMetadataResolver.Default.WithBaseDirectory(context.WorkingDirectory)))
                 .WithEmitDebugInformation(true)
-                .WithFileEncoding(context.Code.Encoding);            
+                .WithFileEncoding(context.Code.Encoding);
+            
             if (!string.IsNullOrWhiteSpace(context.FilePath))
             {
                 opts = opts.WithFilePath(context.FilePath);
@@ -130,7 +131,7 @@ namespace Dotnet.Script.Core
                 {
                     Logger.Verbose($"Adding reference to an inherited dependency => {inheritedAssemblyName.FullName}");
                     var assembly = Assembly.Load(inheritedAssemblyName);
-                    opts = opts.AddReferences(assembly);
+                    opts = opts.AddReferences(assembly);                    
                 }
             }
 
@@ -153,6 +154,17 @@ namespace Dotnet.Script.Core
 
             var loader = new InteractiveAssemblyLoader();
             var script = CSharpScript.Create<TReturn>(code, opts, typeof(THost), loader);
+
+            if (context.OptimizationLevel == OptimizationLevel.Release)
+            {
+                Logger.Verbose("Configuration/Optimization mode: Release");                
+                SetReleaseOptimizationLevel(script.GetCompilation());
+            }
+            else
+            {
+                Logger.Verbose("Configuration/Optimization mode: Debug");
+            }
+
             var orderedDiagnostics = script.GetDiagnostics(SuppressedDiagnosticIds);
 
             if (orderedDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
@@ -162,6 +174,14 @@ namespace Dotnet.Script.Core
             }
 
             return new ScriptCompilationContext<TReturn>(script, context.Code, loader, opts);
+        }
+
+        private static void SetReleaseOptimizationLevel(Compilation compilation)
+        {            
+            var compilationOptionsField = typeof(CSharpCompilation).GetTypeInfo().GetDeclaredField("_options");
+            var compilationOptions = (CSharpCompilationOptions)compilationOptionsField.GetValue(compilation);
+            compilationOptions = compilationOptions.WithOptimizationLevel(OptimizationLevel.Release);
+            compilationOptionsField.SetValue(compilation, compilationOptions);        
         }
 
         private Assembly MapUnresolvedAssemblyToRuntimeLibrary(IDictionary<string, RuntimeAssembly> dependencyMap, AssemblyLoadContext loadContext, AssemblyName assemblyName)

--- a/src/Dotnet.Script.Core/ScriptContext.cs
+++ b/src/Dotnet.Script.Core/ScriptContext.cs
@@ -2,19 +2,20 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Dotnet.Script.DependencyModel.Context;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Dotnet.Script.Core
 {
     public class ScriptContext
     {
-        public ScriptContext(SourceText code, string workingDirectory, IEnumerable<string> args, string filePath = null, bool debugMode = false, ScriptMode scriptMode = ScriptMode.Script)
+        public ScriptContext(SourceText code, string workingDirectory, IEnumerable<string> args, string filePath = null, OptimizationLevel optimizationLevel = OptimizationLevel.Debug, ScriptMode scriptMode = ScriptMode.Script)
         {
             Code = code;
             WorkingDirectory = workingDirectory;
             Args = new ReadOnlyCollection<string>(args.ToArray());
             FilePath = filePath;
-            DebugMode = debugMode;
+            OptimizationLevel = optimizationLevel;
             ScriptMode = filePath != null ? ScriptMode.Script : scriptMode;
         }
 
@@ -26,7 +27,7 @@ namespace Dotnet.Script.Core
 
         public string FilePath { get; }
 
-        public bool DebugMode { get; }
+        public OptimizationLevel OptimizationLevel { get; }
 
         public ScriptMode ScriptMode { get; }
     }

--- a/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
+++ b/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
@@ -4,6 +4,7 @@ using Xunit.Abstractions;
 
 namespace Dotnet.Script.Tests
 {
+    [Collection("IntegrationTests")]
     public class CompilationDependencyResolverTests
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Dotnet.Script.Tests
 {
+    [Collection("IntegrationTests")]
     public class InteractiveRunnerTests
     {
         private class InteractiveTestContext

--- a/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
@@ -60,7 +60,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("2", result);
@@ -76,7 +76,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Error.ToString();
             Assert.Contains("(1,1): error CS0103: The name 'foo' does not exist in the current context", result);
@@ -92,7 +92,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoopWithSeed(false, new ScriptContext(SourceText.From(@"var x = 1;"), Directory.GetCurrentDirectory(), new string[0]));
+            await ctx.Runner.RunLoopWithSeed(new ScriptContext(SourceText.From(@"var x = 1;"), Directory.GetCurrentDirectory(), new string[0]));
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("2", result);
@@ -109,7 +109,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoopWithSeed(false, new ScriptContext(SourceText.From(@"throw new Exception(""die!"");"), Directory.GetCurrentDirectory(), new string[0]));
+            await ctx.Runner.RunLoopWithSeed(new ScriptContext(SourceText.From(@"throw new Exception(""die!"");"), Directory.GetCurrentDirectory(), new string[0]));
 
             var errorResult = ctx.Console.Error.ToString();
             var result = ctx.Console.Out.ToString();
@@ -130,7 +130,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("Submission#0.Foo", result);
@@ -148,7 +148,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("hi, foo", result);
@@ -165,7 +165,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("foo", result);
@@ -184,7 +184,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("[AutoMapper.MapperConfiguration]", result);
@@ -203,7 +203,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);           
+            await ctx.Runner.RunLoop();           
             var result = ctx.Console.Out.ToString();
             Assert.Contains("[Submission#1+SimpleTargets+TargetDictionary]", result);
         }
@@ -221,7 +221,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("500", result);
@@ -240,7 +240,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("2", result);
@@ -261,7 +261,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("[AutoMapper.MapperConfiguration]", result);
@@ -279,7 +279,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoop(false);
+            await ctx.Runner.RunLoop();
             var result = ctx.Console.Out.ToString();
             Assert.Contains("[Submission#0+SimpleTargets+TargetDictionary]", result);
         }

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -12,15 +13,15 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldExecuteHelloWorld()
         {            
-            var result = Execute(Path.Combine("HelloWorld", "HelloWorld.csx"));
-            Assert.Contains("Hello World", result.output);
+            var result = ExecuteInProcess(Path.Combine("HelloWorld", "HelloWorld.csx"));
+            //Assert.Contains("Hello World", result.output);
         }
 
         [Fact]
         public void ShouldExecuteScriptWithInlineNugetPackage()
         {
-            var result = Execute(Path.Combine("InlineNugetPackage", "InlineNugetPackage.csx"));
-            Assert.Contains("AutoMapper.MapperConfiguration", result.output);
+            var result = ExecuteInProcess(Path.Combine("InlineNugetPackage", "InlineNugetPackage.csx"));
+            //Assert.Contains("AutoMapper.MapperConfiguration", result.output);
         }
 
         [Fact]
@@ -137,6 +138,27 @@ namespace Dotnet.Script.Tests
         {
             var result = Execute(Path.Combine("Issue214", "Issue214.csx"));
             Assert.Contains("Hello World!", result.output);
+        }
+
+        [Fact]
+        public static void ShouldCompileScriptWithReleaseConfiguration()
+        {
+            var result = Execute(Path.Combine("Configuration", "Configuration.csx"),"-c", "release");
+            Assert.Contains("false", result.output, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public static void ShouldCompileScriptWithDebugConfigurationWhenSpecified()
+        {
+            var result = Execute(Path.Combine("Configuration", "Configuration.csx"), "-c", "debug");
+            Assert.Contains("true", result.output, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public static void ShouldCompileScriptWithDebugConfigurationWhenNotSpecified()
+        {
+            var result = Execute(Path.Combine("Configuration", "Configuration.csx"));
+            Assert.Contains("true", result.output, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Dotnet.Script.Tests
 {
-    [Collection("ScriptPackagesTests")]
+    [Collection("IntegrationTests")]
     public class ScriptPackagesTests : IClassFixture<ScriptPackagesFixture>
     {
 

--- a/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
@@ -6,6 +6,7 @@ using Xunit.Abstractions;
 
 namespace Dotnet.Script.Tests
 {
+    [Collection("IntegrationTests")]
     public class ScriptProjectProviderTests
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/src/Dotnet.Script.Tests/TestFixtures/Configuration/Configuration.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Configuration/Configuration.csx
@@ -1,0 +1,21 @@
+﻿Console.WriteLine(IsInDebugMode(typeof(Foo).Assembly));
+
+// https://www.codeproject.com/Tips/323212/Accurate-way-to-tell-if-an-assembly-is-compiled-in
+public static bool IsInDebugMode(System.Reflection.Assembly Assembly)
+{
+    var attributes = Assembly.GetCustomAttributes(typeof(System.Diagnostics.DebuggableAttribute), false);
+    if (attributes.Length > 0)
+    {
+        var debuggable = attributes[0] as System.Diagnostics.DebuggableAttribute;
+        if (debuggable != null)
+            return (debuggable.DebuggingFlags & System.Diagnostics.DebuggableAttribute.DebuggingModes.Default) == System.Diagnostics.DebuggableAttribute.DebuggingModes.Default;
+        else
+            return false;
+    }
+    else
+        return false;
+}
+
+public class Foo
+{
+}

--- a/src/Dotnet.Script.Tests/xunit.runner.json
+++ b/src/Dotnet.Script.Tests/xunit.runner.json
@@ -1,3 +1,3 @@
 {
-  parallelizeTestCollections false
+  "parallelizeTestCollections":  false
 }


### PR DESCRIPTION
This PR adds support for specifying the debug/release configuration when executing a script.
The default is `debug` as before, but we can now specify the configuration to use like this

```
dotnet script -c release foo.csx
```

I also took the liberty to clean up some of the code that was related to `debugMode` which was passed around all over the place when all it is needed for is to determine the logging verbosity.

Note: Nothing has been done explicitly to support this in REPL mode. Running scripts in release mode is sort of an edge case and IMO not really needed in the REPL. 
 
