### PR TITLE
Clear MSBuild related env variables before dotnet restore

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -18,8 +18,8 @@ namespace Dotnet.Script.DependencyModel.Context
 
         public void Restore(string pathToProjectFile)
         {
-            _logger.Debug($"Restoring {pathToProjectFile} using the dotnet cli.");
             var runtimeIdentifier = RuntimeHelper.GetRuntimeIdentifier();
+            _logger.Debug($"Restoring {pathToProjectFile} using the dotnet cli. RuntimeIdentifier : {runtimeIdentifier}");            
             var exitcode = _commandRunner.Execute("dotnet", $"restore \"{pathToProjectFile}\" -r {runtimeIdentifier}");
             if (exitcode != 0)
             {

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>0.4.0</Version>    
+    <Version>0.5.0</Version>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dotnet.Script.DependencyModel/Process/CommandRunner.cs
+++ b/src/Dotnet.Script.DependencyModel/Process/CommandRunner.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Dotnet.Script.DependencyModel.Logging;
 
 namespace Dotnet.Script.DependencyModel.Process
@@ -27,11 +28,20 @@ namespace Dotnet.Script.DependencyModel.Process
                 CreateNoWindow = true,
                 Arguments = arguments ?? "",
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = true,                
                 UseShellExecute = false
             };
+            RemoveMsBuildEnvironmentVariables(startInformation.Environment);
             return startInformation;
         }
+        private static void RemoveMsBuildEnvironmentVariables(IDictionary<string, string> environment)
+        {
+            // Remove various MSBuild environment variables set by OmniSharp to ensure that
+            // the .NET CLI is not launched with the wrong values.
+            environment.Remove("MSBUILD_EXE_PATH");
+            environment.Remove("MSBuildExtensionsPath");
+        }
+
 
         private static void RunAndWait(System.Diagnostics.Process process)
         {


### PR DESCRIPTION
This PR fixes #230. We need to get another release out the door so OmniSharp can reference the new `Dotnet.Script.DependencyModel` package. 👍 

