### PR TITLE
Feature/global tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dotnet install tool -g dotnet-script
 
 The advantage of this approach is that we will execute the same command for installation across all platforms.
 
-> In order to se global tool we need at least [.Net Core SDK 2.1.300 preview1](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview1) 
+> In order to use the global tool we need at least [.Net Core SDK 2.1.300 preview1](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview1) 
 
 
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ docker run -it dotnet-script --version
 
 You can manually download all the releases in `zip` format from the [Github releases page](https://github.com/filipw/dotnet-script/releases).
 
+### .Net Core Global Tool
+
+.Net Core 2.1 introduces the concept of global tools meaning that we can install `dotnet-script` using nothing but the `dotnet CLI`
+
+```shell
+dotnet install tool -g dotnet-script
+```
+
+The advantage of this approach is that we will execute the same command for installation across all platforms.
+
+> In order to se global tool we need at least [.Net Core SDK 2.1.300 preview1](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview1) 
+
+
+
 ## Usage
 
 Our typical `helloworld.csx` might look like this

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,5 +1,5 @@
 #! "netcoreapp2.0"
-#load "nuget:Dotnet.Build, 0.2.8"
+#load "nuget:Dotnet.Build, 0.2.9"
 #load "nuget:github-changelog, 0.1.4"
 #load "Choco.csx"
 #load "BuildContext.csx"
@@ -15,14 +15,14 @@ DotNet.Publish(DotnetScriptProjectFolder, PublishArtifactsFolder);
 // We only publish packages from Windows/AppVeyor
 if (BuildEnvironment.IsWindows)
 {
+    NuGet.PackAsTool(DotnetScriptProjectFolder,PublishArtifactsFolder,NuGetArtifactsFolder);
     DotNet.Pack(DotnetScriptProjectFolder, NuGetArtifactsFolder);
     DotNet.Pack(DotnetScriptCoreProjectFolder, NuGetArtifactsFolder);
     DotNet.Pack(DotnetScriptDependencyModelProjectFolder, NuGetArtifactsFolder);
     DotNet.Pack(DotnetScriptDependencyModelNuGetProjectFolder, NuGetArtifactsFolder);
     Choco.Pack(DotnetScriptProjectFolder, PublishArtifactsFolder, ChocolateyArtifactsFolder);
     Zip(PublishArchiveFolder, PathToGitHubReleaseAsset);
-    
-    
+
     if (BuildEnvironment.IsSecure)
     {
         await CreateReleaseNotes();

--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.2.8"
+#load "nuget:Dotnet.Build, 0.2.9"
 using static FileUtils;
 using System.Xml.Linq;
 

--- a/build/Choco.csx
+++ b/build/Choco.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.2.5"
+#load "nuget:Dotnet.Build, 0.2.9"
 
 using System.Xml.Linq;
 


### PR DESCRIPTION
This PR adds support for building `dotnet-script` as a global tool meaning that we can install `dotnet-script` using the following command.

```
dotnet install tool -g dotnet-script
```

The name of the tool package is `dotnet-script.[version].nupkg` which aligns nicely with the existing tools already published to NuGet. Examples are `dotnet-server` and `dotnet-watch`.

We should try to get a 0.20.0 release out the door as quickly as possible claiming the package name on NuGet before anybody else grabs it 😄  
