### PR TITLE
set .net cli environment variables in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: csharp
 dotnet: 2.0.0
+env:
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+    - DOTNET_CLI_TELEMETRY_OPTOUT=true
 mono:
  - latest
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,8 @@ artifacts:
 
 test: off
 environment:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: true
     IS_SECURE_BUILDENVIRONMENT:
         secure: xU2zj54rFEPVqg/UuGU/DA==
     GITHUB_REPO_TOKEN:


### PR DESCRIPTION
Improve CI build performance.
Do not build up package cache + do not send telemetry from CI.