### PR TITLE
Scaffolding/default target framework

### DIFF
--- a/build/Build.csx
+++ b/build/Build.csx
@@ -33,6 +33,7 @@ if (BuildEnvironment.IsWindows)
             await ReleaseManagerFor(Owner,ProjectName,BuildEnvironment.GitHubAccessToken)
             .CreateRelease(Git.Default.GetLatestTag(), PathToReleaseNotes, new [] { new ZipReleaseAsset(PathToGitHubReleaseAsset) });
             NuGet.TryPush(NuGetArtifactsFolder);
+            Choco.TryPush(ChocolateyArtifactsFolder, BuildEnvironment.ChocolateyApiKey);
         }
     }
 }

--- a/build/Choco.csx
+++ b/build/Choco.csx
@@ -26,6 +26,15 @@ public static class Choco
         }
     }
 
+    public static void TryPush(string packagesFolder, string apiKey, string source = "https://push.chocolatey.org/")
+    {
+        var packageFiles = Directory.GetFiles(packagesFolder, "*.nupkg");        
+        foreach(var packageFile in packageFiles)
+        {                                    
+            Command.Capture("choco.exe", $"push {packageFile} --source {source} --key {apiKey}").Dump();           
+        }
+    }
+
     private static void CreateSpecificationFromProject(string pathToProjectFile, string pathToBinaries)
     {
         var projectFile = XDocument.Load(pathToProjectFile);

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts from a project.json dependency definition file and with support for debugging. Based on Roslyn.</Description>
-    <VersionPrefix>0.20.0</VersionPrefix>
+    <VersionPrefix>0.21.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Core/Templates/omnisharp.json.template
+++ b/src/Dotnet.Script.Core/Templates/omnisharp.json.template
@@ -1,5 +1,6 @@
 ﻿{
   "script": {
-    "enableScriptNuGetReferences": true
+    "enableScriptNuGetReferences": true,
+    "defaultTargetFramework": "netcoreapp2.0"
   }
 }

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -1,5 +1,8 @@
 ﻿using System.IO;
 using Xunit;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Dotnet.Script.Tests
 {
@@ -15,6 +18,30 @@ namespace Dotnet.Script.Tests
                 Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "main.csx")));
                 Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "omnisharp.json")));
                 Assert.True(File.Exists(Path.Combine(scriptFolder.Path, ".vscode", "launch.json")));                
+            }
+        }
+
+        [Fact]
+        public void ShouldCreateEnableScriptNugetReferencesSetting()
+        {
+            using (var scriptFolder = new DisposableFolder())
+            {
+                var result = Execute("init", scriptFolder.Path);
+                Assert.Equal(0, result.exitCode);                
+                dynamic settings = JObject.Parse(File.ReadAllText(Path.Combine(scriptFolder.Path, "omnisharp.json")));
+                Assert.True(settings.script.enableScriptNuGetReferences.Value);
+            }
+        }
+
+        [Fact]
+        public void ShouldCreateDefaultTargetFrameworkSetting()
+        {
+            using (var scriptFolder = new DisposableFolder())
+            {
+                var result = Execute("init", scriptFolder.Path);
+                Assert.Equal(0, result.exitCode);
+                dynamic settings = JObject.Parse(File.ReadAllText(Path.Combine(scriptFolder.Path, "omnisharp.json")));
+                Assert.Equal("netcoreapp2.0", settings.script.defaultTargetFramework.Value);                
             }
         }
 

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>0.20.0</VersionPrefix>   
+    <VersionPrefix>0.21.0</VersionPrefix>   
     <Authors>filipw</Authors>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
This PR adds support for setting the `defaultTargetFramework` during `dotnet init`

It now produces the following `omnisharp.json`

```
{                                            
  "script": {                                
    "enableScriptNuGetReferences": true,     
    "defaultTargetFramework": "netcoreapp2.0"
  }                                          
}                                            
```
Also bumped the version to 0.21.0 and fixed the build script so that it pushes the package to Chocolatey. 


