### PR TITLE
use  #!/bin/bash instead of  #!/bin/sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 DOTNET_SCRIPT="$SCRIPT_DIR/build/dotnet-script"

--- a/build/install-dotnet-script.sh
+++ b/build/install-dotnet-script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 curl -L https://github.com/filipw/dotnet-script/releases/download/0.18.0/dotnet-script.0.18.0.zip > dotnet-script.zip
 unzip -o dotnet-script.zip -d ./


### PR DESCRIPTION
We use bash syntax but specify #!/bin/sh. if that's symlinked elsewhere, i.e. to dash, it will show weird error messages.