### PR TITLE
Use linux-x64/x86 runtime identifier on Linux

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
@@ -52,13 +52,14 @@ namespace Dotnet.Script.DependencyModel.Environment
         }
 
         public static string GetRuntimeIdentifier()
-        {            
+        {
             var platformIdentifier = GetPlatformIdentifier();
-            if (platformIdentifier == "osx")
+            if (platformIdentifier == "osx" || platformIdentifier == "linux")
             {
                 return $"{platformIdentifier}-{GetProcessArchitecture()}";
             }
-            return RuntimeEnvironment.GetRuntimeIdentifier();            
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+            return runtimeIdentifier;
         }
 
         public static string CreateTempFolder(string targetDirectory)


### PR DESCRIPTION
This PR ensures that we use the more generic [operatingsystem]-[processor architecture] runtime identifier on Linux. This should fix #254  