### PR TITLE
converted to multistage build in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,24 @@
-FROM microsoft/dotnet:2.0.0-sdk 
+FROM microsoft/dotnet:2.0.0-sdk as builder
 COPY . /dotnet-script
 WORKDIR /dotnet-script
 
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN apt update
+RUN apt install apt-transport-https
+RUN echo "deb https://download.mono-project.com/repo/debian stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list
+
+RUN apt update
+RUN apt install mono-devel -y
+RUN apt install nuget -y
+
 RUN dotnet restore
-RUN dotnet test src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj 
-RUN dotnet publish src/Dotnet.Script/Dotnet.Script.csproj -f netcoreapp2.0
+RUN dotnet test src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+RUN dotnet publish -c Release src/Dotnet.Script/Dotnet.Script.csproj -f netcoreapp2.0
+
+FROM microsoft/dotnet:2.0.0-sdk
+
+COPY --from=builder /dotnet-script/src/Dotnet.Script/bin/Release/netcoreapp2.0/publish/ /dotnet-script/
 
 WORKDIR /scripts
 
-ENTRYPOINT ["dotnet", "/dotnet-script/src/Dotnet.Script/bin/Debug/netcoreapp2.0/publish/dotnet-script.dll"] 
+ENTRYPOINT ["dotnet", "/dotnet-script/dotnet-script.dll"]


### PR DESCRIPTION
As mentioned in #254, this adds [multistage build](https://docs.docker.com/develop/develop-images/multistage-build/) to the `Dockerfile`.
In a nutshell, we first create a Docker image for building the project. This image includes Mono and NuGet for running all the tests. If all tests pass, we run `dotnet publish` in `release` mode and copy the artifacts to a simpler container, only containing the `dotnet-SDK`.
This makes the `Dockerfile` capable of doing the entire build (including NuGet restore) without adding unnecessary fluff in the final container image. 

Still:
```
cd build
docker build -t dotnet-script -f Dockerfile ..
```