### PR TITLE
feature/netcoreapp2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-dotnet: 2.0.0
+dotnet: 2.1.300-preview2-008533
 env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,13 @@ matrix:
   include:
     - os: linux
       dist: trusty      
-      sudo: false
+      sudo: required
+      install:
+        - curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+        - sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+        - sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+        - sudo apt-get update
+        - sudo apt-get install dotnet-sdk-2.0.3
     - os: osx
       osx_image: xcode9      
       sudo: required               

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,13 @@ matrix:
         - sudo apt-get update
         - sudo apt-get install dotnet-sdk-2.0.3
     - os: osx
-      osx_image: xcode9
-      dotnet: 2.0.0
-      dotnet: 2.1.300-preview2-008533      
-      sudo: required               
+      osx_image: xcode9       
+      sudo: required
+      install:
+        - ulimit -n4096  
+        - curl https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+        - chmod +x dotnet-install.sh
+        - ./dotnet-install.sh --channel 2.0             
 script:  
   - ulimit -n8192  
   - chmod +x build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ matrix:
         - sudo apt-get update
         - sudo apt-get install dotnet-sdk-2.0.3
     - os: osx
-      osx_image: xcode9      
+      osx_image: xcode9
+      dotnet: 2.0.0
+      dotnet: 2.1.300-preview2-008533      
       sudo: required               
 script:  
   - ulimit -n8192  

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ matrix:
       sudo: required
       install:
         - ulimit -n8192  
-        - curl https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
-        - chmod +x dotnet-install.sh
-        - ./dotnet-install.sh --channel 2.0             
-script:    
+        - sudo curl -L https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-2.1.2-osx-x64.pkg -o dotnet-sdk.pkg
+        - sudo installer -pkg dotnet-sdk.pkg -target /
+        - dotnet --info        
+script:      
   - chmod +x build.sh
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,10 @@ matrix:
       osx_image: xcode9       
       sudo: required
       install:
-        - ulimit -n4096  
+        - ulimit -n8192  
         - curl https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
         - chmod +x dotnet-install.sh
         - ./dotnet-install.sh --channel 2.0             
-script:  
-  - ulimit -n8192  
+script:    
   - chmod +x build.sh
   - ./build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 image: Visual Studio 2017
 
 install:
+- ps: iwr https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1 -outfile dotnet-install.ps1
+- ps: .\dotnet-install.ps1 -Version 2.1.300-preview2-008530 -InstallDir $env:ProgramFiles/dotnet
 - cmd: choco install dotnet.script
 
 build_script:

--- a/build.sh
+++ b/build.sh
@@ -12,4 +12,4 @@ if [ ! -d "$DOTNET_SCRIPT" ]; then
         exit 1
     fi
 fi
-dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/Build.csx" -- "$SCRIPT_DIR"
+dotnet "$DOTNET_SCRIPT/dotnet-script.dll" "$SCRIPT_DIR/build/Build.csx" "--debug" -- "$SCRIPT_DIR"

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -100,7 +100,7 @@ private void PatchContent(string solutionFolder)
 {
     var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
     var projectFile = XDocument.Load(pathToDotnetScriptProject);
-    var contentElements = projectFile.Descendants("Content");
+    var contentElements = projectFile.Descendants("Content").ToArray();
     foreach (var contentElement in contentElements)
     {
         contentElement.Remove();

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,5 +1,5 @@
 #! "netcoreapp2.0"
-#load "nuget:Dotnet.Build, 0.2.9"
+#load "nuget:Dotnet.Build, 0.3.0"
 #load "nuget:github-changelog, 0.1.4"
 #load "Choco.csx"
 #load "BuildContext.csx"
@@ -10,33 +10,35 @@ using static FileUtils;
 
 DotNet.Build(DotnetScriptProjectFolder);
 DotNet.Test(TestProjectFolder);
-DotNet.Publish(DotnetScriptProjectFolder, PublishArtifactsFolder);
+//DotNet.Publish(DotnetScriptProjectFolder, PublishArtifactsFolder);
 
 // We only publish packages from Windows/AppVeyor
-if (BuildEnvironment.IsWindows)
-{
-    NuGet.PackAsTool(DotnetScriptProjectFolder,PublishArtifactsFolder,NuGetArtifactsFolder);
-    DotNet.Pack(DotnetScriptProjectFolder, NuGetArtifactsFolder);
-    DotNet.Pack(DotnetScriptCoreProjectFolder, NuGetArtifactsFolder);
-    DotNet.Pack(DotnetScriptDependencyModelProjectFolder, NuGetArtifactsFolder);
-    DotNet.Pack(DotnetScriptDependencyModelNuGetProjectFolder, NuGetArtifactsFolder);
-    Choco.Pack(DotnetScriptProjectFolder, PublishArtifactsFolder, ChocolateyArtifactsFolder);
-    Zip(PublishArchiveFolder, PathToGitHubReleaseAsset);
+// if (BuildEnvironment.IsWindows)
+// {    
+//     DotNet.Pack(DotnetScriptProjectFolder, NuGetArtifactsFolder);
+//     DotNet.Pack(DotnetScriptCoreProjectFolder, NuGetArtifactsFolder);
+//     DotNet.Pack(DotnetScriptDependencyModelProjectFolder, NuGetArtifactsFolder);
+//     DotNet.Pack(DotnetScriptDependencyModelNuGetProjectFolder, NuGetArtifactsFolder);
+    
+//     DotNet.Pack(DotnetScriptProjectFolder, NuGetArtifactsFolder, "/p:GlobalTool=true");
+    
+//     Choco.Pack(DotnetScriptProjectFolder, PublishArtifactsFolder, ChocolateyArtifactsFolder);
+//     Zip(PublishArchiveFolder, PathToGitHubReleaseAsset);
+    
+//     if (BuildEnvironment.IsSecure)
+//     {
+//         await CreateReleaseNotes();
 
-    if (BuildEnvironment.IsSecure)
-    {
-        await CreateReleaseNotes();
-
-        if (Git.Default.IsTagCommit())
-        {
-            Git.Default.RequreCleanWorkingTree();
-            await ReleaseManagerFor(Owner,ProjectName,BuildEnvironment.GitHubAccessToken)
-            .CreateRelease(Git.Default.GetLatestTag(), PathToReleaseNotes, new [] { new ZipReleaseAsset(PathToGitHubReleaseAsset) });
-            NuGet.TryPush(NuGetArtifactsFolder);
-            Choco.TryPush(ChocolateyArtifactsFolder, BuildEnvironment.ChocolateyApiKey);
-        }
-    }
-}
+//         if (Git.Default.IsTagCommit())
+//         {
+//             Git.Default.RequreCleanWorkingTree();
+//             await ReleaseManagerFor(Owner,ProjectName,BuildEnvironment.GitHubAccessToken)
+//             .CreateRelease(Git.Default.GetLatestTag(), PathToReleaseNotes, new [] { new ZipReleaseAsset(PathToGitHubReleaseAsset) });
+//             NuGet.TryPush(NuGetArtifactsFolder);
+//             Choco.TryPush(ChocolateyArtifactsFolder, BuildEnvironment.ChocolateyApiKey);
+//         }
+//     }
+// }
 
 private async Task CreateReleaseNotes()
 {

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -25,6 +25,7 @@ if (BuildEnvironment.IsWindows)
         PatchTargetFramework(globalToolBuildFolder.Path, NetCoreApp21);
         PatchPackAsTool(globalToolBuildFolder.Path);
         PatchPackageId(globalToolBuildFolder.Path, GlobalToolPackageId);
+        PatchContent(globalToolBuildFolder.Path);
         DotNet.Pack(Path.Combine(globalToolBuildFolder.Path,"Dotnet.Script"),NuGetArtifactsFolder);
     }
     
@@ -93,4 +94,16 @@ private void PatchPackageId(string solutionFolder, string packageId)
     var packAsToolElement = projectFile.Descendants("PackageId").Single();
     packAsToolElement.Value = packageId;   
     projectFile.Save(pathToDotnetScriptProject); 
+}
+
+private void PatchContent(string solutionFolder)
+{
+    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
+    var projectFile = XDocument.Load(pathToDotnetScriptProject);
+    var contentElements = projectFile.Descendants("Content");
+    foreach (var contentElement in contentElements)
+    {
+        contentElement.Remove();
+    }
+    projectFile.Save(pathToDotnetScriptProject);
 }

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,5 +1,5 @@
 #! "netcoreapp2.0"
-#load "nuget:Dotnet.Build, 0.3.0"
+#load "nuget:Dotnet.Build, 0.3.1"
 #load "nuget:github-changelog, 0.1.4"
 #load "Choco.csx"
 #load "BuildContext.csx"
@@ -7,38 +7,55 @@
 using static ReleaseManagement;
 using static ChangeLog;
 using static FileUtils;
+using System.Xml.Linq;
+
+
 
 DotNet.Build(DotnetScriptProjectFolder);
 DotNet.Test(TestProjectFolder);
-//DotNet.Publish(DotnetScriptProjectFolder, PublishArtifactsFolder);
+DotNet.Publish(DotnetScriptProjectFolder, PublishArtifactsFolder, NetCoreApp20);
 
 // We only publish packages from Windows/AppVeyor
-// if (BuildEnvironment.IsWindows)
-// {    
-//     DotNet.Pack(DotnetScriptProjectFolder, NuGetArtifactsFolder);
-//     DotNet.Pack(DotnetScriptCoreProjectFolder, NuGetArtifactsFolder);
-//     DotNet.Pack(DotnetScriptDependencyModelProjectFolder, NuGetArtifactsFolder);
-//     DotNet.Pack(DotnetScriptDependencyModelNuGetProjectFolder, NuGetArtifactsFolder);
+if (BuildEnvironment.IsWindows)
+{    
     
-//     DotNet.Pack(DotnetScriptProjectFolder, NuGetArtifactsFolder, "/p:GlobalTool=true");
+    using(var globalToolBuildFolder = new DisposableFolder())
+    {
+        Copy(SolutionFolder, globalToolBuildFolder.Path);
+        PatchTargetFramework(globalToolBuildFolder.Path, NetCoreApp21);
+        PatchPackAsTool(globalToolBuildFolder.Path);
+        PatchPackageId(globalToolBuildFolder.Path, GlobalToolPackageId);
+        DotNet.Pack(Path.Combine(globalToolBuildFolder.Path,"Dotnet.Script"),NuGetArtifactsFolder);
+    }
     
-//     Choco.Pack(DotnetScriptProjectFolder, PublishArtifactsFolder, ChocolateyArtifactsFolder);
-//     Zip(PublishArchiveFolder, PathToGitHubReleaseAsset);
+    using(var nugetPackageBuildFolder = new DisposableFolder())
+    {
+        Copy(SolutionFolder, nugetPackageBuildFolder.Path);
+        PatchTargetFramework(nugetPackageBuildFolder.Path, NetCoreApp20);        
+        DotNet.Pack(Path.Combine(nugetPackageBuildFolder.Path,"Dotnet.Script"),NuGetArtifactsFolder);
+    }
     
-//     if (BuildEnvironment.IsSecure)
-//     {
-//         await CreateReleaseNotes();
+    DotNet.Pack(DotnetScriptCoreProjectFolder, NuGetArtifactsFolder);
+    DotNet.Pack(DotnetScriptDependencyModelProjectFolder, NuGetArtifactsFolder);
+    DotNet.Pack(DotnetScriptDependencyModelNuGetProjectFolder, NuGetArtifactsFolder);
+            
+    Choco.Pack(DotnetScriptProjectFolder, PublishArtifactsFolder, ChocolateyArtifactsFolder);
+    Zip(PublishArchiveFolder, PathToGitHubReleaseAsset);
+    
+    if (BuildEnvironment.IsSecure)
+    {
+        await CreateReleaseNotes();
 
-//         if (Git.Default.IsTagCommit())
-//         {
-//             Git.Default.RequreCleanWorkingTree();
-//             await ReleaseManagerFor(Owner,ProjectName,BuildEnvironment.GitHubAccessToken)
-//             .CreateRelease(Git.Default.GetLatestTag(), PathToReleaseNotes, new [] { new ZipReleaseAsset(PathToGitHubReleaseAsset) });
-//             NuGet.TryPush(NuGetArtifactsFolder);
-//             Choco.TryPush(ChocolateyArtifactsFolder, BuildEnvironment.ChocolateyApiKey);
-//         }
-//     }
-// }
+        if (Git.Default.IsTagCommit())
+        {
+            Git.Default.RequreCleanWorkingTree();
+            await ReleaseManagerFor(Owner,ProjectName,BuildEnvironment.GitHubAccessToken)
+            .CreateRelease(Git.Default.GetLatestTag(), PathToReleaseNotes, new [] { new ZipReleaseAsset(PathToGitHubReleaseAsset) });
+            NuGet.TryPush(NuGetArtifactsFolder);
+            Choco.TryPush(ChocolateyArtifactsFolder, BuildEnvironment.ChocolateyApiKey);
+        }
+    }
+}
 
 private async Task CreateReleaseNotes()
 {
@@ -49,4 +66,31 @@ private async Task CreateReleaseNotes()
         generator = generator.IncludeUnreleased();
     }
     await generator.Generate(PathToReleaseNotes);
+}
+
+private void PatchTargetFramework(string solutionFolder, string targetFramework)
+{
+    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
+    var projectFile = XDocument.Load(pathToDotnetScriptProject);
+    var targetFrameworksElement = projectFile.Descendants("TargetFrameworks").Single();
+    targetFrameworksElement.ReplaceWith(new XElement("TargetFramework",targetFramework));
+    projectFile.Save(pathToDotnetScriptProject);
+}
+
+private void PatchPackAsTool(string solutionFolder)
+{
+    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
+    var projectFile = XDocument.Load(pathToDotnetScriptProject);
+    var packAsToolElement = projectFile.Descendants("PackAsTool").Single();
+    packAsToolElement.Value = "true";   
+    projectFile.Save(pathToDotnetScriptProject); 
+}
+
+private void PatchPackageId(string solutionFolder, string packageId)
+{
+    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
+    var projectFile = XDocument.Load(pathToDotnetScriptProject);
+    var packAsToolElement = projectFile.Descendants("PackageId").Single();
+    packAsToolElement.Value = packageId;   
+    projectFile.Save(pathToDotnetScriptProject); 
 }

--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.2.9"
+#load "nuget:Dotnet.Build, 0.3.0"
 using static FileUtils;
 using System.Xml.Linq;
 

--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -1,6 +1,12 @@
-#load "nuget:Dotnet.Build, 0.3.0"
+#load "nuget:Dotnet.Build, 0.3.1"
 using static FileUtils;
 using System.Xml.Linq;
+
+const string NetCoreApp20 = "netcoreapp2.0";
+
+const string NetCoreApp21 = "netcoreapp2.1";
+
+const string GlobalToolPackageId = "dotnet-script";
 
 string Version;
 
@@ -17,6 +23,8 @@ string ChocolateyArtifactsFolder;
 string PublishArtifactsFolder;
 
 string PublishArchiveFolder;
+
+string SolutionFolder;
 
 string DotnetScriptProjectFolder;
 
@@ -41,7 +49,7 @@ string ProjectName;
 Owner = "filipw";
 ProjectName = "dotnet-script";
 Root = FileUtils.GetScriptFolder();
-
+SolutionFolder = Path.Combine(Root,"..","src");
 DotnetScriptProjectFolder = Path.Combine(Root, "..", "src", "Dotnet.Script");
 DotnetScriptCoreProjectFolder = Path.Combine(Root, "..", "src", "Dotnet.Script.Core");
 DotnetScriptDependencyModelProjectFolder = Path.Combine(Root, "..", "src", "Dotnet.Script.DependencyModel");

--- a/build/Choco.csx
+++ b/build/Choco.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.2.9"
+#load "nuget:Dotnet.Build, 0.3.0"
 
 using System.Xml.Linq;
 

--- a/build/Choco.csx
+++ b/build/Choco.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.3.0"
+#load "nuget:Dotnet.Build, 0.3.1"
 
 using System.Xml.Linq;
 

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts from a project.json dependency definition file and with support for debugging. Based on Roslyn.</Description>
-    <VersionPrefix>0.21.0</VersionPrefix>
+    <VersionPrefix>0.22.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Core/Internal/ScriptExtensions.cs
+++ b/src/Dotnet.Script.Core/Internal/ScriptExtensions.cs
@@ -9,11 +9,10 @@ namespace Dotnet.Script.Core.Internal
 {
     internal static class ScriptExtensions
     {
-        public static IEnumerable<Diagnostic> GetDiagnostics<T>(this Script<T> script, IEnumerable<string> suppressedDiagnosticIds)
+        public static IEnumerable<Diagnostic> GetDiagnostics<T>(this Script<T> script)
         {
             var compilation = script.GetCompilation();
-            var diagnostics = compilation.GetDiagnostics().Where(d => !suppressedDiagnosticIds.Contains(d.Id));
-            var orderedDiagnostics = diagnostics.OrderBy((d1, d2) =>
+            var orderedDiagnostics = compilation.GetDiagnostics().OrderBy((d1, d2) =>
             {
                 var severityDiff = (int)d2.Severity - (int)d1.Severity;
                 return severityDiff != 0 ? severityDiff : d1.Location.SourceSpan.Start - d2.Location.SourceSpan.Start;

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -4,19 +4,17 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Scripting;
-using Microsoft.CodeAnalysis.Scripting;
-using Microsoft.CodeAnalysis.Scripting.Hosting;
-using Microsoft.Extensions.DependencyModel;
-using Microsoft.CodeAnalysis.CSharp;
+using System.Threading.Tasks;
 using Dotnet.Script.Core.Internal;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.NuGet;
 using Dotnet.Script.DependencyModel.Runtime;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
 using RuntimeAssembly = Dotnet.Script.DependencyModel.Runtime.RuntimeAssembly;
 
 namespace Dotnet.Script.Core
@@ -26,13 +24,7 @@ namespace Dotnet.Script.Core
         // Note: Windows only, Mac and Linux needs something else?
         [DllImport("Kernel32.dll")]
         private static extern IntPtr LoadLibrary(string path);
-
-        protected virtual IEnumerable<Assembly> ReferencedAssemblies => new[]
-        {
-            typeof(object).GetTypeInfo().Assembly,
-            typeof(Enumerable).GetTypeInfo().Assembly
-        };
-
+        
         static ScriptCompiler()
         {
             // force Roslyn to use ReferenceManager for the first time
@@ -57,7 +49,9 @@ namespace Dotnet.Script.Core
         };
 
         // see: https://github.com/dotnet/roslyn/issues/5501
-        protected virtual IEnumerable<string> SuppressedDiagnosticIds => new[] { "CS1701", "CS1702", "CS1705" };
+        // protected virtual IEnumerable<string> SuppressedDiagnosticIds => new[] { "CS1701", "CS1702", "CS1705" };
+
+        protected virtual IEnumerable<string> SuppressedDiagnosticIds => new[] { "CS1701", "CS1702" };
 
         public CSharpParseOptions ParseOptions { get; } = new CSharpParseOptions(LanguageVersion.Latest, kind: SourceCodeKind.Script);
 
@@ -74,8 +68,7 @@ namespace Dotnet.Script.Core
         public virtual ScriptOptions CreateScriptOptions(ScriptContext context, IList<RuntimeDependency> runtimeDependencies)
         {
             var scriptMap = runtimeDependencies.ToDictionary(rdt => rdt.Name, rdt => rdt.Scripts);
-            var opts = ScriptOptions.Default.AddImports(ImportedNamespaces)
-                .AddReferences(ReferencedAssemblies)
+            var opts = ScriptOptions.Default.AddImports(ImportedNamespaces)                
                 .WithSourceResolver(new NuGetSourceReferenceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, context.WorkingDirectory),scriptMap))
                 .WithMetadataResolver(new NuGetMetadataReferenceResolver(ScriptMetadataResolver.Default.WithBaseDirectory(context.WorkingDirectory)))
                 .WithEmitDebugInformation(true)
@@ -92,29 +85,39 @@ namespace Dotnet.Script.Core
         public virtual ScriptCompilationContext<TReturn> CreateCompilationContext<TReturn, THost>(ScriptContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-
-            var platformIdentifier = RuntimeHelper.GetPlatformIdentifier();
-            Logger.Verbose($"Current runtime is '{platformIdentifier}'.");
+            
+            Logger.Verbose($"Current runtime is '{RuntimeHelper.GetPlatformIdentifier()}'.");
 
             var runtimeDependencies = RuntimeDependencyResolver.GetDependencies(context.WorkingDirectory, context.ScriptMode, context.Code.ToString()).ToArray();
-            var opts = CreateScriptOptions(context, runtimeDependencies.ToList());
 
-            var runtimeId = RuntimeHelper.GetRuntimeIdentifier();
-            var inheritedAssemblyNames = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).Where(x =>
-                    x.FullName.StartsWith("microsoft.codeanalysis", StringComparison.OrdinalIgnoreCase)).ToArray();
+            var scriptOptions = CreateScriptOptions(context, runtimeDependencies.ToList());
 
-            // Build up a dependency map that picks runtime assembly with the highest version.
-            // This aligns with the CoreCLR that uses the highest version strategy.
-            var dependencyMap = runtimeDependencies.SelectMany(rtd => rtd.Assemblies).Distinct().GroupBy(rdt => rdt.Name.Name, rdt => rdt)
-                .Select(gr => new { Name = gr.Key, ResolvedRuntimeAssembly = gr.OrderBy(rdt => rdt.Name.Version).Last() })
-                .ToDictionary(f => f.Name, f => f.ResolvedRuntimeAssembly, StringComparer.OrdinalIgnoreCase);
+            var loadedAssembliesMap = CreateLoadedAssembliesMap();
 
-            foreach (var runtimeAssembly in dependencyMap.Values)
-            {
-                Logger.Verbose("Adding reference to a runtime dependency => " + runtimeAssembly);
-                opts = opts.AddReferences(MetadataReference.CreateFromFile(runtimeAssembly.Path));
-            }
+            var scriptDependenciesMap = CreateScriptDependenciesMap(runtimeDependencies);
 
+            scriptOptions = AddScriptReferences(scriptOptions, loadedAssembliesMap, scriptDependenciesMap);
+
+            LoadNativeAssets(runtimeDependencies);
+
+            AppDomain.CurrentDomain.AssemblyResolve +=
+                (sender, args) => MapUnresolvedAssemblyToRuntimeLibrary(scriptDependenciesMap, loadedAssembliesMap, args);
+
+            string code = GetScriptCode(context);
+
+            var loader = new InteractiveAssemblyLoader();
+
+            var script = CSharpScript.Create<TReturn>(code, scriptOptions, typeof(THost), loader);
+
+            SetOptimizationLevel(context, script);
+
+            EvaluateDiagnostics(script);
+
+            return new ScriptCompilationContext<TReturn>(script, context.Code, loader, scriptOptions);
+        }
+
+        private static void LoadNativeAssets(RuntimeDependency[] runtimeDependencies)
+        {
             foreach (var nativeAsset in runtimeDependencies.SelectMany(rtd => rtd.NativeAssets).Distinct())
             {
                 if (RuntimeHelper.IsWindows())
@@ -122,23 +125,58 @@ namespace Dotnet.Script.Core
                     LoadLibrary(nativeAsset);
                 }
             }
+        }
 
-            foreach (var inheritedAssemblyName in inheritedAssemblyNames)
+        private ScriptOptions AddScriptReferences(ScriptOptions scriptOptions, Dictionary<string, Assembly> loadedAssembliesMap, Dictionary<string, RuntimeAssembly> scriptDependenciesMap)
+        {
+            foreach (var runtimeAssembly in scriptDependenciesMap.Values)
             {
-                // Always prefer the resolved runtime dependency rather than the inherited assembly.
-                if(!dependencyMap.ContainsKey(inheritedAssemblyName.Name))
+                loadedAssembliesMap.TryGetValue(runtimeAssembly.Name.Name, out var loadedAssembly);
+                if (loadedAssembly == null)
                 {
-                    Logger.Verbose($"Adding reference to an inherited dependency => {inheritedAssemblyName.FullName}");
-                    var assembly = Assembly.Load(inheritedAssemblyName);
-                    opts = opts.AddReferences(assembly);
+                    Logger.Verbose("Adding reference to a runtime dependency => " + runtimeAssembly);
+                    scriptOptions = scriptOptions.AddReferences(MetadataReference.CreateFromFile(runtimeAssembly.Path));
+                }
+                else
+                {
+                    //Add the reference from the AssemblyLoadContext if present. 
+                    scriptOptions = scriptOptions.AddReferences(loadedAssembly);
+                    Logger.Verbose("Already loaded => " + loadedAssembly);
                 }
             }
 
-            AppDomain.CurrentDomain.AssemblyResolve +=
-                (sender, args) => MapUnresolvedAssemblyToRuntimeLibrary(dependencyMap, args);
+            return scriptOptions;
+        }
 
-            // when processing raw code, make sure we inject new lines after preprocessor directives
+        private void EvaluateDiagnostics<TReturn>(Script<TReturn> script)
+        {
+            var orderedDiagnostics = script.GetDiagnostics(SuppressedDiagnosticIds);
+
+            if (orderedDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            {
+                throw new CompilationErrorException("Script compilation failed due to one or more errors.",
+                    orderedDiagnostics.ToImmutableArray());
+            }
+        }
+
+        private void SetOptimizationLevel<TReturn>(ScriptContext context, Script<TReturn> script)
+        {
+            if (context.OptimizationLevel == OptimizationLevel.Release)
+            {
+                Logger.Verbose("Configuration/Optimization mode: Release");
+                SetReleaseOptimizationLevel(script.GetCompilation());
+            }
+            else
+            {
+                Logger.Verbose("Configuration/Optimization mode: Debug");
+            }
+        }
+
+        private string GetScriptCode(ScriptContext context)
+        {
             string code;
+            
+            // when processing raw code, make sure we inject new lines after preprocessor directives
             if (context.FilePath == null)
             {
                 var syntaxTree = CSharpSyntaxTree.ParseText(context.Code, ParseOptions);
@@ -151,28 +189,25 @@ namespace Dotnet.Script.Core
                 code = context.Code.ToString();
             }
 
-            var loader = new InteractiveAssemblyLoader();
-            var script = CSharpScript.Create<TReturn>(code, opts, typeof(THost), loader);
+            return code;
+        }
 
-            if (context.OptimizationLevel == OptimizationLevel.Release)
-            {
-                Logger.Verbose("Configuration/Optimization mode: Release");
-                SetReleaseOptimizationLevel(script.GetCompilation());
-            }
-            else
-            {
-                Logger.Verbose("Configuration/Optimization mode: Debug");
-            }
+        private static Dictionary<string, RuntimeAssembly> CreateScriptDependenciesMap(RuntimeDependency[] runtimeDependencies)
+        {
+            // Build up a dependency map that picks runtime assembly with the highest version.
+            // This aligns with the CoreCLR that uses the highest version strategy.
+            return runtimeDependencies.SelectMany(rtd => rtd.Assemblies).Distinct().GroupBy(rdt => rdt.Name.Name, rdt => rdt)
+                .Select(gr => new { Name = gr.Key, ResolvedRuntimeAssembly = gr.OrderBy(rdt => rdt.Name.Version).Last() })
+                .ToDictionary(f => f.Name, f => f.ResolvedRuntimeAssembly, StringComparer.OrdinalIgnoreCase);
+        }
 
-            var orderedDiagnostics = script.GetDiagnostics(SuppressedDiagnosticIds);
-
-            if (orderedDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-            {
-                throw new CompilationErrorException("Script compilation failed due to one or more errors.",
-                    orderedDiagnostics.ToImmutableArray());
-            }
-
-            return new ScriptCompilationContext<TReturn>(script, context.Code, loader, opts);
+        private static Dictionary<string, Assembly> CreateLoadedAssembliesMap()
+        {
+            // Build up a map of loaded assemblies that picks runtime assembly with the highest version.
+            // This aligns with the CoreCLR that uses the highest version strategy.
+            return AppDomain.CurrentDomain.GetAssemblies().Distinct().GroupBy(a => a.GetName().Name, a => a)
+                .Select(gr => new { Name = gr.Key, ResolvedRuntimeAssembly = gr.OrderBy(a => a.GetName().Version).Last() })
+                .ToDictionary(f => f.Name, f => f.ResolvedRuntimeAssembly, StringComparer.OrdinalIgnoreCase);
         }
 
         private static void SetReleaseOptimizationLevel(Compilation compilation)
@@ -183,15 +218,14 @@ namespace Dotnet.Script.Core
             compilationOptionsField.SetValue(compilation, compilationOptions);
         }
 
-        private Assembly MapUnresolvedAssemblyToRuntimeLibrary(IDictionary<string, RuntimeAssembly> dependencyMap, ResolveEventArgs args)
+        private Assembly MapUnresolvedAssemblyToRuntimeLibrary(IDictionary<string, RuntimeAssembly> dependencyMap, IDictionary<string, Assembly> loadedAssemblyMap, ResolveEventArgs args)
         {
             var assemblyName = new AssemblyName(args.Name);
             if (dependencyMap.TryGetValue(assemblyName.Name, out var runtimeAssembly))
             {
                 if (runtimeAssembly.Name.Version > assemblyName.Version)
                 {
-                    var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies()
-                        .FirstOrDefault(a => a.GetName().Name == assemblyName.Name);
+                    loadedAssemblyMap.TryGetValue(assemblyName.Name, out var loadedAssembly);                    
                     if(loadedAssembly != null)
                     {
                         Logger.Log($"Redirecting {assemblyName} to already loaded {loadedAssembly.GetName().Name}");

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,22 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
- 
- 
-
-  
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />    
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />
+    <ProjectReference Include="..\Dotnet.Script.DependencyModel\Dotnet.Script.DependencyModel.csproj" />
     <ProjectReference Include="..\Dotnet.Script\Dotnet.Script.csproj" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -14,8 +14,8 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldExecuteHelloWorld()
         {
-            var result = ExecuteInProcess(Path.Combine("HelloWorld", "HelloWorld.csx"));
-            //Assert.Contains("Hello World", result.output);
+            var result = Execute(Path.Combine("HelloWorld", "HelloWorld.csx"));
+            Assert.Contains("Hello World", result.output);
         }
 
         [Fact]
@@ -126,12 +126,11 @@ namespace Dotnet.Script.Tests
             Assert.Contains("NuGet.Client", result.output);
         }
 
-
         [Fact]
         public static void ShouldHandleIssue204()
         {
-            var result = ExecuteInProcess(Path.Combine("Issue204", "Issue204.csx"));
-            //Assert.Contains("System.Net.WebProxy", result.output);
+            var result = Execute(Path.Combine("Issue204", "Issue204.csx"));
+            Assert.Contains("System.Net.WebProxy", result.output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -339,7 +339,7 @@ namespace Dotnet.Script.Tests
 #else
             configuration = "Release";
 #endif
-            var allArguments = new List<string>(new[] { "exec", Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", configuration, "netcoreapp2.0", "dotnet-script.dll"), fixture });
+            var allArguments = new List<string>(new[] { "exec", Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", configuration, RuntimeHelper.TargetFramework, "dotnet-script.dll"), fixture });
             if (arguments != null)
             {
                 allArguments.AddRange(arguments);

--- a/src/Dotnet.Script.Tests/TestFixtures/Process/Process.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Process/Process.csx
@@ -1,0 +1,9 @@
+﻿using System.Diagnostics;
+
+WriteLine("Success");
+
+private static void RunAndWait(Process process)
+{
+    process.Start();
+    process.WaitForExit();
+}

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.21.0</VersionPrefix>
+        <VersionPrefix>0.22.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,41 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>0.21.0</VersionPrefix>   
+    <VersionPrefix>0.21.0</VersionPrefix>
     <Authors>filipw</Authors>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>dotnet-script</AssemblyName>
-    <OutputType>Exe</OutputType>
-    <PackageId>Dotnet.Script</PackageId>
+      <PackageId>dotnet-script</PackageId>
+    <OutputType>Exe</OutputType>   
     <PackageTags>dotnet;cli;script;csx;csharp;roslyn</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/filipw/Strathweb.TypedRouting.AspNetCore/master/strathweb.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/filipw/dotnet-script</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/filipw/dotnet-script/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>    
+    <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>    
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <IsPackable>true</IsPackable>   
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="dotnet-script.cmd">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="dotnet-script.sh">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
+  <Choose>
+    <When Condition=" '$(TargetFramework)'=='netcoreapp2.1' ">
+      <PropertyGroup>        
+        <PackageId>dotnet-script</PackageId>
+        <PackAsTool>true</PackAsTool>        
+      </PropertyGroup>
+    </When>
+    <When Condition=" '$(TargetFramework)'=='netcoreapp2.0' ">
+        <PropertyGroup>
+            <PackageId>Dotnet.Script</PackageId>
+        </PropertyGroup>
+       <ItemGroup>
+        <Content Include="dotnet-script.cmd">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+        <Content Include="dotnet-script.sh">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,49 +1,38 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>0.21.0</VersionPrefix>
-    <Authors>filipw</Authors>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <DebugType>portable</DebugType>
-    <AssemblyName>dotnet-script</AssemblyName>      
-    <OutputType>Exe</OutputType>   
-    <PackageTags>dotnet;cli;script;csx;csharp;roslyn</PackageTags>
-    <PackageIconUrl>https://raw.githubusercontent.com/filipw/Strathweb.TypedRouting.AspNetCore/master/strathweb.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/filipw/dotnet-script</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/filipw/dotnet-script/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <IsPackable>true</IsPackable>   
-  </PropertyGroup>
-  <Choose>
-    <When Condition=" '$(TargetFramework)'=='netcoreapp2.1' ">
-      <PropertyGroup>        
-        <PackageId>dotnet-script</PackageId>
-        <PackAsTool>true</PackAsTool>        
-      </PropertyGroup>
-    </When>
-    <When Condition=" '$(TargetFramework)'=='netcoreapp2.0' ">
-        <PropertyGroup>
-            <PackageId>Dotnet.Script</PackageId>
-        </PropertyGroup>
-       <ItemGroup>
+    <PropertyGroup>
+        <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
+        <VersionPrefix>0.21.0</VersionPrefix>
+        <Authors>filipw</Authors>
+        <PackageId>Dotnet.Script</PackageId>
+        <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+        <DebugType>portable</DebugType>
+        <AssemblyName>dotnet-script</AssemblyName>
+        <OutputType>Exe</OutputType>
+        <PackageTags>dotnet;cli;script;csx;csharp;roslyn</PackageTags>
+        <PackageIconUrl>https://raw.githubusercontent.com/filipw/Strathweb.TypedRouting.AspNetCore/master/strathweb.png</PackageIconUrl>
+        <PackageProjectUrl>https://github.com/filipw/dotnet-script</PackageProjectUrl>
+        <PackageLicenseUrl>https://github.com/filipw/dotnet-script/blob/master/LICENSE</PackageLicenseUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <PackAsTool>false</PackAsTool>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>    
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
+        <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />
+    </ItemGroup>
+    <ItemGroup>
         <Content Include="dotnet-script.cmd">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
         <Content Include="dotnet-script.sh">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />
-  </ItemGroup>
+    </ItemGroup>
 </Project>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -5,8 +5,7 @@
     <Authors>filipw</Authors>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
-    <AssemblyName>dotnet-script</AssemblyName>
-      <PackageId>dotnet-script</PackageId>
+    <AssemblyName>dotnet-script</AssemblyName>      
     <OutputType>Exe</OutputType>   
     <PackageTags>dotnet;cli;script;csx;csharp;roslyn</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/filipw/Strathweb.TypedRouting.AspNetCore/master/strathweb.png</PackageIconUrl>


### PR DESCRIPTION
This PR adds support for cross compiling `dotnet-script` using `netcoreapp2.0` and `netcoreapp2.1`
The motivation for this is to fix #258 that requires global tools to be compiled for at least `netcoreapp2.1`.

Please refer to this issue for form information https://github.com/dotnet/cli/issues/9073

In the process of adding support for netcoreapp2.1, it was important that existing scripts that contained the `#! "netcoreapp2.0"` pragma should continue to work.

This resulted in a deep dive into how we add assemblies (metadatareferences) for a given script.

We used to add a couple of "inherited" assembly references from the host (dotnet-script) and then load the rest from the dependency context inferred from the script. 

The initial hypothesis was that we needed to get rid of all inherited assembly references since there would be a possible mismatch between the host running as `netcoreapp2.1` and the script dependencies being resolved in the context of a `netcoreapp2.0` application. 

As it turns out when compiling and executing a script , the script does not at all run in 100% isolation from the host. For instance it shares the same AssemblyLoadContext so that means we can't really ignore the assemblies already loaded into the host AppDomain/AssemblyLoadContext.

So the approach taken is that we now inherit "on demand" meaning that when we load a assembly reference from the script dependency context, we will now check if the assembly is already loaded by the host. If its already loaded we skip the reference from the script dependency context, otherwise we load it. This should also fix the scenario when we run as `netcoreapp2.0` where we only have the ``` `netcoreapp2.1` sdk installed.



This change actually made all tests pass without suppressing `CS1705`. 

In this PR we still suppress certain diagnostics, but they are now logged when running in debug mode `-d`

When it comes to the packages we produce nothing much has changed.

The tool package is compiled for `netcoreapp2.1` while the rest of the packages are `netcoreapp2.0` as before





