### PR TITLE
Feature/follow loads

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Dotnet.Script.DependencyModel.ProjectSystem
+{
+    public static class FileUtils
+    {
+        public static string ReadFile(string path)
+        {
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                using (var reader = new StreamReader(fileStream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
@@ -39,7 +39,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static string[] GetLoadDirectives(string csxFile)
         {
-            var content = ReadFile(csxFile);
+            var content = FileUtils.ReadFile(csxFile);
             var matches = Regex.Matches(content, @"^\s*#load\s*""\s*(.+)\s*""", RegexOptions.IgnoreCase | RegexOptions.Multiline);
             List<string> result = new List<string>();
             foreach (var match in matches.Cast<Match>())
@@ -53,18 +53,6 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             }
 
             return result.ToArray();
-        }
-
-
-        private static string ReadFile(string pathToFile)
-        {
-            using (var fileStream = new FileStream(pathToFile, FileMode.Open))
-            {
-                using (var reader = new StreamReader(fileStream))
-                {
-                    return reader.ReadToEnd();
-                }
-            }
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Dotnet.Script.DependencyModel.ProjectSystem
+{
+    public class ScriptFilesResolver
+    {
+        public HashSet<string> GetScriptFiles(string csxFile)
+        {
+            HashSet<string> result = new HashSet<string>();
+            Process(csxFile, result);
+            return result;
+        }
+
+        private void Process(string csxFile, HashSet<string> result)
+        {
+            if (result.Add(csxFile))
+            {
+                var loadDirectives = GetLoadDirectives(csxFile);
+                foreach (var loadDirective in loadDirectives)
+                {
+                    string referencedScript;
+                    if (!Path.IsPathRooted(loadDirective))
+                    {
+                        referencedScript = Path.GetFullPath((new Uri(Path.Combine(Path.GetDirectoryName(csxFile), loadDirective))).LocalPath);
+                    }
+                    else
+                    {
+                        referencedScript = loadDirective;
+                    }
+
+                    Process(referencedScript, result);
+                }
+            }
+        }
+
+        private static string[] GetLoadDirectives(string csxFile)
+        {
+            var content = ReadFile(csxFile);
+            var matches = Regex.Matches(content, @"^\s*#load\s*""\s*(.+)\s*""", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+            List<string> result = new List<string>();
+            foreach (var match in matches.Cast<Match>())
+            {
+                var value = match.Groups[1].Value;
+                if (value.StartsWith("nuget", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
+                result.Add(value);
+            }
+
+            return result.ToArray();
+        }
+
+
+        private static string ReadFile(string pathToFile)
+        {
+            using (var fileStream = new FileStream(pathToFile, FileMode.Open))
+            {
+                using (var reader = new StreamReader(fileStream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -44,7 +44,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             foreach (var csxFile in csxFiles)
             {
                 _logger.Debug($"Parsing {csxFile}");
-                var fileContent = ReadFile(csxFile);
+                var fileContent = FileUtils.ReadFile(csxFile);
                 allPackageReferences.UnionWith(ReadPackageReferencesFromReferenceDirective(fileContent));
                 allPackageReferences.UnionWith(ReadPackageReferencesFromLoadDirective(fileContent));
                 string targetFramework = ReadTargetFramework(fileContent);
@@ -101,17 +101,6 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
                 return match.Groups[1].Value;
             }
             return null;
-        }
-
-        private static string ReadFile(string pathToFile)
-        {
-            using (var fileStream = new FileStream(pathToFile, FileMode.Open))
-            {
-                using (var reader = new StreamReader(fileStream))
-                {
-                    return reader.ReadToEnd();
-                }
-            }
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
@@ -54,6 +54,12 @@ namespace Dotnet.Script.DependencyModel.Runtime
             return GetDependenciesInternal(pathToProjectFile);
         }
 
+        public IEnumerable<RuntimeDependency> GetDependencies(string scriptFile)
+        {
+            var pathToProjectFile =  _scriptProjectProvider.CreateProjectForScriptFile(scriptFile);
+            return GetDependenciesInternal(pathToProjectFile);
+        }
+
         private IEnumerable<RuntimeDependency> GetDependenciesInternal(string pathToProjectFile)
         {
             var dependencyInfo = _scriptDependencyInfoProvider.GetDependencyInfo(pathToProjectFile);

--- a/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System;
 using Microsoft.CodeAnalysis.Text;
+using Dotnet.Script.DependencyModel.Context;
 
 namespace Dotnet.Script.Tests
 {
@@ -93,7 +94,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoopWithSeed(new ScriptContext(SourceText.From(@"var x = 1;"), Directory.GetCurrentDirectory(), new string[0]));
+            await ctx.Runner.RunLoopWithSeed(new ScriptContext(SourceText.From(@"var x = 1;"), Directory.GetCurrentDirectory(), new string[0], scriptMode:ScriptMode.REPL));
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("2", result);
@@ -110,7 +111,7 @@ namespace Dotnet.Script.Tests
             };
 
             var ctx = GetRunner(commands);
-            await ctx.Runner.RunLoopWithSeed(new ScriptContext(SourceText.From(@"throw new Exception(""die!"");"), Directory.GetCurrentDirectory(), new string[0]));
+            await ctx.Runner.RunLoopWithSeed(new ScriptContext(SourceText.From(@"throw new Exception(""die!"");"), Directory.GetCurrentDirectory(), new string[0], scriptMode:ScriptMode.REPL));
 
             var errorResult = ctx.Console.Error.ToString();
             var result = ctx.Console.Out.ToString();

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -120,6 +120,13 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public static void ShouldHandleIssue189()
+        {
+            var result = Execute(Path.Combine("Issue189","SomeFolder","Script.csx"));
+            Assert.Contains("Newtonsoft.Json.JsonConvert", result.output);
+        }
+
+        [Fact]
         public static void ShouldHandleIssue198()
         {
             var result = Execute(Path.Combine("Issue198", "Issue198.csx"));

--- a/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
@@ -1,0 +1,90 @@
+﻿using System.IO;
+using Xunit;
+using Dotnet.Script.DependencyModel.ProjectSystem;
+
+namespace Dotnet.Script.Tests
+{
+    public class ScriptFilesResolverTests
+    {
+        [Fact]
+        public void ShouldOnlyResolveRootScript()
+        {
+            using (var rootFolder = new DisposableFolder())
+            {
+                var rootScript = WriteScript(string.Empty, rootFolder.Path, "Foo.csx");
+                WriteScript(string.Empty, rootFolder.Path, "Bar.csx");
+                var scriptFilesResolver = new ScriptFilesResolver();
+
+                var files = scriptFilesResolver.GetScriptFiles(rootScript);
+
+                Assert.True(files.Count == 1);
+                Assert.Contains(files, f => f.Contains("Foo.csx"));
+                Assert.Contains(files, f => !f.Contains("Bar.csx"));
+            }
+        }
+        [Fact]
+        public void ShouldResolveLoadedScriptInRootFolder()
+        {
+            using (var rootFolder = new DisposableFolder())
+            {
+                var rootScript = WriteScript("#load \"Bar.csx\"", rootFolder.Path, "Foo.csx");
+                WriteScript(string.Empty, rootFolder.Path, "Bar.csx");
+                var scriptFilesResolver = new ScriptFilesResolver();
+
+                var files = scriptFilesResolver.GetScriptFiles(rootScript);
+
+                Assert.True(files.Count == 2);
+                Assert.Contains(files, f => f.Contains("Foo.csx"));
+                Assert.Contains(files, f => f.Contains("Bar.csx"));
+            }
+        }
+
+        [Fact]
+        public void ShouldResolveLoadedScriptInSubFolder()
+        {
+            using (var rootFolder = new DisposableFolder())
+            {
+                var rootScript = WriteScript("#load \"SubFolder/Bar.csx\"", rootFolder.Path, "Foo.csx");
+                var subFolder = Path.Combine(rootFolder.Path, "SubFolder");
+                Directory.CreateDirectory(subFolder);
+                WriteScript(string.Empty, subFolder, "Bar.csx");
+
+                var scriptFilesResolver = new ScriptFilesResolver();
+                var files = scriptFilesResolver.GetScriptFiles(rootScript);
+
+                Assert.True(files.Count == 2);
+                Assert.Contains(files, f => f.Contains("Foo.csx"));
+                Assert.Contains(files, f => f.Contains("Bar.csx"));
+            }
+        }
+
+        [Fact]
+        public void ShouldResolveLoadedScriptWithRootPath()
+        {
+            using (var rootFolder = new DisposableFolder())
+            {
+                var subFolder = Path.Combine(rootFolder.Path, "SubFolder");
+                Directory.CreateDirectory(subFolder);
+                var fullPathToBarScript = WriteScript(string.Empty, subFolder, "Bar.csx");
+                var rootScript = WriteScript($"#load \"{fullPathToBarScript}\"", rootFolder.Path, "Foo.csx");
+
+
+                var scriptFilesResolver = new ScriptFilesResolver();
+                var files = scriptFilesResolver.GetScriptFiles(rootScript);
+
+                Assert.True(files.Count == 2);
+                Assert.Contains(files, f => f.Contains("Foo.csx"));
+                Assert.Contains(files, f => f.Contains("Bar.csx"));
+            }
+        }
+
+
+        private static string WriteScript(string content, string folder, string name)
+        {
+            var fullPath = Path.Combine(folder, name);
+            File.WriteAllText(Path.Combine(folder, name), content);
+            return fullPath;
+
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue189/AnotherFolder/Dependencies.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue189/AnotherFolder/Dependencies.csx
@@ -1,0 +1,1 @@
+﻿#r "nuget: Newtonsoft.Json,10.0.3"

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue189/SomeFolder/Script.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue189/SomeFolder/Script.csx
@@ -1,0 +1,3 @@
+﻿#load "../AnotherFolder/Dependencies.csx"
+using Newtonsoft.Json;
+Console.WriteLine(typeof(JsonConvert));


### PR DESCRIPTION
This PR adds support for following `#load` directives when resolving the set of csx files that is relevant for the current execution context.

This means that we can `#load` other scripts from anywhere on the file system and not being constrained by having all script files either in the root folder or somewhere in a folder beneath the root folder. 

A good  example of this is issue #189  which is now fixed by this PR.

*Note*
For script packages we ONLY load all scripts files when we are unable to determine the entry point script.
An entry point script is identified by a file named `main.csx`  or a single script file located at the root folder in the package. 

This aligns with the conclusion(https://github.com/filipw/dotnet-script/issues/156) we made after discussing this with the Roslyn team 


https://github.com/filipw/dotnet-script/blob/f685903a87cc5ac61fa5cb4a83615c309833f741/src/Dotnet.Script.DependencyModel/ScriptPackage/ScriptFilesDependencyResolver.cs#L31