### PR TITLE
Environmental information

### DIFF
--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -22,12 +22,12 @@ namespace Dotnet.Script.Core
             string pathToLaunchFile = Path.Combine(vsCodeDirectory, "launch.json");
             if (!File.Exists(pathToLaunchFile))
             {
-                string baseDirectory = Path.GetDirectoryName(new Uri(typeof(Scaffolder).GetTypeInfo().Assembly.CodeBase).LocalPath);
-                string csxPath = Path.Combine(baseDirectory, "dotnet-script.dll").Replace(@"\", "/");
+                string installLocation = RuntimeHelper.InstallLocation;
+                string dotnetScriptPath = Path.Combine(installLocation, "dotnet-script.dll").Replace(@"\", "/");
                                 
                 string lauchFileTemplate = TemplateLoader.ReadTemplate("launch.json.template");
 
-                string launchFileContent = lauchFileTemplate.Replace("PATH_TO_DOTNET-SCRIPT", csxPath);
+                string launchFileContent = lauchFileTemplate.Replace("PATH_TO_DOTNET-SCRIPT", dotnetScriptPath);
                 WriteFile(pathToLaunchFile, launchFileContent);
             }
             

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -85,7 +85,7 @@ namespace Dotnet.Script.Core
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            Logger.Verbose($"Current runtime is '{RuntimeHelper.GetPlatformIdentifier()}'.");
+            Logger.Verbose($"Current runtime is '{RuntimeHelper.PlatformIdentifier}'.");
             RuntimeDependency[] runtimeDependencies = GetRuntimeDependencies(context);
 
             var scriptOptions = CreateScriptOptions(context, runtimeDependencies.ToList());
@@ -130,7 +130,7 @@ namespace Dotnet.Script.Core
         {
             foreach (var nativeAsset in runtimeDependencies.SelectMany(rtd => rtd.NativeAssets).Distinct())
             {
-                if (RuntimeHelper.IsWindows())
+                if (RuntimeHelper.IsWindows)
                 {
                     LoadLibrary(nativeAsset);
                 }

--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -18,7 +18,7 @@ namespace Dotnet.Script.DependencyModel.Context
 
         public void Restore(string pathToProjectFile)
         {
-            var runtimeIdentifier = RuntimeHelper.GetRuntimeIdentifier();
+            var runtimeIdentifier = RuntimeHelper.RuntimeIdentifier;
             _logger.Debug($"Restoring {pathToProjectFile} using the dotnet cli. RuntimeIdentifier : {runtimeIdentifier}");            
             var exitcode = _commandRunner.Execute("dotnet", $"restore \"{pathToProjectFile}\" -r {runtimeIdentifier}");
             if (exitcode != 0)

--- a/src/Dotnet.Script.DependencyModel/Context/NuGetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/NuGetRestorer.cs
@@ -28,7 +28,7 @@ namespace Dotnet.Script.DependencyModel.Context
         public void Restore(string pathToProjectFile)
         {
             ExtractNugetExecutable();
-            if (RuntimeHelper.IsWindows())
+            if (RuntimeHelper.IsWindows)
             {
                 _commandRunner.Execute(PathToNuget, $"restore {pathToProjectFile}");
             }
@@ -42,7 +42,7 @@ namespace Dotnet.Script.DependencyModel.Context
 
         private bool CheckAvailability()
         {
-            if (RuntimeHelper.IsWindows())
+            if (RuntimeHelper.IsWindows)
             {
                 return _commandRunner.Execute(PathToNuget) == 0;
             }

--- a/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
@@ -79,7 +79,6 @@ namespace Dotnet.Script.DependencyModel.Environment
             return storePath;
         }
 
-
         private static string GetProcessArchitecture()
         {
             return RuntimeEnvironment.RuntimeArchitecture;            

--- a/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
@@ -15,21 +15,28 @@ namespace Dotnet.Script.DependencyModel.Environment
 
         private static readonly Lazy<string> LazyInstallLocation = new Lazy<string>(GetInstallLocation);
 
-        public static string GetPlatformIdentifier()
-        {
-            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Darwin) return "osx";
-            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Linux) return "linux";
-            return "win";            
-        }
+        private static readonly Lazy<string> LazyPlatformIdentifier = new Lazy<string>(GetPlatformIdentifier);
 
-        public static bool IsWindows()
-        {
-            return GetPlatformIdentifier() == "win";
-        }
+        private static readonly Lazy<string> LazyRuntimeIdentifier = new Lazy<string>(GetRuntimeIdentifier);
+
+        private static readonly Lazy<bool> LazyIsWindows = new Lazy<bool>(() => PlatformIdentifier == "win");
+                
+        public static bool IsWindows => LazyIsWindows.Value;
+
+        public static string PlatformIdentifier => LazyPlatformIdentifier.Value;
+
+        public static string RuntimeIdentifier => LazyRuntimeIdentifier.Value;
 
         public static string TargetFramework => LazyTargetFramework.Value;
 
         public static string InstallLocation => LazyInstallLocation.Value;
+
+        private static string GetPlatformIdentifier()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Darwin) return "osx";
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Linux) return "linux";
+            return "win";
+        }
 
         private static string GetNetCoreAppVersion()
         {
@@ -54,7 +61,7 @@ namespace Dotnet.Script.DependencyModel.Environment
         private static string GetDotnetBinaryPath()
         {
             string basePath;
-            if (IsWindows())
+            if (IsWindows)
             {
                 basePath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles);
             }
@@ -78,7 +85,7 @@ namespace Dotnet.Script.DependencyModel.Environment
             return RuntimeEnvironment.RuntimeArchitecture;            
         }
 
-        public static string GetRuntimeIdentifier()
+        private static string GetRuntimeIdentifier()
         {
             var platformIdentifier = GetPlatformIdentifier();
             if (platformIdentifier == "osx" || platformIdentifier == "linux")
@@ -99,7 +106,7 @@ namespace Dotnet.Script.DependencyModel.Environment
             var tempDirectory = Path.GetTempPath();
             var pathRoot = Path.GetPathRoot(targetDirectory);
             var targetDirectoryWithoutRoot = targetDirectory.Substring(pathRoot.Length);
-            if (pathRoot.Length > 0 && RuntimeHelper.IsWindows())
+            if (pathRoot.Length > 0 && IsWindows)
             {
                 var driveLetter = pathRoot.Substring(0, 1);
                 if (driveLetter == "\\")

--- a/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/RuntimeHelper.cs
@@ -11,7 +11,9 @@ namespace Dotnet.Script.DependencyModel.Environment
         private static readonly Regex RuntimeMatcher =
             new Regex($"{GetPlatformIdentifier()}.*-{GetProcessArchitecture()}");
 
-        private static readonly Lazy<string> LazyTargetFramework = new Lazy<string>(GetNetCoreAppVersion); 
+        private static readonly Lazy<string> LazyTargetFramework = new Lazy<string>(GetNetCoreAppVersion);
+
+        private static readonly Lazy<string> LazyInstallLocation = new Lazy<string>(GetInstallLocation);
 
         public static string GetPlatformIdentifier()
         {
@@ -27,6 +29,8 @@ namespace Dotnet.Script.DependencyModel.Environment
 
         public static string TargetFramework => LazyTargetFramework.Value;
 
+        public static string InstallLocation => LazyInstallLocation.Value;
+
         private static string GetNetCoreAppVersion()
         {
             // https://github.com/dotnet/BenchmarkDotNet/blob/94863ab4d024eca04d061423e5aad498feff386b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs#L156 
@@ -40,6 +44,11 @@ namespace Dotnet.Script.DependencyModel.Environment
             }
             var version = match.Groups[1].Value;
             return $"netcoreapp{version}";
+        }
+
+        private static string GetInstallLocation()
+        {
+            return Path.GetDirectoryName(new Uri(typeof(RuntimeHelper).GetTypeInfo().Assembly.CodeBase).LocalPath);            
         }
 
         private static string GetDotnetBinaryPath()

--- a/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
@@ -113,7 +113,7 @@ namespace Dotnet.Script.DependencyModel.Runtime
 
             var runtimeAssemblyGroup =
                 runtimeLibrary.RuntimeAssemblyGroups.FirstOrDefault(rag =>
-                    rag.Runtime == RuntimeHelper.GetRuntimeIdentifier());
+                    rag.Runtime == RuntimeHelper.RuntimeIdentifier);
 
             if (runtimeAssemblyGroup == null)
             {

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -36,7 +36,7 @@ namespace Dotnet.Script.Tests
         public void ShouldHandlePackageWithNativeLibraries()
         {
             // We have no story for this on *nix yet
-            if (RuntimeHelper.IsWindows())
+            if (RuntimeHelper.IsWindows)
             {
                 var result = Execute(Path.Combine("NativeLibrary", "NativeLibrary.csx"));
                 Assert.Contains("Connection successful", result.output);
@@ -77,7 +77,7 @@ namespace Dotnet.Script.Tests
         {
             // System.Data.SqlClient loads native assets
             // No story on *nix yet.
-            if (RuntimeHelper.IsWindows())
+            if (RuntimeHelper.IsWindows)
             {
                 var result = Execute(Path.Combine("Issue166", "Issue166.csx"));
                 Assert.Contains("Connection successful", result.output);

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -136,7 +136,7 @@ namespace Dotnet.Script.Tests
             foreach (var specFile in specFiles)
             {
                 string command;
-                if (RuntimeHelper.IsWindows())
+                if (RuntimeHelper.IsWindows)
                 {                    
                     command = pathtoNuget430;
                     var result = ProcessHelper.RunAndCaptureOutput(command, new[] { $"pack {specFile}", $"-OutputDirectory {pathToPackagesOutputFolder}" });

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -212,21 +212,11 @@ namespace Dotnet.Script
             sb.AppendLine($"Version             : {versionAttribute?.InformationalVersion}");            
             sb.AppendLine($"Install location    : {RuntimeHelper.InstallLocation}");
             sb.AppendLine($"Target framework    : {RuntimeHelper.TargetFramework}");
-            sb.AppendLine($"Platform identifier : {RuntimeHelper.GetPlatformIdentifier()}");
-            sb.AppendLine($"Runtime identifier  : {RuntimeHelper.GetRuntimeIdentifier()}");
+            sb.AppendLine($"Platform identifier : {RuntimeHelper.PlatformIdentifier}");
+            sb.AppendLine($"Runtime identifier  : {RuntimeHelper.RuntimeIdentifier}");
             return sb.ToString();
 
             
-        }
-
-        private static string GetInfo()
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine($"Install location    : {RuntimeHelper.InstallLocation}");
-            sb.AppendLine($"Target framework    : {RuntimeHelper.TargetFramework}");
-            sb.AppendLine($"Platform identifier : {RuntimeHelper.GetPlatformIdentifier()}");
-            sb.AppendLine($"Runtime identifier  : {RuntimeHelper.GetRuntimeIdentifier()}");
-            return sb.ToString();
         }
 
         private static ScriptCompiler GetScriptCompiler(bool debugMode)

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -217,7 +217,10 @@ namespace Dotnet.Script
         private static string GetInfo()
         {
             StringBuilder sb = new StringBuilder();
+            sb.AppendLine($"Install location    : {RuntimeHelper.InstallLocation}");
             sb.AppendLine($"Target framework    : {RuntimeHelper.TargetFramework}");
+            sb.AppendLine($"Platform identifier : {RuntimeHelper.GetPlatformIdentifier()}");
+            sb.AppendLine($"Runtime identifier  : {RuntimeHelper.GetRuntimeIdentifier()}");
             return sb.ToString();
         }
 

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -72,14 +72,11 @@ namespace Dotnet.Script
 
             app.VersionOption("-v | --version", GetVersionInfo);
 
-            app.VersionOption("-i | --info", GetInfo);
-
             app.Command("eval", c =>
             {
                 c.Description = "Execute CSX code.";
                 var code = c.Argument("code", "Code to execute.");
-                var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for the code compiler. Defaults to current directory.", CommandOptionType.SingleValue);
-
+                var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for the code compiler. Defaults to current directory.", CommandOptionType.SingleValue);                
                 c.OnExecute(async () =>
                 {
                     int exitCode = 0;
@@ -210,8 +207,16 @@ namespace Dotnet.Script
 
         private static string GetVersionInfo()
         {
-            var versionAttribute = typeof(Program).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().SingleOrDefault();            
-            return versionAttribute?.InformationalVersion;
+            StringBuilder sb = new StringBuilder();
+            var versionAttribute = typeof(Program).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().SingleOrDefault();                        
+            sb.AppendLine($"Version             : {versionAttribute?.InformationalVersion}");            
+            sb.AppendLine($"Install location    : {RuntimeHelper.InstallLocation}");
+            sb.AppendLine($"Target framework    : {RuntimeHelper.TargetFramework}");
+            sb.AppendLine($"Platform identifier : {RuntimeHelper.GetPlatformIdentifier()}");
+            sb.AppendLine($"Runtime identifier  : {RuntimeHelper.GetRuntimeIdentifier()}");
+            return sb.ToString();
+
+            
         }
 
         private static string GetInfo()

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -13,6 +13,8 @@ using Microsoft.CodeAnalysis.Scripting;
 using Dotnet.Script.DependencyModel.Context;
 using Microsoft.CodeAnalysis;
 using System.Net;
+using System.Text;
+using Dotnet.Script.DependencyModel.Environment;
 
 namespace Dotnet.Script
 {
@@ -69,6 +71,8 @@ namespace Dotnet.Script
             app.HelpOption("-? | -h | --help");
 
             app.VersionOption("-v | --version", GetVersionInfo);
+
+            app.VersionOption("-i | --info", GetInfo);
 
             app.Command("eval", c =>
             {
@@ -208,6 +212,13 @@ namespace Dotnet.Script
         {
             var versionAttribute = typeof(Program).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().SingleOrDefault();            
             return versionAttribute?.InformationalVersion;
+        }
+
+        private static string GetInfo()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine($"Target framework    : {RuntimeHelper.TargetFramework}");
+            return sb.ToString();
         }
 
         private static ScriptCompiler GetScriptCompiler(bool debugMode)


### PR DESCRIPTION
This PR adds support for displaying environmental information that is relevant for script execution.

usage 
```
dotnet script --version
```

now yields

```
Version             : 0.23.0
Install location    : C:\Github\dotnet-script\src\Dotnet.Script\bin\Debug\netcoreapp2.0
Target framework    : netcoreapp2.0
Platform identifier : win
Runtime identifier  : win10-x64
```

> Note : Went with extending the existing `-v|--version` option instead of `-i|--info` since that would conflict with the existing interactive mode.

This PR also cleans up the `RuntimeHelper` class making all information available as properties backed by a `Lazy<T>`

