### PR TITLE
Feature/info option

### DIFF
--- a/src/Dotnet.Script.Tests/EnvironmentTests.cs
+++ b/src/Dotnet.Script.Tests/EnvironmentTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using System.Text.RegularExpressions;
+
+
+namespace Dotnet.Script.Tests
+{
+    public class EnvironmentTests
+    {
+        [Fact]
+        public void ShouldPrintVersionNumber()
+        {
+            var result = ScriptTestRunner.Default.Execute("--version");
+            Assert.Equal(0, result.exitCode);
+            Assert.Matches(@"\d*.\d*.\d*", result.output);
+
+            result = ScriptTestRunner.Default.Execute("-v");
+            Assert.Equal(0, result.exitCode);
+            Assert.Matches(@"\d*.\d*.\d*", result.output);
+        }
+
+        [Fact]
+        public void ShouldPrintInfo()
+        {
+            var result = ScriptTestRunner.Default.Execute("--info");
+            Assert.Equal(0, result.exitCode);
+            Assert.Contains("Version", result.output);
+            Assert.Contains("Install location", result.output);
+            Assert.Contains("Target framework", result.output);
+            Assert.Contains("Platform identifier", result.output);
+            Assert.Contains("Runtime identifier", result.output);
+        }
+
+    }
+}

--- a/src/Dotnet.Script.Tests/ScriptTestRunner.cs
+++ b/src/Dotnet.Script.Tests/ScriptTestRunner.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Dotnet.Script.DependencyModel.Environment;
+
+namespace Dotnet.Script.Tests
+{
+    public class ScriptTestRunner
+    {
+        public static readonly ScriptTestRunner Default = new ScriptTestRunner();
+
+        private ScriptEnvironment _scriptEnvironment;
+
+        private ScriptTestRunner()
+        {
+            _scriptEnvironment = ScriptEnvironment.Default;
+        }
+
+
+        public (string output, int exitCode) Execute(params string[] arguments)
+        {
+            var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments(arguments));
+            return result;
+        }
+
+        public int ExecuteInProcess(params string[] arguments)
+        {                        
+            return Program.Main(arguments ?? Array.Empty<string>());
+        }
+
+        public (string output, int exitCode) ExecuteFixture(string fixture, params string[] arguments)
+        {
+            var pathToFixture = Path.Combine("..", "..", "..", "TestFixtures", fixture);
+            var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments(new string[] { pathToFixture}.Concat(arguments ?? Array.Empty<string>()).ToArray()));
+            return result;
+        }
+
+        public int ExecuteFixtureInProcess(string fixture, params string[] arguments)
+        {
+            var pathToFixture = Path.Combine("..", "..", "..", "TestFixtures", fixture);
+            return Program.Main(new[] { GetPathToFixture(fixture) }.Concat(arguments ?? Array.Empty<string>()).ToArray());
+        }
+
+        private static string GetPathToFixture(string fixture)
+        {
+            return Path.Combine("..", "..", "..", "TestFixtures", fixture);
+        }
+
+        private string[] GetDotnetScriptArguments(params string[] arguments)
+        {
+            string configuration;
+#if DEBUG
+            configuration = "Debug";
+#else
+            configuration = "Release";
+#endif
+            var allArguments = new List<string>(new[] { "exec", Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", configuration, _scriptEnvironment.TargetFramework, "dotnet-script.dll")});
+            if (arguments != null)
+            {
+                allArguments.AddRange(arguments);
+            }
+            return allArguments.ToArray();
+        }
+    }
+}

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -70,7 +70,9 @@ namespace Dotnet.Script
 
             app.HelpOption("-? | -h | --help");
 
-            app.VersionOption("-v | --version", GetVersionInfo);
+            app.VersionOption("-v | --version", GetVersion());
+
+            var infoOption = app.Option("--info", "Displays environmental information", CommandOptionType.NoValue);
 
             app.Command("eval", c =>
             {
@@ -127,6 +129,13 @@ namespace Dotnet.Script
             app.OnExecute(async () =>
             {
                 int exitCode = 0;
+
+                if (infoOption.HasValue())
+                {
+                    Console.Write(GetEnvironmentInfo());
+                    return 0;
+                }
+
                 if (!string.IsNullOrWhiteSpace(file.Value))
                 {
                     var optimizationLevel = OptimizationLevel.Debug;
@@ -207,18 +216,21 @@ namespace Dotnet.Script
             return runner.Execute<int>(context);
         }
 
-        private static string GetVersionInfo()
+        private static string GetEnvironmentInfo()
         {
-            StringBuilder sb = new StringBuilder();
-            var versionAttribute = typeof(Program).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().SingleOrDefault();                        
-            sb.AppendLine($"Version             : {versionAttribute?.InformationalVersion}");            
+            StringBuilder sb = new StringBuilder();            
+            sb.AppendLine($"Version             : {GetVersion()}");            
             sb.AppendLine($"Install location    : {ScriptEnvironment.Default.InstallLocation}");
             sb.AppendLine($"Target framework    : {ScriptEnvironment.Default.TargetFramework}");
             sb.AppendLine($"Platform identifier : {ScriptEnvironment.Default.PlatformIdentifier}");
             sb.AppendLine($"Runtime identifier  : {ScriptEnvironment.Default.RuntimeIdentifier}");
-            return sb.ToString();
+            return sb.ToString();            
+        }
 
-            
+        private static string GetVersion()
+        {
+            var versionAttribute = typeof(Program).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().SingleOrDefault();
+            return versionAttribute?.InformationalVersion;
         }
 
         private static ScriptCompiler GetScriptCompiler(bool debugMode)


### PR DESCRIPTION
This PR adds support for the `--info` option that displays environmental information related to resolving dependencies, compiling and executing scripts.

```
dotnet script -v|--version
```

yields

```
0.23.0
```

while 

```
dotnet script --info
```

yields 

```
Version             : 0.23.0
Install location    : C:\Github\dotnet-script\src\Dotnet.Script\bin\Debug\netcoreapp2.0
Target framework    : netcoreapp2.0
Platform identifier : win
Runtime identifier  : win10-x64
```

Also added the `ScriptTestRunner` class as a start to clean up much of the stuff going on in tests.
There is currently a lot of duplication of code related to script arguments and such. 
Will do an overall cleanup in a separate PR 👍 

