### PR TITLE
Avoid loading version info unless option is specified

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -70,7 +70,7 @@ namespace Dotnet.Script
 
             app.HelpOption("-? | -h | --help");
 
-            app.VersionOption("-v | --version", GetVersion());
+            app.VersionOption("-v | --version", GetVersion);
 
             var infoOption = app.Option("--info", "Displays environmental information", CommandOptionType.NoValue);
 


### PR DESCRIPTION
This should also improve start-up performance a teeny-weeny bit because the version information was being loaded on each and every run irrespective of whether the version option (`-v` or `--version`) was specified.