### PR TITLE
Fix NuGet exe resource name in NuGetRestorer

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Context/NuGetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/NuGetRestorer.cs
@@ -57,7 +57,7 @@ namespace Dotnet.Script.DependencyModel.Context
             if (!File.Exists(PathToNuget))
             {
                 _logger.Debug("Extracting NuGet executable");
-                using (Stream input = typeof(NuGetRestorer).GetTypeInfo().Assembly.GetManifestResourceStream("Dotnet.Script.NuGetMetadataResolver.NuGet.NuGet.exe"))
+                using (Stream input = typeof(NuGetRestorer).GetTypeInfo().Assembly.GetManifestResourceStream("Dotnet.Script.DependencyModel.NuGet.NuGet430.exe"))
                 {
 
                     byte[] byteData = StreamToBytes(input);


### PR DESCRIPTION
Steps to reproduce in a C# Interactive session after cloning (04a60727e4c22d0c8ef11aef3712663144350196 at time of reporting) and building:

```
Microsoft (R) Visual C# Interactive Compiler version 2.8.0.62830
Copyright (C) Microsoft Corporation. All rights reserved.

Type "#help" for more information.
> #r "src\Dotnet.Script.DependencyModel\bin\Debug\net46\Dotnet.Script.DependencyModel.dll"
>
> using Dotnet.Script.DependencyModel.Context;
> using Dotnet.Script.DependencyModel.Logging;
> using Dotnet.Script.DependencyModel.Process;
>
> LogFactory logFactory = type => (level, msg) => Console.WriteLine(msg);
>
> var restorer = new NuGetRestorer(new CommandRunner(logFactory), logFactory);
> restorer.Restore(Environment.GetEnvironmentVariable("TEMP"))
Extracting NuGet executable
Object reference not set to an instance of an object.
  + Dotnet.Script.DependencyModel.Context.NuGetRestorer.StreamToBytes(System.IO.Stream)
  + Dotnet.Script.DependencyModel.Context.NuGetRestorer.ExtractNugetExecutable()
  + Dotnet.Script.DependencyModel.Context.NuGetRestorer.Restore(string)
```

This seems to be cause by the resource name for the embedded NuGet executable being incorrect. This PR fixes that, after applying which, the last line in the session above:

    restorer.Restore(Environment.GetEnvironmentVariable("TEMP"))

gives the following output instead of throwing a `NullReferenceException`:

```
Extracting NuGet executable
The folder 'C:\Users\johndoe\AppData\Local\Temp' does not contain an msbuild solution or packages.config file to restore.
```
