### PR TITLE
Include .NET Core version in the --info

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>0.24.0</VersionPrefix>
+    <VersionPrefix>0.25.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Tests/EnvironmentTests.cs
+++ b/src/Dotnet.Script.Tests/EnvironmentTests.cs
@@ -28,6 +28,7 @@ namespace Dotnet.Script.Tests
             Assert.Contains("Version", result.output);
             Assert.Contains("Install location", result.output);
             Assert.Contains("Target framework", result.output);
+            Assert.Contains(".NET Core version", result.output);
             Assert.Contains("Platform identifier", result.output);
             Assert.Contains("Runtime identifier", result.output);
         }

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.24.0</VersionPrefix>
+        <VersionPrefix>0.25.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -22,7 +22,7 @@
     </PropertyGroup>    
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.0" />
-        <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -5,16 +5,15 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.CommandLineUtils;
 using Dotnet.Script.Core;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Runtime;
 using Microsoft.CodeAnalysis.Scripting;
 using Dotnet.Script.DependencyModel.Context;
 using Microsoft.CodeAnalysis;
-using System.Net;
 using System.Text;
 using Dotnet.Script.DependencyModel.Environment;
+using McMaster.Extensions.CommandLineUtils;
 
 namespace Dotnet.Script
 {
@@ -218,10 +217,12 @@ namespace Dotnet.Script
 
         private static string GetEnvironmentInfo()
         {
+            var netCoreVersion = ScriptEnvironment.Default.NetCoreVersion;
             StringBuilder sb = new StringBuilder();            
             sb.AppendLine($"Version             : {GetVersion()}");            
             sb.AppendLine($"Install location    : {ScriptEnvironment.Default.InstallLocation}");
-            sb.AppendLine($"Target framework    : {ScriptEnvironment.Default.TargetFramework}");
+            sb.AppendLine($"Target framework    : {netCoreVersion.Tfm}");
+            sb.AppendLine($".NET Core version   : {netCoreVersion.Version}");
             sb.AppendLine($"Platform identifier : {ScriptEnvironment.Default.PlatformIdentifier}");
             sb.AppendLine($"Runtime identifier  : {ScriptEnvironment.Default.RuntimeIdentifier}");
             return sb.ToString();            


### PR DESCRIPTION
Something like:

```
Version             : 0.24.0
Install location    : Z:\Documents\dev\mirror\dotnet-script\src\Dotnet.Script\bin\Debug\netcoreapp2.1
Target framework    : netcoreapp2.1
.NET Core version   : 2.1.0-preview2-26406-04
Platform identifier : win
Runtime identifier  : win10-x64
```

Also updated the args lib to the fork and it solved the extra line that prints with `--version`