### PR TITLE
Bumped github-changelog to 0.1.5

### DIFF
--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,6 +1,6 @@
 #! "netcoreapp2.0"
 #load "nuget:Dotnet.Build, 0.3.1"
-#load "nuget:github-changelog, 0.1.4"
+#load "nuget:github-changelog, 0.1.5"
 #load "Choco.csx"
 #load "BuildContext.csx"
 


### PR DESCRIPTION
Bumps the version of `github-changelog` to 0.1.5 that fixes a bug when retrieving issues. 

https://github.com/seesharper/github-changelog/releases/tag/0.1.5
