### PR TITLE
Bugfix/issue294

### DIFF
--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>0.6.1</Version>
+    <Version>0.6.2</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel.Nuget/NuGetSourceReferenceResolver.cs
+++ b/src/Dotnet.Script.DependencyModel.Nuget/NuGetSourceReferenceResolver.cs
@@ -49,14 +49,16 @@ namespace Dotnet.Script.DependencyModel.NuGet
         public override string ResolveReference(string path, string baseFilePath)
         {
             if (path.StartsWith("nuget:", StringComparison.OrdinalIgnoreCase))
-            {                
+            {
                 var packageName = PackageNameMatcher.Match(path).Groups[1].Value;
-                var scripts = _scriptMap[packageName];
-                if (scripts.Count == 1)
+                if (_scriptMap.TryGetValue(packageName, out var scripts))
                 {
-                    return scripts[0];
+                    if (scripts.Count == 1)
+                    {
+                        return scripts[0];
+                    }
+                    return path;
                 }
-                return path;
             }
             var resolvedReference = _sourceReferenceResolver.ResolveReference(path, baseFilePath);
             return resolvedReference;

--- a/src/Dotnet.Script.Tests/NuGetSourceReferenceResolverTests.cs
+++ b/src/Dotnet.Script.Tests/NuGetSourceReferenceResolverTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Text;
+using Dotnet.Script.DependencyModel.NuGet;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Dotnet.Script.Tests
+{
+    public class NuGetSourceReferenceResolverTests
+    {
+        [Fact]
+        public void ShouldHandleResolvingInvalidPackageReference()
+        {
+            Dictionary<string, IReadOnlyList<string>> scriptMap = new Dictionary<string, IReadOnlyList<string>>();
+            NuGetSourceReferenceResolver resolver = new NuGetSourceReferenceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, Directory.GetCurrentDirectory()), scriptMap);
+            resolver.ResolveReference("nuget:InvalidPackage, 1.2.3", Directory.GetCurrentDirectory());
+        }        
+    }
+}


### PR DESCRIPTION
Fixes #294 by checking if the package exists, If it does not exists, we default to the underlying `SourceReferenceResolver` and its handling of an unresolved reference. 