### PR TITLE
Use standard text file reading/writing methods

### DIFF
--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -40,7 +40,7 @@ namespace Dotnet.Script.Core
             if (!File.Exists(pathToScriptFile))
             {
                 var scriptFileTemplate = TemplateLoader.ReadTemplate("helloworld.csx.template");
-                FileUtils.WriteFile(pathToScriptFile, scriptFileTemplate);
+                File.WriteAllText(pathToScriptFile, scriptFileTemplate);
                 _logger.Log($"...'{pathToScriptFile}' [Created]");
             }
             else
@@ -83,7 +83,7 @@ namespace Dotnet.Script.Core
                 var omniSharpFileTemplate = TemplateLoader.ReadTemplate("omnisharp.json.template");
                 JObject settings = JObject.Parse(omniSharpFileTemplate);
                 settings["script"]["defaultTargetFramework"] = _scriptEnvironment.TargetFramework;
-                FileUtils.WriteFile(pathToOmniSharpJson, settings.ToString());
+                File.WriteAllText(pathToOmniSharpJson, settings.ToString());
                 _logger.Log($"...'{pathToOmniSharpJson}' [Created]");
             }
             else
@@ -108,13 +108,13 @@ namespace Dotnet.Script.Core
             {                
                 string lauchFileTemplate = TemplateLoader.ReadTemplate("launch.json.template");
                 string launchFileContent = lauchFileTemplate.Replace("PATH_TO_DOTNET-SCRIPT", dotnetScriptPath);
-                FileUtils.WriteFile(pathToLaunchFile, launchFileContent);
+                File.WriteAllText(pathToLaunchFile, launchFileContent);
                 _logger.Log($"...'{pathToLaunchFile}' [Created]");
             }
             else
             {
                 _logger.Log($"...'{pathToLaunchFile}' already exists' [Skipping]");
-                var launchFileContent = FileUtils.ReadFile(pathToLaunchFile);
+                var launchFileContent = File.ReadAllText(pathToLaunchFile);
                 string pattern = @"^(\s*"")(.*dotnet-script.dll)("").*$";
                 if (Regex.IsMatch(launchFileContent, pattern, RegexOptions.Multiline))
                 {
@@ -122,7 +122,7 @@ namespace Dotnet.Script.Core
                     if (launchFileContent != newLaunchFileContent)
                     {
                         _logger.Log($"...Fixed path to dotnet-script: '{dotnetScriptPath}' [Updated]");
-                        FileUtils.WriteFile(pathToLaunchFile, newLaunchFileContent);
+                        File.WriteAllText(pathToLaunchFile, newLaunchFileContent);
                     }
                 }
             }

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -8,28 +8,6 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 {
     public static class FileUtils
     {
-        public static string ReadFile(string path)
-        {
-            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            {
-                using (var reader = new StreamReader(fileStream))
-                {
-                    return reader.ReadToEnd();
-                }
-            }
-        }
-
-        public static void WriteFile(string path, string content)
-        {
-            using (var fileStream = new FileStream(path, FileMode.Create))
-            {
-                using (var streamWriter = new StreamWriter(fileStream))
-                {
-                    streamWriter.Write(content);
-                }
-            }
-        }
-
         public static string CreateTempFolder(string targetDirectory)
         {
             if (!Path.IsPathRooted(targetDirectory))

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
@@ -39,7 +39,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static string[] GetLoadDirectives(string csxFile)
         {
-            var content = FileUtils.ReadFile(csxFile);
+            var content = File.ReadAllText(csxFile);
             var matches = Regex.Matches(content, @"^\s*#load\s*""\s*(.+)\s*""", RegexOptions.IgnoreCase | RegexOptions.Multiline);
             List<string> result = new List<string>();
             foreach (var match in matches.Cast<Match>())

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -44,7 +44,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             foreach (var csxFile in csxFiles)
             {
                 _logger.Debug($"Parsing {csxFile}");
-                var fileContent = FileUtils.ReadFile(csxFile);
+                var fileContent = File.ReadAllText(csxFile);
                 allPackageReferences.UnionWith(ReadPackageReferencesFromReferenceDirective(fileContent));
                 allPackageReferences.UnionWith(ReadPackageReferencesFromLoadDirective(fileContent));
                 string targetFramework = ReadTargetFramework(fileContent);

--- a/src/Dotnet.Script.Tests/FileUtils.cs
+++ b/src/Dotnet.Script.Tests/FileUtils.cs
@@ -5,17 +5,6 @@ namespace Dotnet.Script.Tests
 {
     public class FileUtils
     {
-        public static void WriteFile(string path, string content)
-        {
-            using (var fileStream = new FileStream(path, FileMode.Create))
-            {
-                using (var streamWriter = new StreamWriter(fileStream))
-                {
-                    streamWriter.Write(content);
-                }
-            }
-        }
-
         public static void RemoveDirectory(string path)
         {
             if (!Directory.Exists(path))

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -123,8 +123,8 @@ namespace Dotnet.Script.Tests
 
                 config.SelectToken("configurations[0].args[1]").Replace("InvalidPath/dotnet-script.dll,");
 
-                FileUtils.WriteFile(pathToLaunchConfiguration, config.ToString());
-                
+                File.WriteAllText(pathToLaunchConfiguration, config.ToString());
+
                 var result = Execute("init", scriptFolder.Path);
 
                 config = JObject.Parse(File.ReadAllText(pathToLaunchConfiguration));


### PR DESCRIPTION
I don't see the purpose of the helper methods `FileUtils.ReadFile`:

https://github.com/filipw/dotnet-script/blob/5969026f0ccba56f51009ebdb3f33bc560472002/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs#L11-L20

and `FileUtils.WriteFile`:

https://github.com/filipw/dotnet-script/blob/5969026f0ccba56f51009ebdb3f33bc560472002/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs#L22-L31

In this PR, I propose to remove and replace them with calls to standard helpers from BCL: [`File.ReadAllText`][File.ReadAllText] and [`File.WriteAllText`][File.WriteAllText]. This is in the spirit of less is more. What's more, I'm not even sure the file share mode of [`FileShare.ReadWrite`][FileShare.ReadWrite] is correct as it can lead to corruption (slim chance by what tempt fate unnecessarily).


[File.ReadAllText]: https://docs.microsoft.com/dotnet/api/system.io.file.readalltext?view=netcore-2.0#System_IO_File_ReadAllText_System_String_
[File.WriteAllText]: https://docs.microsoft.com/dotnet/api/system.io.file.writealltext?view=netcore-2.0#System_IO_File_WriteAllText_System_String_System_String_
[FileShare.ReadWrite]: https://docs.microsoft.com/dotnet/api/system.io.fileshare?view=netcore-2.0#System_IO_FileShare_ReadWrite