### PR TITLE
updated readme for 0.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Tool 'dotnet-script' (version '0.22.0') was successfully installed.
 
 The advantage of this approach is that you can use the same command for installation across all platforms.
 
-> ⚠️ In order to use the global tool you need [.Net Core SDK 2.1.300 preview2](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview2) or higher. The earlier previews of .NET Core 2.1, such as [.Net Core SDK 2.1.300 preview1](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview1), are not supported.
+> ⚠️ In order to use the global tool you need [.Net Core SDK 2.1.300](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300) or higher. The earlier previews and release candidates of .NET Core 2.1 are not supported.
 
 .NET Core SDK also supports viewing a list of installed tools and their uninstallation.
 


### PR DESCRIPTION
I did a fresh install of dotnet-script on a new machine and found that version 0.25 has a requirement for .net core 2.1.300, and that the prior previews and release candidates will no longer function.