### PR TITLE
 Added support for passing in runtime ID when doing publish to exe

### DIFF
--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -57,8 +57,13 @@ namespace Dotnet.Script.Core
             File.Copy(sourceNugetPropsPath, destinationNugetPropsPath, overwrite: true);
         }
 
-        public void CreateExecutable<TReturn, THost>(ScriptContext context, LogFactory logFactory, string runtimeIdentifier = null)
+        public void CreateExecutable<TReturn, THost>(ScriptContext context, LogFactory logFactory, string runtimeIdentifier)
         {
+            if (runtimeIdentifier == null)
+            {
+                throw new ArgumentNullException(nameof(runtimeIdentifier));
+            }
+
             const string AssemblyName = "scriptAssembly";
 
             var tempProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath));
@@ -73,11 +78,9 @@ namespace Dotnet.Script.Core
 
             CopyProgramTemplate(tempProjectDirecory);
 
-            runtimeIdentifier = runtimeIdentifier ?? _scriptEnvironment.RuntimeIdentifier;
-
             var commandRunner = new CommandRunner(logFactory);
             // todo: may want to add ability to return dotnet.exe errors
-            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o {Path.Combine(context.WorkingDirectory, runtimeIdentifier)}");
+            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o {context.WorkingDirectory}");
             if (exitcode != 0) throw new Exception($"dotnet publish failed with result '{exitcode}'");
         }
 

--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -57,7 +57,7 @@ namespace Dotnet.Script.Core
             File.Copy(sourceNugetPropsPath, destinationNugetPropsPath, overwrite: true);
         }
 
-        public void CreateExecutable<TReturn, THost>(ScriptContext context, LogFactory logFactory)
+        public void CreateExecutable<TReturn, THost>(ScriptContext context, LogFactory logFactory, string runtimeIdentifier = null)
         {
             const string AssemblyName = "scriptAssembly";
 
@@ -73,11 +73,11 @@ namespace Dotnet.Script.Core
 
             CopyProgramTemplate(tempProjectDirecory);
 
-            var runtimeIdentifier = _scriptEnvironment.RuntimeIdentifier;
+            runtimeIdentifier = runtimeIdentifier ?? _scriptEnvironment.RuntimeIdentifier;
 
             var commandRunner = new CommandRunner(logFactory);
             // todo: may want to add ability to return dotnet.exe errors
-            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o {context.WorkingDirectory}");
+            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o {Path.Combine(context.WorkingDirectory, runtimeIdentifier)}");
             if (exitcode != 0) throw new Exception($"dotnet publish failed with result '{exitcode}'");
         }
 

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -30,7 +30,7 @@ namespace Dotnet.Script.Tests
                 var publishResult = Execute(string.Join(" ", args), workspaceFolder.Path);
                 Assert.Equal(0, publishResult.exitCode);
 
-                var exePath = Path.Combine(workspaceFolder.Path, "publish", "script");
+                var exePath = Path.Combine(workspaceFolder.Path, "publish", _scriptEnvironment.RuntimeIdentifier, "script");
                 var executableRunResult = _commandRunner.Execute(exePath);
 
                 Assert.Equal(0, executableRunResult);
@@ -50,7 +50,7 @@ namespace Dotnet.Script.Tests
                 var publishResult = Execute(string.Join(" ", args), workspaceFolder.Path);
                 Assert.Equal(0, publishResult.exitCode);
 
-                var exePath = Path.Combine(publishRootFolder.Path, "script");
+                var exePath = Path.Combine(publishRootFolder.Path, _scriptEnvironment.RuntimeIdentifier, "script");
                 var executableRunResult = _commandRunner.Execute(exePath);
 
                 Assert.Equal(0, executableRunResult);
@@ -69,7 +69,7 @@ namespace Dotnet.Script.Tests
                 var publishResult = Execute(string.Join(" ", args), workspaceFolder.Path);
                 Assert.Equal(0, publishResult.exitCode);
 
-                var exePath = Path.Combine(workspaceFolder.Path, "publish", "script");
+                var exePath = Path.Combine(workspaceFolder.Path, "publish", _scriptEnvironment.RuntimeIdentifier, "script");
                 var executableRunResult = _commandRunner.Execute(exePath);
 
                 Assert.Equal(0, executableRunResult);

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -38,6 +38,25 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public void SimplePublishTestToDifferentRuntimeId()
+        {
+            using (var workspaceFolder = new DisposableFolder())
+            {
+                var runtimeId = _scriptEnvironment.RuntimeIdentifier == "win10-x64" ? "osx -x64" : "win10-x64";
+                var code = @"WriteLine(""hello world"");";
+                var mainPath = Path.Combine(workspaceFolder.Path, "main.csx");
+                File.WriteAllText(mainPath, code);
+                var args = new string[] { "publish", mainPath, "--runtime", runtimeId };
+                var publishResult = Execute(string.Join(" ", args), workspaceFolder.Path);
+                Assert.Equal(0, publishResult.exitCode);
+
+                var publishPath = Path.Combine(workspaceFolder.Path, "publish", runtimeId);
+                Assert.True(Directory.Exists(publishPath), $"Publish directory {publishPath} was not found.");
+                Assert.True(Directory.EnumerateFiles(publishPath).GetEnumerator().MoveNext(), $"Publish directory {publishPath} was empty.");
+            }
+        }
+
+        [Fact]
         public void SimplePublishToOtherFolderTest()
         {
             using (var workspaceFolder = new DisposableFolder())

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -42,7 +42,7 @@ namespace Dotnet.Script.Tests
         {
             using (var workspaceFolder = new DisposableFolder())
             {
-                var runtimeId = _scriptEnvironment.RuntimeIdentifier == "win10-x64" ? "osx -x64" : "win10-x64";
+                var runtimeId = _scriptEnvironment.RuntimeIdentifier == "win10-x64" ? "osx-x64" : "win10-x64";
                 var code = @"WriteLine(""hello world"");";
                 var mainPath = Path.Combine(workspaceFolder.Path, "main.csx");
                 File.WriteAllText(mainPath, code);
@@ -52,7 +52,11 @@ namespace Dotnet.Script.Tests
 
                 var publishPath = Path.Combine(workspaceFolder.Path, "publish", runtimeId);
                 Assert.True(Directory.Exists(publishPath), $"Publish directory {publishPath} was not found.");
-                Assert.True(Directory.EnumerateFiles(publishPath).GetEnumerator().MoveNext(), $"Publish directory {publishPath} was empty.");
+
+                using (var enumerator = Directory.EnumerateFiles(publishPath).GetEnumerator())
+                {
+                    Assert.True(enumerator.MoveNext(), $"Publish directory {publishPath} was empty.");
+                }
             }
         }
 
@@ -69,7 +73,7 @@ namespace Dotnet.Script.Tests
                 var publishResult = Execute(string.Join(" ", args), workspaceFolder.Path);
                 Assert.Equal(0, publishResult.exitCode);
 
-                var exePath = Path.Combine(publishRootFolder.Path, _scriptEnvironment.RuntimeIdentifier, "script");
+                var exePath = Path.Combine(publishRootFolder.Path, "script");
                 var executableRunResult = _commandRunner.Execute(exePath);
 
                 Assert.Equal(0, executableRunResult);

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -131,14 +131,14 @@ namespace Dotnet.Script
 
             app.Command("publish", c =>
             {
-                c.Description = "Creates an executable or DLL from a script";
+                c.Description = "Creates a self contained executable or DLL from a script";
                 var fileNameArgument = c.Argument("filename", "The script file name");
                 var publishDirectoryOption = c.Option("-o |--output", "Directory where the published executable should be placed.  Defaults to a 'publish' folder in the current directory.", CommandOptionType.SingleValue);
-                var dllName = c.Option("-n |--name", "The name for the generated DLL (EXE not supported at this time).  Defaults to the name of the script.", CommandOptionType.SingleValue);
-                var dllOption = c.Option("--dll", "Publish to a .dll instead of a .exe", CommandOptionType.NoValue);
-                var commandConfig = c.Option("-c | --configuration <configuration>", "Configuration to use for running the script [Release/Debug] Default is \"Debug\"", CommandOptionType.SingleValue);
+                var dllName = c.Option("-n |--name", "The name for the generated DLL (executable not supported at this time).  Defaults to the name of the script.", CommandOptionType.SingleValue);
+                var dllOption = c.Option("--dll", "Publish to a .dll instead of an executable.", CommandOptionType.NoValue);
+                var commandConfig = c.Option("-c | --configuration <configuration>", "Configuration to use for publishing the script [Release/Debug]. Default is \"Debug\"", CommandOptionType.SingleValue);
                 var publishDebugMode = c.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
-                var runtime = c.Option("-r |--runtime", "The runtime to publish the self contained EXE to. Defaults to the your current platform.", CommandOptionType.SingleValue);
+                var runtime = c.Option("-r |--runtime", "The runtime used when publishing the self contained executable. Defaults to the your current runtime.", CommandOptionType.SingleValue);
 
                 c.OnExecute(() =>
                 {

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -138,6 +138,8 @@ namespace Dotnet.Script
                 var dllOption = c.Option("--dll", "Publish to a .dll instead of a .exe", CommandOptionType.NoValue);
                 var commandConfig = c.Option("-c | --configuration <configuration>", "Configuration to use for running the script [Release/Debug] Default is \"Debug\"", CommandOptionType.SingleValue);
                 var publishDebugMode = c.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
+                var runtime = c.Option("-r |--runtime", "The runtime to publish the self contained EXE to. Defaults to the your current platform.", CommandOptionType.SingleValue);
+
                 c.OnExecute(() =>
                 {
                     if (fileNameArgument.Value == null)
@@ -163,9 +165,13 @@ namespace Dotnet.Script
                     var context = new ScriptContext(code, absolutePublishDirectory, Enumerable.Empty<string>(), absoluteFilePath, optimizationLevel);
 
                     if (dllOption.HasValue())
+                    {
                         publisher.CreateAssembly<int, CommandLineScriptGlobals>(context, logFactory, dllName.Value());
+                    }
                     else
-                        publisher.CreateExecutable<int, CommandLineScriptGlobals>(context, logFactory);
+                    {
+                        publisher.CreateExecutable<int, CommandLineScriptGlobals>(context, logFactory, runtime.Value());
+                    }
 
                     return 0;
 

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -154,8 +154,15 @@ namespace Dotnet.Script
                         optimizationLevel = OptimizationLevel.Release;
                     }
 
+                    var runtimeIdentifier = runtime.Value() ?? ScriptEnvironment.Default.RuntimeIdentifier;
                     var absoluteFilePath = Path.IsPathRooted(fileNameArgument.Value) ? fileNameArgument.Value : Path.Combine(Directory.GetCurrentDirectory(), fileNameArgument.Value);
-                    var publishDirectory = publishDirectoryOption.Value() ?? Path.Combine(Path.GetDirectoryName(absoluteFilePath), "publish");
+
+                    // if a publish directory has been specified, then it is used directly, otherwise:
+                    // -- for EXE {current dir}/publish/{runtime ID}
+                    // -- for DLL {current dir}/publish
+                    var publishDirectory = publishDirectoryOption.Value() ?? 
+                        (dllOption.HasValue() ? Path.Combine(Path.GetDirectoryName(absoluteFilePath), "publish") : Path.Combine(Path.GetDirectoryName(absoluteFilePath), "publish", runtimeIdentifier));
+
                     var absolutePublishDirectory = Path.IsPathRooted(publishDirectory) ? publishDirectory : Path.Combine(Directory.GetCurrentDirectory(), publishDirectory);
                     var logFactory = GetLogFactory();
                     var compiler = GetScriptCompiler(publishDebugMode.HasValue());
@@ -170,7 +177,7 @@ namespace Dotnet.Script
                     }
                     else
                     {
-                        publisher.CreateExecutable<int, CommandLineScriptGlobals>(context, logFactory, runtime.Value());
+                        publisher.CreateExecutable<int, CommandLineScriptGlobals>(context, logFactory, runtimeIdentifier);
                     }
 
                     return 0;

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -138,7 +138,7 @@ namespace Dotnet.Script
                 var dllOption = c.Option("--dll", "Publish to a .dll instead of an executable.", CommandOptionType.NoValue);
                 var commandConfig = c.Option("-c | --configuration <configuration>", "Configuration to use for publishing the script [Release/Debug]. Default is \"Debug\"", CommandOptionType.SingleValue);
                 var publishDebugMode = c.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
-                var runtime = c.Option("-r |--runtime", "The runtime used when publishing the self contained executable. Defaults to the your current runtime.", CommandOptionType.SingleValue);
+                var runtime = c.Option("-r |--runtime", "The runtime used when publishing the self contained executable. Defaults to your current runtime.", CommandOptionType.SingleValue);
 
                 c.OnExecute(() =>
                 {


### PR DESCRIPTION
When publishing to an exe you can now pass the runtime ID to create a self contained executable for a different platform than your current one.
For example: `dotnet script publish main.csx --runtime osx-x64`. 

If the runtime is not passed, the current runtime is used (as it was the case earlier). 
If the output directory is passed, the output directory is used.
If no output directory is passed, the default path is computed the following way `{current dir}/publish/{runtime id}`.

cc @Sharpiro 