### PR TITLE
Feature/single netcoreapp target

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Run C# scripts from the .NET CLI, define NuGet packages inline and edit/debug th
 
 | Name    | Version                             | Framework | Description
 | --------| ---------------------------------------- | ---------- |-------
-| `dotnet-script` | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/) | `netcoreapp2.1` / `netcoreapp2.0` | .NET Core global tool
-| `Dotnet.Script`| [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/) | `netcoreapp2.1` / `netcoreapp2.0` | .NET Core project tool
+| `dotnet-script` | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/) | `netcoreapp2.1` | .NET Core global tool
+| `Dotnet.Script`| [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/) | `netcoreapp2.1` | .NET Core project tool
 | `Dotnet.Script.Core` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.Core.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.Core/) | `netstandard2.0` | Core library for hosting dotnet-script logic in your own app.
-| `Dotnet.Script.DependencyModel` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel/) | `netstandard2.0` / `net46` | Provides runtime and compilation dependency resolution for dotnet-script based scripts.
-| `Dotnet.Script.DependencyModel.Nuget` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.Nuget.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel.Nuget/) | `netstandard2.0` / `net46` | A null implementation of a `MetadataReferenceResolver` that allows inline nuget references to be specified in script (csx) files.
+| `Dotnet.Script.DependencyModel` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel/) | `netstandard2.0` | Provides runtime and compilation dependency resolution for dotnet-script based scripts.
+| `Dotnet.Script.DependencyModel.Nuget` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.Nuget.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel.Nuget/) | `netstandard2.0` | A null implementation of a `MetadataReferenceResolver` that allows inline nuget references to be specified in script (csx) files.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run C# scripts from the .NET CLI, define NuGet packages inline and edit/debug th
 
 ### Prerequisites
 
-The only thing we need to install is [.Net Core 2.0+ SDK](https://www.microsoft.com/net/download/core). dotnet-script supports both .NET Core 2.1 and .NET Core 2.0. Depending on the currently active .NET Core SDK, dotnet-script will run either as `netcoreapp2.1` or as `netcoreapp2.0`. You can use [global.json](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json) file to control that.
+The only thing we need to install is [.Net Core 2.1+ SDK](https://www.microsoft.com/net/download/core). 
 
 ### .Net Core 2.1 Global Tool
 
@@ -108,25 +108,18 @@ You can manually download all the releases in `zip` format from the [Github rele
 Our typical `helloworld.csx` might look like this:
 
 ```
-#! "netcoreapp2.0"
+#! "netcoreapp2.1"
 Console.WriteLine("Hello world!");
 ```
 
 Let us take a quick look at what is going on here.
 
-`#! "netcoreapp2.0"` tells OmniSharp to resolve metadata in the context of a`netcoreapp2.0` application. This will bring in all assemblies from [Microsoft.NETCore.App](https://www.nuget.org/packages/Microsoft.NETCore.App/2.0.0) and should cover most scripting needs. 
+`#! "netcoreapp2.1"` tells OmniSharp to resolve metadata in the context of a`netcoreapp2.1` application. This will bring in all assemblies from [Microsoft.NETCore.App](https://www.nuget.org/packages/Microsoft.NETCore.App/2.0.0) and should cover most scripting needs. 
 
 That is all it takes and we can execute the script
 
 ```
 dotnet script helloworld.csx
-```
-
-If you are using .NET Core 2.1 SDK, you could also create your script as a `netcoreapp2.1` application.
-
-```
-#! "netcoreapp2.1"
-Console.WriteLine("Hello world!");
 ```
 
 ### Scaffolding
@@ -262,7 +255,7 @@ To consume a script package all we need to do specify the NuGet package in the `
 The following example loads the [simple-targets](https://www.nuget.org/packages/simple-targets-csx) package that contains script files to be included in our script.
 
 ```C#
-#! "netcoreapp2.0"
+#! "netcoreapp2.1"
 #load "nuget:simple-targets-csx, 6.0.0"
 
 using static SimpleTargets;
@@ -416,9 +409,7 @@ The following example shows how we can pipe data in and out of a script.
 The `UpperCase.csx` script simply converts the standard input to upper case and writes it back out to standard output.
 
 ```csharp
-#! "netcoreapp2.0"
-#r "nuget: NetStandard.Library, 2.0.0"
-
+#! "netcoreapp2.1"
 using (var streamReader = new StreamReader(Console.OpenStandardInput()))
 {    
     Write(streamReader.ReadToEnd().ToUpper()); 

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -19,7 +19,7 @@ if (BuildEnvironment.IsWindows)
     DotNet.Test(testDesktopProjectFolder);    
 }
 
-DotNet.Publish(dotnetScriptProjectFolder, publishArtifactsFolder, NetCoreApp20);
+DotNet.Publish(dotnetScriptProjectFolder, publishArtifactsFolder, NetCoreApp21);
 
 // We only publish packages from Windows/AppVeyor
 if (BuildEnvironment.IsWindows)
@@ -27,8 +27,7 @@ if (BuildEnvironment.IsWindows)
     
     using(var globalToolBuildFolder = new DisposableFolder())
     {
-        Copy(solutionFolder, globalToolBuildFolder.Path);
-        PatchTargetFramework(globalToolBuildFolder.Path, NetCoreApp21);
+        Copy(solutionFolder, globalToolBuildFolder.Path);        
         PatchPackAsTool(globalToolBuildFolder.Path);
         PatchPackageId(globalToolBuildFolder.Path, GlobalToolPackageId);
         PatchContent(globalToolBuildFolder.Path);
@@ -37,8 +36,7 @@ if (BuildEnvironment.IsWindows)
     
     using(var nugetPackageBuildFolder = new DisposableFolder())
     {
-        Copy(solutionFolder, nugetPackageBuildFolder.Path);
-        PatchTargetFramework(nugetPackageBuildFolder.Path, NetCoreApp20);        
+        Copy(solutionFolder, nugetPackageBuildFolder.Path);        
         DotNet.Pack(Path.Combine(nugetPackageBuildFolder.Path,"Dotnet.Script"), nuGetArtifactsFolder);
     }
     
@@ -73,15 +71,6 @@ private async Task CreateReleaseNotes()
         generator = generator.IncludeUnreleased();
     }
     await generator.Generate(pathToReleaseNotes);
-}
-
-private void PatchTargetFramework(string solutionFolder, string targetFramework)
-{
-    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
-    var projectFile = XDocument.Load(pathToDotnetScriptProject);
-    var targetFrameworksElement = projectFile.Descendants("TargetFrameworks").Single();
-    targetFrameworksElement.ReplaceWith(new XElement("TargetFramework",targetFramework));
-    projectFile.Save(pathToDotnetScriptProject);
 }
 
 private void PatchPackAsTool(string solutionFolder)

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -19,7 +19,7 @@ if (BuildEnvironment.IsWindows)
     DotNet.Test(testDesktopProjectFolder);    
 }
 
-DotNet.Publish(dotnetScriptProjectFolder, publishArtifactsFolder, NetCoreApp21);
+DotNet.Publish(dotnetScriptProjectFolder, publishArtifactsFolder);
 
 // We only publish packages from Windows/AppVeyor
 if (BuildEnvironment.IsWindows)

--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -2,7 +2,6 @@
 using static FileUtils;
 using System.Xml.Linq;
 
-const string NetCoreApp21 = "netcoreapp2.1";
 const string GlobalToolPackageId = "dotnet-script";
 
 var owner = "filipw";

--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -2,7 +2,6 @@
 using static FileUtils;
 using System.Xml.Linq;
 
-const string NetCoreApp20 = "netcoreapp2.0";
 const string NetCoreApp21 = "netcoreapp2.1";
 const string GlobalToolPackageId = "dotnet-script";
 

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageLicenseUrl>https://github.com/filipw/dotnet-script/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/filipw/dotnet-script</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/filipw/Strathweb.TypedRouting.AspNetCore/master/strathweb.png</PackageIconUrl>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>
     <Description>Provides runtime and compilation dependency resolution for dotnet-script based scripts.</Description>

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -4,7 +4,7 @@
         <VersionPrefix>0.25.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
-        <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <DebugType>portable</DebugType>
         <AssemblyName>dotnet-script</AssemblyName>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
This PR removes support for netcoreapp2.0 meaning that we only target netcoreapp2.1 for the dotnet script executable. 
Since OmniSharp is Net461 now, we can also stop cross compiling Dotnet.Script.DepenencyModel for both netstandard2.0 and net46.

This also means that users will get the same target version regardless of whether they've installed using chocolatey or through the global tools. 
