### PR TITLE
Feature/console colors

### DIFF
--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -150,7 +150,7 @@ namespace Dotnet.Script.Core
                 await doWork();
                 if (_scriptState?.Exception != null)
                 {
-                    Console.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(_scriptState.Exception));
+                    Console.WriteError(CSharpObjectFormatter.Instance.FormatException(_scriptState.Exception));
                 }
 
                 if (_scriptState?.ReturnValue != null)
@@ -162,12 +162,12 @@ namespace Dotnet.Script.Core
             {
                 foreach (var diagnostic in e.Diagnostics)
                 {
-                    Console.WritePrettyError(diagnostic.ToString());
+                    Console.WriteError(diagnostic.ToString());
                 }
             }
             catch (Exception e)
             {
-                Console.WritePrettyError(CSharpObjectFormatter.Instance.FormatException(e));
+                Console.WriteError(CSharpObjectFormatter.Instance.FormatException(e));
             }
         }
     }

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -31,7 +31,7 @@ namespace Dotnet.Script.Core
 
         public void CreateNewScriptFile(string fileName, string currentDirectory)
         {
-            _scriptConsole.Out.WriteLine($"Creating '{fileName}'");
+            _scriptConsole.WriteNormal($"Creating '{fileName}'");
             if(!Path.HasExtension(fileName))
             {
                 fileName = Path.ChangeExtension(fileName, ".csx");
@@ -41,11 +41,11 @@ namespace Dotnet.Script.Core
             {
                 var scriptFileTemplate = TemplateLoader.ReadTemplate("helloworld.csx.template");
                 File.WriteAllText(pathToScriptFile, scriptFileTemplate);
-                _scriptConsole.Out.WriteLine($"...'{pathToScriptFile}' [Created]");
+                _scriptConsole.WriteSuccess($"...'{pathToScriptFile}' [Created]");
             }
             else
             {
-                _scriptConsole.Out.WriteLine($"...'{pathToScriptFile}' already exists [Skipping]");
+                _scriptConsole.WriteHighlighted($"...'{pathToScriptFile}' already exists [Skipping]");
             }
         }
 
@@ -66,7 +66,7 @@ namespace Dotnet.Script.Core
             _scriptConsole.Out.WriteLine($"Creating default script file '{DefaultScriptFileName}'");
             if (Directory.GetFiles(currentWorkingDirectory, "*.csx").Any())
             {
-                _scriptConsole.Out.WriteLine("...Folder already contains one or more script files [Skipping]");
+                _scriptConsole.WriteHighlighted("...Folder already contains one or more script files [Skipping]");
             }
             else
             {
@@ -76,7 +76,7 @@ namespace Dotnet.Script.Core
 
         private void CreateOmniSharpConfigurationFile(string currentWorkingDirectory)
         {
-            _scriptConsole.Out.WriteLine("Creating OmniSharp configuration file");
+            _scriptConsole.WriteNormal("Creating OmniSharp configuration file");
             string pathToOmniSharpJson = Path.Combine(currentWorkingDirectory, "omnisharp.json");
             if (!File.Exists(pathToOmniSharpJson))
             {
@@ -84,11 +84,11 @@ namespace Dotnet.Script.Core
                 JObject settings = JObject.Parse(omniSharpFileTemplate);
                 settings["script"]["defaultTargetFramework"] = _scriptEnvironment.TargetFramework;
                 File.WriteAllText(pathToOmniSharpJson, settings.ToString());
-                _scriptConsole.Out.WriteLine($"...'{pathToOmniSharpJson}' [Created]");
+                _scriptConsole.WriteSuccess($"...'{pathToOmniSharpJson}' [Created]");
             }
             else
             {
-                _scriptConsole.Out.WriteLine($"...'{pathToOmniSharpJson} already exists' [Skipping]");
+                _scriptConsole.WriteHighlighted($"...'{pathToOmniSharpJson} already exists' [Skipping]");
             }
         }
 
@@ -100,7 +100,7 @@ namespace Dotnet.Script.Core
                 Directory.CreateDirectory(vsCodeDirectory);
             }
 
-            _scriptConsole.Out.WriteLine("Creating VS Code launch configuration file");
+            _scriptConsole.WriteNormal("Creating VS Code launch configuration file");
             string pathToLaunchFile = Path.Combine(vsCodeDirectory, "launch.json");
             string installLocation = _scriptEnvironment.InstallLocation;
             string dotnetScriptPath = Path.Combine(installLocation, "dotnet-script.dll").Replace(@"\", "/");
@@ -109,11 +109,11 @@ namespace Dotnet.Script.Core
                 string lauchFileTemplate = TemplateLoader.ReadTemplate("launch.json.template");
                 string launchFileContent = lauchFileTemplate.Replace("PATH_TO_DOTNET-SCRIPT", dotnetScriptPath);
                 File.WriteAllText(pathToLaunchFile, launchFileContent);
-                _scriptConsole.Out.WriteLine($"...'{pathToLaunchFile}' [Created]");
+                _scriptConsole.WriteSuccess($"...'{pathToLaunchFile}' [Created]");
             }
             else
             {
-                _scriptConsole.Out.WriteLine($"...'{pathToLaunchFile}' already exists' [Skipping]");
+                _scriptConsole.WriteHighlighted($"...'{pathToLaunchFile}' already exists' [Skipping]");
                 var launchFileContent = File.ReadAllText(pathToLaunchFile);
                 string pattern = @"^(\s*"")(.*dotnet-script.dll)("").*$";
                 if (Regex.IsMatch(launchFileContent, pattern, RegexOptions.Multiline))
@@ -121,7 +121,7 @@ namespace Dotnet.Script.Core
                     var newLaunchFileContent = Regex.Replace(launchFileContent, pattern, $"$1{dotnetScriptPath}$3", RegexOptions.Multiline);
                     if (launchFileContent != newLaunchFileContent)
                     {
-                        _scriptConsole.Out.WriteLine($"...Fixed path to dotnet-script: '{dotnetScriptPath}' [Updated]");
+                        _scriptConsole.WriteHighlighted($"...Fixed path to dotnet-script: '{dotnetScriptPath}' [Updated]");
                         File.WriteAllText(pathToLaunchFile, newLaunchFileContent);
                     }
                 }

--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -13,7 +13,7 @@ namespace Dotnet.Script.Core
 
         public virtual void Clear() => Console.Clear();
 
-        public virtual void WritePrettyError(string value)
+        public virtual void WriteError(string value)
         {
             Console.ForegroundColor = ConsoleColor.Red;
             Error.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
@@ -25,6 +25,18 @@ namespace Dotnet.Script.Core
             Console.ForegroundColor = ConsoleColor.Green;
             Out.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
             Console.ResetColor();
+        }
+
+        public virtual void WriteHighlighted(string value)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Out.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
+            Console.ResetColor();
+        }
+
+        public virtual void WriteNormal(string value)
+        {
+            Out.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
         }
 
         public ScriptConsole(TextWriter output, TextReader input, TextWriter error)

--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -20,6 +20,13 @@ namespace Dotnet.Script.Core
             Console.ResetColor();
         }
 
+        public virtual void WriteSuccess(string value)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Out.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
+            Console.ResetColor();
+        }
+
         public ScriptConsole(TextWriter output, TextReader input, TextWriter error)
         {
             Out = output;

--- a/src/Dotnet.Script.Core/ScriptEmitter.cs
+++ b/src/Dotnet.Script.Core/ScriptEmitter.cs
@@ -44,7 +44,7 @@ namespace Dotnet.Script.Core
             {
                 foreach (var diagnostic in e.Diagnostics)
                 {
-                    _scriptConsole.WritePrettyError(diagnostic.ToString());
+                    _scriptConsole.WriteError(diagnostic.ToString());
                 }
 
                 throw;

--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -54,7 +54,7 @@ namespace Dotnet.Script.Core
             var sourceNugetPropsPath = Path.Combine(tempProjectDirecory, "obj", "script.csproj.nuget.g.props");
             var destinationNugetPropsPath = Path.Combine(context.WorkingDirectory, "obj", "script.csproj.nuget.g.props");
             File.Copy(sourceNugetPropsPath, destinationNugetPropsPath, overwrite: true);
-            _scriptConsole.Out.WriteLine($"Published {context.FilePath} to { scriptAssemblyPath}");
+            _scriptConsole.WriteSuccess($"Published {context.FilePath} to { scriptAssemblyPath}");
         }
 
         public void CreateExecutable<TReturn, THost>(ScriptContext context, LogFactory logFactory, string runtimeIdentifier)
@@ -81,7 +81,7 @@ namespace Dotnet.Script.Core
             // todo: may want to add ability to return dotnet.exe errors
             var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o {context.WorkingDirectory}");
             if (exitcode != 0) throw new Exception($"dotnet publish failed with result '{exitcode}'");
-            _scriptConsole.Out.WriteLine($"Published {context.FilePath} (executable) to {context.WorkingDirectory}");
+            _scriptConsole.WriteSuccess($"Published {context.FilePath} (executable) to {context.WorkingDirectory}");
         }
 
         private string CreateScriptAssembly<TReturn, THost>(ScriptContext context, string outputDirectory, string assemblyFileName)

--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -113,10 +113,10 @@ namespace Dotnet.Script.Core
             }
             catch (CompilationErrorException ex)
             {
-                _scriptConsole.WritePrettyError(ex.Message);
+                _scriptConsole.WriteError(ex.Message);
                 foreach (var diagnostic in ex.Diagnostics)
                 {
-                    _scriptConsole.WritePrettyError(diagnostic.ToString());
+                    _scriptConsole.WriteError(diagnostic.ToString());
                 }
                 throw;
             }

--- a/src/Dotnet.Script.Core/ScriptRunner.cs
+++ b/src/Dotnet.Script.Core/ScriptRunner.cs
@@ -70,7 +70,7 @@ namespace Dotnet.Script.Core
             {
                 foreach (var diagnostic in e.Diagnostics)
                 {
-                    ScriptConsole.WritePrettyError(diagnostic.ToString());
+                    ScriptConsole.WriteError(diagnostic.ToString());
                 }
 
                 throw;
@@ -89,7 +89,7 @@ namespace Dotnet.Script.Core
             {
                 // once Roslyn ships with this, we can format he exception using CSharpObjectFormatter
                 // https://github.com/dotnet/roslyn/blob/4175350b87f928e136cbb14c2668b7cb3338d5a1/src/Scripting/Core/Hosting/CommonMemberFilter.cs#L18
-                ScriptConsole.WritePrettyError(scriptState.Exception.ToString());
+                ScriptConsole.WriteError(scriptState.Exception.ToString());
                 throw new ScriptRuntimeException("Script execution resulted in an exception.", scriptState.Exception);
             }
 


### PR DESCRIPTION
Adds support for outputting messages with colors to the console. 

The `ScriptConsole` class now has the following methods 

* WriteNormal  - Write a message using the default foreground color
* WriteHighlighted - Writes a highlighted message (yellow)
* WriteSuccess - Writes a message indicating success (green)
* WriteError - Writes an error message (red) to stderr
 
An example would be when initializing a folder using `dotnet script init`

![image](https://user-images.githubusercontent.com/1034073/44364810-456d3700-a4c8-11e8-9239-b757bba8ccb4.png)

Issuing the same command again will "highlight" that some files already exists.

![image](https://user-images.githubusercontent.com/1034073/44365067-fbd11c00-a4c8-11e8-94f5-95c62d338845.png)


