### PR TITLE
 handle arguments in the "exec dll" flow

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>0.26.0</VersionPrefix>
+    <VersionPrefix>0.26.1</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -193,6 +193,25 @@ namespace Dotnet.Script.Tests
             }
         }
 
+        [Fact]
+        public void DllWithArgsTests()
+        {
+            using (var workspaceFolder = new DisposableFolder())
+            {
+                var code = @"WriteLine(""Hello "" + Args[0] + Args[1] + Args[2] + Args[3] + Args[4]);";
+                var mainPath = Path.Combine(workspaceFolder.Path, "main.csx");
+                File.WriteAllText(mainPath, code);
+                var publishResult = ScriptTestRunner.Default.Execute($"publish {mainPath} --dll", workspaceFolder.Path);
+                Assert.Equal(0, publishResult.exitCode);
+
+                var dllPath = Path.Combine(workspaceFolder.Path, "publish", "main.dll");
+                var dllRunResult = ScriptTestRunner.Default.Execute($"exec {dllPath} -- w o r l d", workspaceFolder.Path);
+
+                Assert.Equal(0, dllRunResult.exitCode);
+                Assert.Contains("Hello world", dllRunResult.output);
+            }
+        }
+
         private LogFactory GetLogFactory()
         {
             return TestOutputHelper.CreateTestLogFactory();

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.26.0</VersionPrefix>
+        <VersionPrefix>0.26.1</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -211,7 +211,7 @@ namespace Dotnet.Script
                        
                         var compiler = GetScriptCompiler(commandDebugMode.HasValue(), logFactory);
                         var runner = new ScriptRunner(compiler, logFactory, ScriptConsole.Default);
-                        var result = await runner.Execute<int>(absoluteFilePath);
+                        var result = await runner.Execute<int>(absoluteFilePath, app.RemainingArguments.Concat(argsAfterDoubleHypen));
                         return result;
                     }
                     return exitCode;


### PR DESCRIPTION
Fixes #332 

Propagate arguments to dotnet script exec. Syntax: `dotnet script exec <path to dll> -- <args>` (same delimiter as we have for regular scripting).