### PR TITLE
Pass arguments when executing a dll

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -193,6 +193,28 @@ namespace Dotnet.Script.Tests
             }
         }
 
+        [Fact]
+        public void ShouldPassArgumentsWhenExecutingDll()
+        {
+            using (var workspaceFolder = new DisposableFolder())
+            {
+                var code = @"WriteLine(Args[0]);";
+                var mainPath = Path.Combine(workspaceFolder.Path, "main.csx");
+                File.WriteAllText(mainPath, code);
+                var publishResult = ScriptTestRunner.Default.Execute("publish main.csx --dll", workspaceFolder.Path);
+                Assert.Equal(0, publishResult.exitCode);
+
+                var dllPath = Path.Combine(workspaceFolder.Path, "publish", "main.dll");
+
+                var dllRunResult = ScriptTestRunner.Default.Execute($"exec {dllPath} -- SampleArgument", workspaceFolder.Path);
+
+                Assert.Equal(0, dllRunResult.exitCode);
+                Assert.Contains("SampleArgument", dllRunResult.output);
+
+            }
+        }
+
+
         private LogFactory GetLogFactory()
         {
             return TestOutputHelper.CreateTestLogFactory();

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -211,7 +211,7 @@ namespace Dotnet.Script
                        
                         var compiler = GetScriptCompiler(commandDebugMode.HasValue(), logFactory);
                         var runner = new ScriptRunner(compiler, logFactory, ScriptConsole.Default);
-                        var result = await runner.Execute<int>(absoluteFilePath);
+                        var result = await runner.Execute<int>(absoluteFilePath, app.RemainingArguments.Concat(argsAfterDoubleHypen));
                         return result;
                     }
                     return exitCode;


### PR DESCRIPTION
Fixes #332 where the provided args where not passed into the `ScriptRunner` when issuing an `exec someassembly.dll`