### PR TITLE
make csx files directly runnable on Windows, OSX and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ Run C# scripts from the .NET CLI, define NuGet packages inline and edit/debug th
 
 ## Build status
 
-| Build server | Platform     | Build status                                                                                                                                  |
-|--------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| AppVeyor     | Windows      | [![](https://img.shields.io/appveyor/ci/filipw/dotnet-script/master.svg)](https://ci.appveyor.com/project/filipw/dotnet-script/branch/master) |
-| Travis       | Linux / OS X | [![](https://travis-ci.org/filipw/dotnet-script.svg?branch=master)](https://travis-ci.org/filipw/dotnet-script)                               |
+| Build server | Platform    | Build status                             |
+| ------------ | ----------- | ---------------------------------------- |
+| AppVeyor     | Windows     | [![](https://img.shields.io/appveyor/ci/filipw/dotnet-script/master.svg)](https://ci.appveyor.com/project/filipw/dotnet-script/branch/master) |
+| Travis       | Linux / OS X | [![](https://travis-ci.org/filipw/dotnet-script.svg?branch=master)](https://travis-ci.org/filipw/dotnet-script) |
 
 
 ## Nuget Packages
 
-| Name                                  | Version                                                                                                                                                             | Framework        |
-|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-| `dotnet-script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/)                                             | `netcoreapp2.1`  |
-| `Dotnet.Script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/)                                             | `netcoreapp2.1`  |
-| `Dotnet.Script.Core`                  | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.Core.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.Core/)                                   | `netstandard2.0` |
-| `Dotnet.Script.DependencyModel`       | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel/)             | `netstandard2.0` |
-| `Dotnet.Script.DependencyModel.Nuget` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.Nuget.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel.Nuget/) | `netstandard2.0` |
+| Name    | Version                             | Framework | Description
+| --------| ---------------------------------------- | ---------- |-------
+| `dotnet-script` | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/) | `netcoreapp2.1` | .NET Core global tool
+| `Dotnet.Script`| [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/) | `netcoreapp2.1` | .NET Core project tool
+| `Dotnet.Script.Core` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.Core.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.Core/) | `netstandard2.0` | Core library for hosting dotnet-script logic in your own app.
+| `Dotnet.Script.DependencyModel` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel/) | `netstandard2.0` | Provides runtime and compilation dependency resolution for dotnet-script based scripts.
+| `Dotnet.Script.DependencyModel.Nuget` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.Nuget.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel.Nuget/) | `netstandard2.0` | A null implementation of a `MetadataReferenceResolver` that allows inline nuget references to be specified in script (csx) files.
 
 ## Installing
 
@@ -94,7 +94,7 @@ docker build -t dotnet-script -f Dockerfile ..
 
 And run:
 
-```shell
+```
 docker run -it dotnet-script --version
 ```
 
@@ -107,11 +107,16 @@ You can manually download all the releases in `zip` format from the [Github rele
 
 Our typical `helloworld.csx` might look like this:
 
-```cs
+```
+#! "netcoreapp2.1"
 Console.WriteLine("Hello world!");
 ```
 
-That is all it takes and we can execute the script. Args are accessible via the global Args array.
+Let us take a quick look at what is going on here.
+
+`#! "netcoreapp2.1"` tells OmniSharp to resolve metadata in the context of a`netcoreapp2.1` application. This will bring in all assemblies from [Microsoft.NETCore.App](https://www.nuget.org/packages/Microsoft.NETCore.App/2.0.0) and should cover most scripting needs. 
+
+That is all it takes and we can execute the script
 
 ```
 dotnet script helloworld.csx
@@ -198,39 +203,17 @@ As an alternative to maintaining a local `NuGet.Config` file we can define these
 
 It is also possible to specify packages sources when executing the script.
 
-```shell
+```
 dotnet script foo.csx -s https://SomePackageSource
 ```
 
 Multiple packages sources can be specified like this:
 
-```shell
+```
 dotnet script foo.csx -s https://SomePackageSource -s https://AnotherPackageSource
 ```
 
-### Creating DLLs or Exes from a CSX file
-Dotnet-Script can create a standalone executable or DLL for your script. 
 
-| Switch | Long switch                     | description                                                                                                          |
-|--------|---------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| -o     | --output                        | Directory where the published executable should be placed.  Defaults to a 'publish' folder in the current directory. |
-| -n     | --name                          | The name for the generated DLL (executable not supported at this time).  Defaults to the name of the script.         |
-|        | --dll                           | Publish to a .dll instead of an executable.                                                                          |
-| -c     | --configuration <configuration> | Configuration to use for publishing the script [Release/Debug]. Default is "Debug"                                   |
-| -d     | --debug                         | Enables debug output.                                                                                                |
-| -r     | --runtime                       | The runtime used when publishing the self contained executable. Defaults to your current runtime.                    |
-
-The executable you can run directly independent of dotnet install, while the DLL is can be run using the dotnet CLI like this:
-
-```shell
-dotnet publish\myscript.dll -- arg1 arg2
-```
-
-### DLL Cache
-Dotnet-Script will automatically create a DLL on first execution of a script and as long as the source code has not changed it will continue to 
-use that DLL significantlly speeding up the execution of your scripts (by 8x).  The cached DLL's are stored in the user %tmp%/dotnet-script folder. 
-
-You can override this a automatic caching by passing **--nocache** flag, which will cause your script to be dynamically compiled everytime you run it.
 
 ### Debugging
 
@@ -383,13 +366,13 @@ Using Roslyn syntax parsing, we also support multiline REPL mode. This means tha
 
 Aside from the regular C# script code, you can invoke the following commands (directives) from within the REPL:
 
-| Command  | Description                                                  |
-|----------|--------------------------------------------------------------|
-| `#load`  | Load a script into the REPL (same as `#load` usage in CSX)   |
-| `#r`     | Load an assembly into the REPL (same as `#r` usage in CSX)   |
+| Command  | Description                              |
+| -------- | ---------------------------------------- |
+| `#load`  | Load a script into the REPL (same as `#load` usage in CSX) |
+| `#r`     | Load an assembly into the REPL (same as `#r` usage in CSX) |
 | `#reset` | Reset the REPL back to initial state (without restarting it) |
-| `#cls`   | Clear the console screen without resetting the REPL state    |
-| `#exit`  | Exits the REPL                                               |
+| `#cls`   | Clear the console screen without resetting the REPL state |
+| `#exit`  | Exits the REPL                           |
 
 ### Seeding REPL with a script
 

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -28,7 +28,6 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Templates\helloworld.csx.template" />
-    <EmbeddedResource Include="Templates\launch-linux.json.template" />
     <EmbeddedResource Include="Templates\launch.json.template" />
     <EmbeddedResource Include="Templates\omnisharp.json.template" />
     <EmbeddedResource Include="Templates\program.publish.template" />

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <None Remove="Templates\helloworld.csx.template" />
+    <None Remove="Templates\launch-linux.json.template" />
     <None Remove="Templates\launch.json.template" />
     <None Remove="Templates\omnisharp.json.template" />
     <None Remove="Templates\program.publish.template" />
@@ -27,6 +28,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Templates\helloworld.csx.template" />
+    <EmbeddedResource Include="Templates\launch-linux.json.template" />
     <EmbeddedResource Include="Templates\launch.json.template" />
     <EmbeddedResource Include="Templates\omnisharp.json.template" />
     <EmbeddedResource Include="Templates\program.publish.template" />

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -1,6 +1,7 @@
 ﻿using Dotnet.Script.Core.Templates;
 using Dotnet.Script.DependencyModel.Environment;
 using Newtonsoft.Json.Linq;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -43,10 +44,12 @@ namespace Dotnet.Script.Core
                     RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     // add a shebang to set dotnet-script as the interpreter for .csx files
-                    scriptFileTemplate = "#!/usr/bin/env dotnet-script\n" + scriptFileTemplate;
+                    // add make sure we are using environment newlines, because shebang won't work with windows cr\lf
+                    scriptFileTemplate = "#!/usr/bin/env dotnet-script" + Environment.NewLine +
+                        scriptFileTemplate.Replace("\r\n", Environment.NewLine);
                 }
 
-                File.WriteAllText(pathToScriptFile, scriptFileTemplate);
+                File.WriteAllText(pathToScriptFile, scriptFileTemplate, System.Text.Encoding.ASCII /* Linux shebang can't handle BOM */);
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
                     RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -133,8 +136,20 @@ namespace Dotnet.Script.Core
             string dotnetScriptPath = Path.Combine(installLocation, "dotnet-script.dll").Replace(@"\", "/");
             if (!File.Exists(pathToLaunchFile))
             {
-                string lauchFileTemplate = TemplateLoader.ReadTemplate("launch.json.template");
-                string launchFileContent = lauchFileTemplate.Replace("PATH_TO_DOTNET-SCRIPT", dotnetScriptPath);
+                string launchFileTemplate = null;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    // since we have the shebang in the .csx file, we have to massage it to remove it when compiling
+                    // if it is massaged the debugger won't debug it because it detects it's changed, so this launch
+                    // template sets the flag which says it's ok to debug anyway
+                    launchFileTemplate = TemplateLoader.ReadTemplate("launch-linux.json.template");
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    launchFileTemplate = TemplateLoader.ReadTemplate("launch.json.template");
+                }
+                string launchFileContent = launchFileTemplate.Replace("PATH_TO_DOTNET-SCRIPT", dotnetScriptPath);
                 File.WriteAllText(pathToLaunchFile, launchFileContent);
                 _scriptConsole.WriteSuccess($"...'{pathToLaunchFile}' [Created]");
             }

--- a/src/Dotnet.Script.Core/Templates/helloworld.csx.template
+++ b/src/Dotnet.Script.Core/Templates/helloworld.csx.template
@@ -1,3 +1,2 @@
-﻿#! "netcoreapp2.0"
-
+﻿
 Console.WriteLine("Hello world!");

--- a/src/Dotnet.Script.Core/Templates/launch.json.template
+++ b/src/Dotnet.Script.Core/Templates/launch.json.template
@@ -7,9 +7,9 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "exec",
-                "PATH_TO_DOTNET-SCRIPT",
-                "${file}"
+              "exec", 
+              "PATH_TO_DOTNET-SCRIPT", 
+              "${file}"
             ],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": true

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Dotnet.Script.DependencyModel.Context;
 using Dotnet.Script.DependencyModel.Logging;
@@ -91,7 +90,7 @@ namespace Dotnet.Script.DependencyModel.Compilation
             {
                 return Array.Empty<string>();
             }            
-            var referencePaths = compilationLibrary.ResolveReferencePaths(compilationAssemblyResolvers).Select(p => Path.GetFullPath(p)).ToArray();
+            var referencePaths = compilationLibrary.ResolveReferencePaths(compilationAssemblyResolvers).ToArray();
 
             foreach (var referencePath in referencePaths)
             {

--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -1,8 +1,8 @@
-﻿using Dotnet.Script.DependencyModel.Environment;
+﻿using System;
+using System.Linq;
+using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Process;
-using System;
-using System.Linq;
 
 namespace Dotnet.Script.DependencyModel.Context
 {
@@ -20,10 +20,9 @@ namespace Dotnet.Script.DependencyModel.Context
         }
 
         public void Restore(string pathToProjectFile, string[] packageSources)
-        {
+        {           
             var packageSourcesArgument = CreatePackageSourcesArguments();
             var runtimeIdentifier = _scriptEnvironment.RuntimeIdentifier;
-
             _logger.Debug($"Restoring {pathToProjectFile} using the dotnet cli. RuntimeIdentifier : {runtimeIdentifier}");
             var exitcode = _commandRunner.Execute("dotnet", $"restore \"{pathToProjectFile}\" -r {runtimeIdentifier} {packageSourcesArgument}");
             if (exitcode != 0)
@@ -41,6 +40,6 @@ namespace Dotnet.Script.DependencyModel.Context
             }
         }
 
-        public bool CanRestore => true;
+        public bool CanRestore => _commandRunner.Execute("dotnet", "--version") == 0;
     }
 }

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -1,7 +1,7 @@
-using Dotnet.Script.DependencyModel.Environment;
-using Dotnet.Script.Shared.Tests;
 using System;
 using System.IO;
+using Dotnet.Script.DependencyModel.Environment;
+using Dotnet.Script.Shared.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,8 +14,6 @@ namespace Dotnet.Script.Tests
 
         public ScriptExecutionTests(ITestOutputHelper testOutputHelper)
         {
-            var dllCache = Path.Combine(Path.GetTempPath(), "dotnet-scripts");
-            FileUtils.RemoveDirectory(dllCache);
             testOutputHelper.Capture();
             _scriptEnvironment = ScriptEnvironment.Default;
         }
@@ -37,7 +35,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldIncludeExceptionLineNumberAndFile()
         {
-            var result = ScriptTestRunner.Default.ExecuteFixture("Exception", "--nocache");
+            var result = ScriptTestRunner.Default.ExecuteFixture("Exception");
             Assert.Contains("Exception.csx:line 1", result.output);
         }
 
@@ -62,7 +60,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldReturnStackTraceInformationWhenScriptFails()
         {
-            var result = ScriptTestRunner.Default.ExecuteFixture("Exception", "--nocache");
+            var result = ScriptTestRunner.Default.ExecuteFixture("Exception");
             Assert.Contains("die!", result.output);
             Assert.Contains("Exception.csx:line 1", result.output);
         }
@@ -81,8 +79,6 @@ namespace Dotnet.Script.Tests
             Assert.Contains("Bad HTTP authentication header", result.output);
         }
 
-#if DISABLED
-        // This unit test does not work with DLLs.  I am not certain what it was testing.
         [Fact]
         public void ShouldHandleIssue166()
         {
@@ -94,7 +90,6 @@ namespace Dotnet.Script.Tests
                 Assert.Contains("Connection successful", result.output);
             }
         }
-#endif
 
         [Fact]
         public void ShouldPassUnknownArgumentToScript()
@@ -168,7 +163,7 @@ namespace Dotnet.Script.Tests
 
         [Fact]
         public void ShouldCompileScriptWithReleaseConfiguration()
-        {
+        {            
             var result = ScriptTestRunner.Default.ExecuteFixture("Configuration", "-c release");
             Assert.Contains("false", result.output, StringComparison.OrdinalIgnoreCase);
         }
@@ -290,7 +285,7 @@ namespace Dotnet.Script.Tests
 
             string script =
     @"#r ""nuget: AgileObjects.AgileMapper, 0.25.0""
-#r ""TestLibrary.dll""
+    #r ""TestLibrary.dll""
     
     using AgileObjects.AgileMapper;
 

--- a/src/Dotnet.Script.Tests/TestPathUtils.cs
+++ b/src/Dotnet.Script.Tests/TestPathUtils.cs
@@ -26,7 +26,7 @@ namespace Dotnet.Script.Tests
         {
             var fixtureFolderPath = GetPathToTestFixtureFolder(fixture);
             var pathToFixture = Path.Combine(fixtureFolderPath, $"{Path.GetFileNameWithoutExtension(fixtureFolderPath)}.csx");
-            return Path.GetFullPath(pathToFixture);
+            return pathToFixture;
         }
     }
 }

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -110,7 +110,8 @@ namespace Dotnet.Script
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for initialization. Defaults to current directory.", CommandOptionType.SingleValue);
                 c.OnExecute(() =>
                 {
-                    var scaffolder = new Scaffolder();
+                    var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
+                    var scaffolder = new Scaffolder(logFactory);
                     scaffolder.InitializerFolder(fileName.Value, cwd.Value() ?? Directory.GetCurrentDirectory());
                     return 0;
                 });
@@ -123,7 +124,8 @@ namespace Dotnet.Script
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory the new script file to be created. Defaults to current directory.", CommandOptionType.SingleValue);
                 c.OnExecute(() =>
                 {
-                    var scaffolder = new Scaffolder();
+                    var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
+                    var scaffolder = new Scaffolder(logFactory);
                     if (fileNameArgument.Value == null)
                     {
                         c.ShowHelp();

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -257,9 +257,12 @@ namespace Dotnet.Script
         // directive
         private static String RemoveShebang(String rawCode)
         {
-            if (rawCode.StartsWith("#!/usr/"))
+            if (rawCode.StartsWith("#!/usr/bin/env dotnet-script"))
             {
                 rawCode = rawCode.Substring(rawCode.IndexOf("\n") + 1);
+                // insert extra line after to allow directives to be parsed and 
+                // keep the debugger line numbers the same
+                rawCode = rawCode.Insert(rawCode.IndexOf(Environment.NewLine), Environment.NewLine);
             }
 
             return rawCode;

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -52,11 +52,11 @@ namespace Dotnet.Script
             }
         }
 
-        public static Func<string, bool, LogFactory> CreateLogFactory 
+        public static Func<string, bool, LogFactory> CreateLogFactory
             = (verbosity, debugMode) => LogHelper.CreateLogFactory(debugMode ? "debug" : verbosity);
 
         private static int Wain(string[] args)
-        {           
+        {
             var app = new CommandLineApplication(throwOnUnexpectedArg: false)
             {
                 ExtendedHelpText = "Starting without a path to a CSX file or a command, starts the REPL (interactive) mode."
@@ -71,7 +71,7 @@ namespace Dotnet.Script
             var debugMode = app.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
 
             var verbosity = app.Option("--verbosity", " Set the verbosity level of the command. Allowed values are t[trace], d[ebug], i[nfo], w[arning], e[rror], and c[ritical].", CommandOptionType.SingleValue);
-            
+
             var argsBeforeDoubleHyphen = args.TakeWhile(a => a != "--").ToArray();
             var argsAfterDoubleHypen = args.SkipWhile(a => a != "--").Skip(1).ToArray();
 
@@ -85,7 +85,7 @@ namespace Dotnet.Script
             {
                 c.Description = "Execute CSX code.";
                 var code = c.Argument("code", "Code to execute.");
-                var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for the code compiler. Defaults to current directory.", CommandOptionType.SingleValue);                
+                var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for the code compiler. Defaults to current directory.", CommandOptionType.SingleValue);
                 c.OnExecute(async () =>
                 {
                     int exitCode = 0;
@@ -109,7 +109,7 @@ namespace Dotnet.Script
                 var fileName = c.Argument("filename", "(Optional) The name of the sample script file to be created during initialization. Defaults to 'main.csx'");
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for initialization. Defaults to current directory.", CommandOptionType.SingleValue);
                 c.OnExecute(() =>
-                {                    
+                {
                     var scaffolder = new Scaffolder();
                     scaffolder.InitializerFolder(fileName.Value, cwd.Value() ?? Directory.GetCurrentDirectory());
                     return 0;
@@ -122,7 +122,7 @@ namespace Dotnet.Script
                 var fileNameArgument = c.Argument("filename", "The script file name");
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory the new script file to be created. Defaults to current directory.", CommandOptionType.SingleValue);
                 c.OnExecute(() =>
-                {                    
+                {
                     var scaffolder = new Scaffolder();
                     if (fileNameArgument.Value == null)
                     {
@@ -165,16 +165,17 @@ namespace Dotnet.Script
                     // if a publish directory has been specified, then it is used directly, otherwise:
                     // -- for EXE {current dir}/publish/{runtime ID}
                     // -- for DLL {current dir}/publish
-                    var publishDirectory = publishDirectoryOption.Value() ?? 
+                    var publishDirectory = publishDirectoryOption.Value() ??
                         (dllOption.HasValue() ? Path.Combine(Path.GetDirectoryName(absoluteFilePath), "publish") : Path.Combine(Path.GetDirectoryName(absoluteFilePath), "publish", runtimeIdentifier));
 
                     var absolutePublishDirectory = Path.IsPathRooted(publishDirectory) ? publishDirectory : Path.Combine(Directory.GetCurrentDirectory(), publishDirectory);
 
                     var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
                     var compiler = GetScriptCompiler(publishDebugMode.HasValue(), logFactory);
-                    var scriptEmmiter = new ScriptEmitter(ScriptConsole.Default, compiler);                    
+                    var scriptEmmiter = new ScriptEmitter(ScriptConsole.Default, compiler);
                     var publisher = new ScriptPublisher(logFactory, scriptEmmiter);
-                    var code = SourceText.From(File.ReadAllText(absoluteFilePath));
+                    var rawCode = File.ReadAllText(absoluteFilePath);
+                    var code = SourceText.From(RemoveShebang(rawCode));
                     var context = new ScriptContext(code, absolutePublishDirectory, Enumerable.Empty<string>(), absoluteFilePath, optimizationLevel);
 
                     if (dllOption.HasValue())
@@ -186,7 +187,7 @@ namespace Dotnet.Script
                         publisher.CreateExecutable<int, CommandLineScriptGlobals>(context, logFactory, runtimeIdentifier);
                     }
 
-                    return 0;                  
+                    return 0;
                 });
             });
 
@@ -208,7 +209,7 @@ namespace Dotnet.Script
                         var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
 
                         var absoluteFilePath = Path.IsPathRooted(dllPath.Value) ? dllPath.Value : Path.Combine(Directory.GetCurrentDirectory(), dllPath.Value);
-                       
+
                         var compiler = GetScriptCompiler(commandDebugMode.HasValue(), logFactory);
                         var runner = new ScriptRunner(compiler, logFactory, ScriptConsole.Default);
                         var result = await runner.Execute<int>(absoluteFilePath, app.RemainingArguments.Concat(argsAfterDoubleHypen));
@@ -245,9 +246,23 @@ namespace Dotnet.Script
                 }
                 return exitCode;
             });
-            
+
 
             return app.Execute(argsBeforeDoubleHyphen);
+        }
+
+        // on osx/linux the shebang #!/usr/bin/env dotnet-script is a text file convention 
+        // which tells the system what program to use to interpret the content of a file marked as +x
+        // this function strips that out the shebang so that the compiler doesn't try to interpet as a 
+        // directive
+        private static String RemoveShebang(String rawCode)
+        {
+            if (rawCode.StartsWith("#!/usr/"))
+            {
+                rawCode = rawCode.Substring(rawCode.IndexOf("\n") + 1);
+            }
+
+            return rawCode;
         }
 
         private static async Task<int> RunScript(string file, bool debugMode, LogFactory logFactory, OptimizationLevel optimizationLevel, IEnumerable<string> args, bool interactive, string[] packageSources)
@@ -267,21 +282,19 @@ namespace Dotnet.Script
             var absoluteFilePath = Path.IsPathRooted(file) ? file : Path.Combine(Directory.GetCurrentDirectory(), file);
             var directory = Path.GetDirectoryName(absoluteFilePath);
 
-            using (var filestream = new FileStream(absoluteFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            var rawCode = File.ReadAllText(absoluteFilePath);
+            var sourceText = SourceText.From(RemoveShebang(rawCode));
+            var context = new ScriptContext(sourceText, directory, args, absoluteFilePath, optimizationLevel, packageSources: packageSources);
+            if (interactive)
             {
-                var sourceText = SourceText.From(filestream);
-                var context = new ScriptContext(sourceText, directory, args, absoluteFilePath, optimizationLevel, packageSources: packageSources);               
-                if (interactive)
-                {
-                    var compiler = GetScriptCompiler(debugMode, logFactory);
-                    
-                    var runner = new InteractiveRunner(compiler, logFactory, ScriptConsole.Default, packageSources);
-                    await runner.RunLoopWithSeed(context);
-                    return 0;
-                }
+                var compiler = GetScriptCompiler(debugMode, logFactory);
 
-                return await Run(debugMode, logFactory,  context);
+                var runner = new InteractiveRunner(compiler, logFactory, ScriptConsole.Default, packageSources);
+                await runner.RunLoopWithSeed(context);
+                return 0;
             }
+
+            return await Run(debugMode, logFactory, context);
         }
 
         private static bool IsHttpUri(string fileName)
@@ -297,9 +310,9 @@ namespace Dotnet.Script
             await runner.RunLoop();
         }
 
-        private static Task<int> RunCode(string code, bool debugMode, LogFactory logFactory,  OptimizationLevel optimizationLevel, IEnumerable<string> args, string currentWorkingDirectory, string[] packageSources)
-        {            
-            var sourceText = SourceText.From(code);            
+        private static Task<int> RunCode(string code, bool debugMode, LogFactory logFactory, OptimizationLevel optimizationLevel, IEnumerable<string> args, string currentWorkingDirectory, string[] packageSources)
+        {
+            var sourceText = SourceText.From(RemoveShebang(code));
             var context = new ScriptContext(sourceText, currentWorkingDirectory ?? Directory.GetCurrentDirectory(), args, null, optimizationLevel, ScriptMode.Eval, packageSources: packageSources);
             return Run(debugMode, logFactory, context);
         }
@@ -331,10 +344,10 @@ namespace Dotnet.Script
         }
 
         private static ScriptCompiler GetScriptCompiler(bool debugMode, LogFactory logFactory)
-        {          
+        {
             var runtimeDependencyResolver = new RuntimeDependencyResolver(logFactory);
             var compiler = new ScriptCompiler(logFactory, runtimeDependencyResolver);
             return compiler;
-        }       
+        }
     }
 }

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -175,7 +175,7 @@ namespace Dotnet.Script
                     var scriptEmmiter = new ScriptEmitter(ScriptConsole.Default, compiler);
                     var publisher = new ScriptPublisher(logFactory, scriptEmmiter);
                     var rawCode = File.ReadAllText(absoluteFilePath);
-                    var code = SourceText.From(RemoveShebang(rawCode));
+                    var code = SourceText.From(rawCode);
                     var context = new ScriptContext(code, absolutePublishDirectory, Enumerable.Empty<string>(), absoluteFilePath, optimizationLevel);
 
                     if (dllOption.HasValue())
@@ -251,23 +251,6 @@ namespace Dotnet.Script
             return app.Execute(argsBeforeDoubleHyphen);
         }
 
-        // on osx/linux the shebang #!/usr/bin/env dotnet-script is a text file convention 
-        // which tells the system what program to use to interpret the content of a file marked as +x
-        // this function strips that out the shebang so that the compiler doesn't try to interpet as a 
-        // directive
-        private static String RemoveShebang(String rawCode)
-        {
-            if (rawCode.StartsWith("#!/usr/bin/env dotnet-script"))
-            {
-                rawCode = rawCode.Substring(rawCode.IndexOf("\n") + 1);
-                // insert extra line after to allow directives to be parsed and 
-                // keep the debugger line numbers the same
-                rawCode = rawCode.Insert(rawCode.IndexOf(Environment.NewLine), Environment.NewLine);
-            }
-
-            return rawCode;
-        }
-
         private static async Task<int> RunScript(string file, bool debugMode, LogFactory logFactory, OptimizationLevel optimizationLevel, IEnumerable<string> args, bool interactive, string[] packageSources)
         {
             if (!File.Exists(file))
@@ -286,7 +269,7 @@ namespace Dotnet.Script
             var directory = Path.GetDirectoryName(absoluteFilePath);
 
             var rawCode = File.ReadAllText(absoluteFilePath);
-            var sourceText = SourceText.From(RemoveShebang(rawCode));
+            var sourceText = SourceText.From(rawCode);
             var context = new ScriptContext(sourceText, directory, args, absoluteFilePath, optimizationLevel, packageSources: packageSources);
             if (interactive)
             {
@@ -315,7 +298,7 @@ namespace Dotnet.Script
 
         private static Task<int> RunCode(string code, bool debugMode, LogFactory logFactory, OptimizationLevel optimizationLevel, IEnumerable<string> args, string currentWorkingDirectory, string[] packageSources)
         {
-            var sourceText = SourceText.From(RemoveShebang(code));
+            var sourceText = SourceText.From(code);
             var context = new ScriptContext(sourceText, currentWorkingDirectory ?? Directory.GetCurrentDirectory(), args, null, optimizationLevel, ScriptMode.Eval, packageSources: packageSources);
             return Run(debugMode, logFactory, context);
         }


### PR DESCRIPTION
**On windows**
* change dotnet-init to register .csx files to be handled by dotnet-script in the registry

**On Mac/Linux**
* change dotnet-init to add a donet-script shebang instruction to the csx files on init
* change dotnet-init mark the new csx file as executable via chmod command
* strip the shebang off the source code before sending to the compiler