### PR TITLE
Fix source file lock & scope

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -361,7 +361,9 @@ namespace Dotnet.Script
 
             SourceText sourceText;
             using (var filestream = File.OpenRead(absoluteFilePath))
+            {
                 sourceText = SourceText.From(filestream);
+            }
 
             var context = new ScriptContext(sourceText, directory, args, absoluteFilePath, optimizationLevel, packageSources: packageSources);
             if (interactive)

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -359,21 +359,21 @@ namespace Dotnet.Script
             var absoluteFilePath = Path.IsPathRooted(file) ? file : Path.Combine(Directory.GetCurrentDirectory(), file);
             var directory = Path.GetDirectoryName(absoluteFilePath);
 
+            SourceText sourceText;
             using (var filestream = File.OpenRead(absoluteFilePath))
+                sourceText = SourceText.From(filestream);
+
+            var context = new ScriptContext(sourceText, directory, args, absoluteFilePath, optimizationLevel, packageSources: packageSources);
+            if (interactive)
             {
-                var sourceText = SourceText.From(filestream);
-                var context = new ScriptContext(sourceText, directory, args, absoluteFilePath, optimizationLevel, packageSources: packageSources);
-                if (interactive)
-                {
-                    var compiler = GetScriptCompiler(debugMode, logFactory);
+                var compiler = GetScriptCompiler(debugMode, logFactory);
 
-                    var runner = new InteractiveRunner(compiler, logFactory, ScriptConsole.Default, packageSources);
-                    await runner.RunLoopWithSeed(context);
-                    return 0;
-                }
-
-                return await Run(debugMode, logFactory, context);
+                var runner = new InteractiveRunner(compiler, logFactory, ScriptConsole.Default, packageSources);
+                await runner.RunLoopWithSeed(context);
+                return 0;
             }
+
+            return await Run(debugMode, logFactory, context);
         }
 
         private static bool IsHttpUri(string fileName)

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -359,7 +359,7 @@ namespace Dotnet.Script
             var absoluteFilePath = Path.IsPathRooted(file) ? file : Path.Combine(Directory.GetCurrentDirectory(), file);
             var directory = Path.GetDirectoryName(absoluteFilePath);
 
-            using (var filestream = new FileStream(absoluteFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var filestream = File.OpenRead(absoluteFilePath))
             {
                 var sourceText = SourceText.From(filestream);
                 var context = new ScriptContext(sourceText, directory, args, absoluteFilePath, optimizationLevel, packageSources: packageSources);


### PR DESCRIPTION
This fixes two problems:

- It forbids write-access to the source file while it is being used to avoid corruption if a script is open in an editor or being written to at the same time as the duration of its execution.
- It reduces the scope & time during which the source file is open for reading and locked; especially, it doesn't need to be kept open and locked during its entire execution.

The changes assume that `SourceText.From` buffers the entire source to memory. I say _assume_ because it's not clearly stated or documented anywhere so it's what I could figure out from reading [the source code](https://github.com/dotnet/roslyn/blob/Visual-Studio-2017-Version-15.8/src/Compilers/Core/Portable/Text/SourceText.cs). The [only comment in the remarks section](https://github.com/dotnet/roslyn/blob/Visual-Studio-2017-Version-15.8/src/Compilers/Core/Portable/Text/SourceText.cs#L165
) doesn't say much either:

> Reads from the beginning of the stream. Leaves the stream open.

If the assumption seems risky in case the behaviour changes with a future version, it might be just simpler to use the `SourceText.From` overload taking a string or a byte array.