### PR TITLE
Add static modifier to Program

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace Dotnet.Script
 {
-    public class Program
+    public static class Program
     {
         private const string DebugFlagShort = "-d";
         private const string DebugFlagLong = "--debug";


### PR DESCRIPTION
Because it doesn't have an instance-based state or methods and marking `Program` static makes that very clear and should be kept so.