### PR TITLE
Make case-insensitive string checks deterministic

### DIFF
--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -3,12 +3,21 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace Dotnet.Script
 {
+    using System.Collections.Generic;
+
     static class Extensions
     {
-        public static bool ValueEquals(this CommandOption option, string value, StringComparison comparison)
+        public static bool ValueEquals(this CommandOption option, Func<string, bool> predicate)
         {
             if (option == null) throw new ArgumentNullException(nameof(option));
-            return option.HasValue() && string.Equals(option.Value(), value, comparison);
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            return option.HasValue() && predicate(option.Value());
+        }
+
+        public static Func<T, bool> PredicateEquals<T>(this IEqualityComparer<T> comparer, T first)
+        {
+            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+            return second => comparer.Equals(first);
         }
     }
 }

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -1,0 +1,11 @@
+namespace Dotnet.Script
+{
+    using System;
+    using McMaster.Extensions.CommandLineUtils;
+
+    static class Extensions
+    {
+        public static bool ValueEquals(this CommandOption option, string value, StringComparison comparison) =>
+            option.HasValue() && string.Equals(option.Value(), value, comparison);
+    }
+}

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -3,21 +3,12 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace Dotnet.Script
 {
-    using System.Collections.Generic;
-
     static class Extensions
     {
-        public static bool ValueEquals(this CommandOption option, Func<string, bool> predicate)
+        public static bool ValueEquals(this CommandOption option, string value, StringComparison comparison)
         {
             if (option == null) throw new ArgumentNullException(nameof(option));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            return option.HasValue() && predicate(option.Value());
-        }
-
-        public static Func<T, bool> PredicateEquals<T>(this IEqualityComparer<T> comparer, T first)
-        {
-            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
-            return second => comparer.Equals(first);
+            return option.HasValue() && string.Equals(option.Value(), value, comparison);
         }
     }
 }

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -17,7 +17,7 @@ namespace Dotnet.Script
         public static Func<T, bool> PredicateEquals<T>(this IEqualityComparer<T> comparer, T first)
         {
             if (comparer == null) throw new ArgumentNullException(nameof(comparer));
-            return second => comparer.Equals(first, second);
+            return second => comparer.Equals(first);
         }
     }
 }

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -1,8 +1,8 @@
+using System;
+using McMaster.Extensions.CommandLineUtils;
+
 namespace Dotnet.Script
 {
-    using System;
-    using McMaster.Extensions.CommandLineUtils;
-
     static class Extensions
     {
         public static bool ValueEquals(this CommandOption option, string value, StringComparison comparison) =>

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -5,7 +5,10 @@ namespace Dotnet.Script
 {
     static class Extensions
     {
-        public static bool ValueEquals(this CommandOption option, string value, StringComparison comparison) =>
-            option.HasValue() && string.Equals(option.Value(), value, comparison);
+        public static bool ValueEquals(this CommandOption option, string value, StringComparison comparison)
+        {
+            if (option == null) throw new ArgumentNullException(nameof(option));
+            return option.HasValue() && string.Equals(option.Value(), value, comparison);
+        }
     }
 }

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -17,7 +17,7 @@ namespace Dotnet.Script
         public static Func<T, bool> PredicateEquals<T>(this IEqualityComparer<T> comparer, T first)
         {
             if (comparer == null) throw new ArgumentNullException(nameof(comparer));
-            return second => comparer.Equals(first);
+            return second => comparer.Equals(first, second);
         }
     }
 }

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -69,6 +69,7 @@ namespace Dotnet.Script
             var interactive = app.Option("-i | --interactive", "Execute a script and drop into the interactive mode afterwards.", CommandOptionType.NoValue);
 
             var configuration = app.Option("-c | --configuration <configuration>", "Configuration to use for running the script [Release/Debug] Default is \"Debug\"", CommandOptionType.SingleValue);
+            var release = StringComparer.OrdinalIgnoreCase.PredicateEquals("release");
 
             var packageSources = app.Option("-s | --sources <SOURCE>", "Specifies a NuGet package source to use when resolving NuGet packages.", CommandOptionType.MultipleValue);
 
@@ -98,7 +99,7 @@ namespace Dotnet.Script
                     if (!string.IsNullOrWhiteSpace(code.Value))
                     {
                         var optimizationLevel = OptimizationLevel.Debug;
-                        if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
+                        if (configuration.ValueEquals(release))
                         {
                             optimizationLevel = OptimizationLevel.Release;
                         }
@@ -162,7 +163,7 @@ namespace Dotnet.Script
                     }
 
                     var optimizationLevel = OptimizationLevel.Debug;
-                    if (commandConfig.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
+                    if (commandConfig.ValueEquals(release))
                     {
                         optimizationLevel = OptimizationLevel.Release;
                     }
@@ -243,7 +244,7 @@ namespace Dotnet.Script
                     if (Debugger.IsAttached || nocache.HasValue())
                     {
                         var optimizationLevel = OptimizationLevel.Debug;
-                        if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
+                        if (configuration.ValueEquals(release))
                         {
                             optimizationLevel = OptimizationLevel.Release;
                         }
@@ -307,7 +308,7 @@ namespace Dotnet.Script
                         {
                             // then we autopublish into the %temp%\dotnet-scripts\{uniqueFolderName} path
                             var optimizationLevel = OptimizationLevel.Debug;
-                            if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
+                            if (configuration.ValueEquals(release))
                             {
                                 optimizationLevel = OptimizationLevel.Release;
                             }

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -69,7 +69,6 @@ namespace Dotnet.Script
             var interactive = app.Option("-i | --interactive", "Execute a script and drop into the interactive mode afterwards.", CommandOptionType.NoValue);
 
             var configuration = app.Option("-c | --configuration <configuration>", "Configuration to use for running the script [Release/Debug] Default is \"Debug\"", CommandOptionType.SingleValue);
-            var release = StringComparer.OrdinalIgnoreCase.PredicateEquals("release");
 
             var packageSources = app.Option("-s | --sources <SOURCE>", "Specifies a NuGet package source to use when resolving NuGet packages.", CommandOptionType.MultipleValue);
 
@@ -99,7 +98,7 @@ namespace Dotnet.Script
                     if (!string.IsNullOrWhiteSpace(code.Value))
                     {
                         var optimizationLevel = OptimizationLevel.Debug;
-                        if (configuration.ValueEquals(release))
+                        if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                         {
                             optimizationLevel = OptimizationLevel.Release;
                         }
@@ -163,7 +162,7 @@ namespace Dotnet.Script
                     }
 
                     var optimizationLevel = OptimizationLevel.Debug;
-                    if (commandConfig.ValueEquals(release))
+                    if (commandConfig.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                     {
                         optimizationLevel = OptimizationLevel.Release;
                     }
@@ -244,7 +243,7 @@ namespace Dotnet.Script
                     if (Debugger.IsAttached || nocache.HasValue())
                     {
                         var optimizationLevel = OptimizationLevel.Debug;
-                        if (configuration.ValueEquals(release))
+                        if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                         {
                             optimizationLevel = OptimizationLevel.Release;
                         }
@@ -308,7 +307,7 @@ namespace Dotnet.Script
                         {
                             // then we autopublish into the %temp%\dotnet-scripts\{uniqueFolderName} path
                             var optimizationLevel = OptimizationLevel.Debug;
-                            if (configuration.ValueEquals(release))
+                            if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                             {
                                 optimizationLevel = OptimizationLevel.Release;
                             }

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -98,7 +98,7 @@ namespace Dotnet.Script
                     if (!string.IsNullOrWhiteSpace(code.Value))
                     {
                         var optimizationLevel = OptimizationLevel.Debug;
-                        if (configuration.HasValue() && configuration.Value().ToLower() == "release")
+                        if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                         {
                             optimizationLevel = OptimizationLevel.Release;
                         }
@@ -162,7 +162,7 @@ namespace Dotnet.Script
                     }
 
                     var optimizationLevel = OptimizationLevel.Debug;
-                    if (commandConfig.HasValue() && commandConfig.Value().ToLower() == "release")
+                    if (commandConfig.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                     {
                         optimizationLevel = OptimizationLevel.Release;
                     }
@@ -243,7 +243,7 @@ namespace Dotnet.Script
                     if (Debugger.IsAttached || nocache.HasValue())
                     {
                         var optimizationLevel = OptimizationLevel.Debug;
-                        if (configuration.HasValue() && configuration.Value().ToLower() == "release")
+                        if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                         {
                             optimizationLevel = OptimizationLevel.Release;
                         }
@@ -307,7 +307,7 @@ namespace Dotnet.Script
                         {
                             // then we autopublish into the %temp%\dotnet-scripts\{uniqueFolderName} path
                             var optimizationLevel = OptimizationLevel.Debug;
-                            if (configuration.HasValue() && configuration.Value().ToLower() == "release")
+                            if (configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase))
                             {
                                 optimizationLevel = OptimizationLevel.Release;
                             }


### PR DESCRIPTION
Because [`String.ToLower`](https://docs.microsoft.com/en-us/dotnet/api/system.string.tolower?view=netstandard-2.0#System_String_ToLower) is, per its documentation, culture-specific:

> ## Remarks
>
> This method takes into account the casing rules of the current culture.
