### PR TITLE
Use just the content hash for cached publication

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
@@ -4,6 +4,8 @@ using Dotnet.Script.DependencyModel.ProjectSystem;
 
 namespace Dotnet.Script.Tests
 {
+    using System.Linq;
+
     public class ScriptFilesResolverTests
     {
         [Fact]
@@ -17,7 +19,7 @@ namespace Dotnet.Script.Tests
 
                 var files = scriptFilesResolver.GetScriptFiles(rootScript);
 
-                Assert.True(files.Count == 1);
+                Assert.Single(files);
                 Assert.Contains(files, f => f.Contains("Foo.csx"));
                 Assert.Contains(files, f => !f.Contains("Bar.csx"));
             }
@@ -33,9 +35,8 @@ namespace Dotnet.Script.Tests
 
                 var files = scriptFilesResolver.GetScriptFiles(rootScript);
 
-                Assert.True(files.Count == 2);
-                Assert.Contains(files, f => f.Contains("Foo.csx"));
-                Assert.Contains(files, f => f.Contains("Bar.csx"));
+                Assert.Equal(2, files.Count);
+                Assert.Equal(new[] { "Foo.csx", "Bar.csx" }, files.Select(Path.GetFileName));
             }
         }
 
@@ -52,9 +53,8 @@ namespace Dotnet.Script.Tests
                 var scriptFilesResolver = new ScriptFilesResolver();
                 var files = scriptFilesResolver.GetScriptFiles(rootScript);
 
-                Assert.True(files.Count == 2);
-                Assert.Contains(files, f => f.Contains("Foo.csx"));
-                Assert.Contains(files, f => f.Contains("Bar.csx"));
+                Assert.Equal(2, files.Count);
+                Assert.Equal(new[] { "Foo.csx", "Bar.csx" }, files.Select(Path.GetFileName));
             }
         }
 
@@ -72,9 +72,8 @@ namespace Dotnet.Script.Tests
                 var scriptFilesResolver = new ScriptFilesResolver();
                 var files = scriptFilesResolver.GetScriptFiles(rootScript);
 
-                Assert.True(files.Count == 2);
-                Assert.Contains(files, f => f.Contains("Foo.csx"));
-                Assert.Contains(files, f => f.Contains("Bar.csx"));
+                Assert.Equal(2, files.Count);
+                Assert.Equal(new[] { "Foo.csx", "Bar.csx" }, files.Select(Path.GetFileName));
             }
         }
 

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -4,9 +4,5 @@ namespace Dotnet.Script
 {
     static class Extensions
     {
-        public static string ToHexadecimalString(this byte[] bytes) =>
-            BitConverter.ToString(bytes)
-                        .Replace("-", string.Empty)
-                        .ToLowerInvariant();
     }
 }

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Dotnet.Script
+{
+    static class Extensions
+    {
+        public static string ToHexadecimalString(this byte[] bytes) =>
+            BitConverter.ToString(bytes)
+                        .Replace("-", string.Empty)
+                        .ToLowerInvariant();
+    }
+}

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -1,8 +1,18 @@
-using System;
+using System.IO;
 
 namespace Dotnet.Script
 {
+    using System;
+
     static class Extensions
     {
+        public static bool CreateIfMissing(this DirectoryInfo directory)
+        {
+            if (directory == null) throw new ArgumentNullException(nameof(directory));
+            if (directory.Exists)
+                return false;
+            directory.Create();
+            return true;
+        }
     }
 }

--- a/src/Dotnet.Script/Extensions.cs
+++ b/src/Dotnet.Script/Extensions.cs
@@ -1,9 +1,8 @@
+using System;
 using System.IO;
 
 namespace Dotnet.Script
 {
-    using System;
-
     static class Extensions
     {
         public static bool CreateIfMissing(this DirectoryInfo directory)

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -280,7 +280,7 @@ namespace Dotnet.Script
                                         .ToLowerInvariant();
 
                         string cacheFolder = Path.Combine(Path.GetTempPath(), "dotnet-scripts");
-                        string publishDirectory = Path.Combine(cacheFolder, sourceHash);
+                        DirectoryInfo publishDirectory = new DirectoryInfo(Path.Combine(cacheFolder, sourceHash));
 
                         if (scriptUrl != null) // was downloaded?
                         {
@@ -290,7 +290,10 @@ namespace Dotnet.Script
                             {
                                 filename = "script.csx";
                             }
-                            absoluteSourcePath = Path.Combine(publishDirectory, filename);
+                            
+                            publishDirectory.CreateIfMissing();
+
+                            absoluteSourcePath = Path.Combine(publishDirectory.FullName, filename);
                             var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
                             using (var writer = new StreamWriter(absoluteSourcePath, append: false, encoding))
                             {
@@ -299,7 +302,7 @@ namespace Dotnet.Script
                         }
 
                         // given the path to a script we create a %temp%\dotnet-scripts\{uniqueFolderName} path
-                        string pathToDll = Path.Combine(publishDirectory, "script.dll");
+                        string pathToDll = Path.Combine(publishDirectory.FullName, "script.dll");
 
                         // get hash code from previous run 
                         var compiler = GetScriptCompiler(true, logFactory);
@@ -307,10 +310,7 @@ namespace Dotnet.Script
                         // if we haven't created a dll
                         if (!File.Exists(pathToDll))
                         {
-                            if (!Directory.Exists(publishDirectory))
-                            {
-                                Directory.CreateDirectory(publishDirectory);
-                            }
+                            publishDirectory.CreateIfMissing();
 
                             // then we autopublish into the %temp%\dotnet-scripts\{uniqueFolderName} path
                             var optimizationLevel = OptimizationLevel.Debug;

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -322,7 +322,7 @@ namespace Dotnet.Script
                             var runtimeIdentifier = ScriptEnvironment.Default.RuntimeIdentifier;
                             var scriptEmmiter = new ScriptEmitter(ScriptConsole.Default, compiler);
                             var publisher = new ScriptPublisher(logFactory, scriptEmmiter);
-                            var context = new ScriptContext(code, publishDirectory, Enumerable.Empty<string>(), absoluteSourcePath, optimizationLevel);
+                            var context = new ScriptContext(code, publishDirectory.FullName, Enumerable.Empty<string>(), absoluteSourcePath, optimizationLevel);
 
                             // create the assembly in our cache folder
                             publisher.CreateAssembly<int, CommandLineScriptGlobals>(context, logFactory, Path.GetFileNameWithoutExtension(pathToDll));

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -256,7 +256,8 @@ namespace Dotnet.Script
                         string uniqueFolderName = "";
                         using (var sha = SHA256.Create())
                         {
-                            uniqueFolderName = Convert.ToBase64String(sha.ComputeHash(Encoding.Unicode.GetBytes(file.Value))).Replace("=", String.Empty).Replace("/", string.Empty);
+                            uniqueFolderName = sha.ComputeHash(Encoding.UTF8.GetBytes(file.Value))
+                                                  .ToHexadecimalString();
                         }
 
                         string publishDirectory = Path.Combine(cacheFolder, uniqueFolderName);
@@ -292,7 +293,7 @@ namespace Dotnet.Script
                         string pathToDll = Path.Combine(publishDirectory, Path.GetFileNameWithoutExtension(absoluteSourcePath) + ".dll");
 
                         // source hash is the checkSum of the code
-                        string sourceHash = Convert.ToBase64String(code.GetChecksum().ToArray());
+                        string sourceHash = code.GetChecksum().ToArray().ToHexadecimalString();
 
                         // get hash code from previous run 
                         string hashCache = Path.Combine(publishDirectory, ".hash");


### PR DESCRIPTION
This builds on top of the great addition in PR #342 by @tomlm.

I didn't understand the benefits of maintaining two hashes in #342, one of the script's path and the other of the script's content. This PR uses just the latter (hash of the script content) as part of the path to the cached DLL, yielding the following advantages:

1. The script can be moved or copied around the file system and the cache will be hit so long as it's the same content!

2. It avoids locking issues when updating the source of long-running scripts (which includes simple scripts having a call to `Console.ReadLine()`at the end). For example, if a script takes some time to run, I'm not able to edit and update it. The implementation in #345 fails due to locking issues, at least on Windows. With this PR, the change in the content will mean a separately published/cached version will run without interfering with existing one!

These advantages are even more pronounced when you think of a repo of C# scripts where you can switch between branches & run different versions of scripts without affecting those already in flight. The cache will help even more when switching between different versions.

This PR also changes the encoding of the hash bytes in text from Base64 to the more conventional hexadecimal. If it needs to be made shorter then [Base32](https://crockford.com/wrmg/base32.html) would be a better compromise.
