### PR TITLE
Use case-insensitivity for PackageReference Id & Version

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/PackageReference.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/PackageReference.cs
@@ -1,9 +1,11 @@
-﻿namespace Dotnet.Script.DependencyModel.ProjectSystem
+﻿using System;
+
+namespace Dotnet.Script.DependencyModel.ProjectSystem
 {
     /// <summary>
     /// Represents a NuGet package reference found in a script file.
     /// </summary>
-    public class PackageReference
+    public class PackageReference : IEquatable<PackageReference>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PackageReference"/> class.
@@ -36,14 +38,24 @@
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return Id.GetHashCode() ^ Version.GetHashCode() ^ Origin.GetHashCode();
+            var stringComparer = StringComparer.OrdinalIgnoreCase;
+            return stringComparer.GetHashCode(Id)
+                 ^ stringComparer.GetHashCode(Version)
+                 ^ Origin.GetHashCode();
         }
 
-        /// <inheritdoc />
+        public bool Equals(PackageReference other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(Version, other.Version, StringComparison.OrdinalIgnoreCase)
+                && Origin == other.Origin;
+        }
+
         public override bool Equals(object obj)
         {
-            var other = (PackageReference)obj;
-            return other.Id == Id && other.Version == Version && other.Origin == Origin;
+            return Equals(obj as PackageReference);
         }
     }
 }

--- a/src/Dotnet.Script.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptParserTests.cs
@@ -42,6 +42,24 @@ namespace Dotnet.Script.Tests
             Assert.Equal("1.2.3", result.PackageReferences.Single().Version);
         }
 
+        [Theory]
+        [InlineData("Package", "1.2.3-beta-1")]
+        [InlineData("PACKAGE", "1.2.3-beta-1")]
+        [InlineData("Package", "1.2.3-BETA-1")]
+        public void ShouldResolveUniquePackages(string id, string version)
+        {
+            var parser = CreateParser();
+            var code = new StringBuilder();
+            code.AppendLine("#r \"nuget:Package, 1.2.3-beta-1\"");
+            code.AppendLine($"#r \"nuget:{id}, {version}\"");
+
+            var result = parser.ParseFromCode(code.ToString());
+
+            Assert.Equal(1, result.PackageReferences.Count);
+            Assert.Equal("Package", result.PackageReferences.Single().Id);
+            Assert.Equal("1.2.3-beta-1", result.PackageReferences.Single().Version);
+        }
+
         [Fact]
         public void ShouldResolveMultiplePackages()
         {


### PR DESCRIPTION
This PR fixes the `PackageReference` implementation by making `Id` and `Version` case-insensitive when comparing for equality and computing the hash code. This in turn fixes `ScriptParser`'s ability to see unique references without regard to case differences, which is proven through newly added tests.

As a bonus, `PackageReference` also implements `IEquatable<PackageReference>`.