### PR TITLE
Fix for regular expression issues in ScriptParser

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -69,7 +69,8 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         const string DirectivePatternPrefix = @"^"
                                             + Hws + @"*#";
         const string DirectivePatternSuffix = Hws + @"*""nuget:"
-                                            + Hws + @"*(.+?)"
+                                            // https://github.com/NuGet/docs.microsoft.com-nuget/issues/543#issue-270039223
+                                            + Hws + @"*(\w+(?:[_.-]\w+)*)"
                                             + Hws + @"*,"
                                             + Hws + @"*(.+?)""";
 

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -102,7 +102,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static string ReadTargetFramework(string fileContent)
         {
-            const string pattern = @"^\s*#!\s*""(.*)""";
+            const string pattern = @"^" + Hws + @"*#!" + Hws + @"*""(.*)""";
             var match = Regex.Match(fileContent, pattern);
             if (match.Success)
             {

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -64,9 +64,17 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             return new ParseResult(allPackageReferences, currentTargetFramework);
         }
 
+        const string Hws = @"[\x20\t]"; // hws = horizontal whitespace
+
         private static IEnumerable<PackageReference> ReadPackageReferencesFromReferenceDirective(string fileContent)
         {
-            const string pattern = @"^\s*#r\s*""nuget:\s*(.+)\s*,\s*(.*)""";
+            const string pattern = @"^"
+                                 + Hws + @"*#r"
+                                 + Hws + @"*""nuget:"
+                                 + Hws + @"*(.+)"
+                                 + Hws + @"*,"
+                                 + Hws + @"*(.*)""";
+
             var matches = Regex.Matches(fileContent, pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
             foreach (var match in matches.Cast<Match>())
@@ -80,7 +88,13 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static IEnumerable<PackageReference> ReadPackageReferencesFromLoadDirective(string fileContent)
         {
-            const string pattern = @"^\s*#load\s*""nuget:\s*(.+)\s*,\s*(.*)""";
+            const string pattern = @"^"
+                                 + Hws + @"*#load"
+                                 + Hws + @"*""nuget:"
+                                 + Hws + @"*(.+)"
+                                 + Hws + @"*,"
+                                 + Hws + @"*(.*)""";
+
             var matches = Regex.Matches(fileContent, pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
             foreach (var match in matches.Cast<Match>())

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -69,9 +69,9 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         const string DirectivePatternPrefix = @"^"
                                             + Hws + @"*#";
         const string DirectivePatternSuffix = Hws + @"*""nuget:"
-                                            + Hws + @"*(.+)"
+                                            + Hws + @"*(.+?)"
                                             + Hws + @"*,"
-                                            + Hws + @"*(.*)""";
+                                            + Hws + @"*(.+?)""";
 
         private static IEnumerable<PackageReference> ReadPackageReferencesFromReferenceDirective(string fileContent)
         {

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -66,27 +66,22 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         const string Hws = @"[\x20\t]"; // hws = horizontal whitespace
 
+        const string DirectivePatternPrefix = @"^"
+                                            + Hws + @"*#";
+        const string DirectivePatternSuffix = Hws + @"*""nuget:"
+                                            + Hws + @"*(.+)"
+                                            + Hws + @"*,"
+                                            + Hws + @"*(.*)""";
+
         private static IEnumerable<PackageReference> ReadPackageReferencesFromReferenceDirective(string fileContent)
         {
-            const string pattern = @"^"
-                                 + Hws + @"*#r"
-                                 + Hws + @"*""nuget:"
-                                 + Hws + @"*(.+)"
-                                 + Hws + @"*,"
-                                 + Hws + @"*(.*)""";
-
+            const string pattern = DirectivePatternPrefix + "r" + DirectivePatternSuffix;
             return ReadPackageReferencesFromDirective(PackageOrigin.ReferenceDirective, pattern, fileContent);
         }
 
         private static IEnumerable<PackageReference> ReadPackageReferencesFromLoadDirective(string fileContent)
         {
-            const string pattern = @"^"
-                                 + Hws + @"*#load"
-                                 + Hws + @"*""nuget:"
-                                 + Hws + @"*(.+)"
-                                 + Hws + @"*,"
-                                 + Hws + @"*(.*)""";
-
+            const string pattern = DirectivePatternPrefix + "load" + DirectivePatternSuffix;
             return ReadPackageReferencesFromDirective(PackageOrigin.LoadDirective, pattern, fileContent);
         }
 

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -75,15 +75,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
                                  + Hws + @"*,"
                                  + Hws + @"*(.*)""";
 
-            var matches = Regex.Matches(fileContent, pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
-
-            foreach (var match in matches.Cast<Match>())
-            {
-                var id = match.Groups[1].Value;
-                var version = match.Groups[2].Value;
-                var packageReference = new PackageReference(id, version, PackageOrigin.ReferenceDirective);
-                yield return packageReference;
-            }
+            return ReadPackageReferencesFromDirective(PackageOrigin.ReferenceDirective, pattern, fileContent);
         }
 
         private static IEnumerable<PackageReference> ReadPackageReferencesFromLoadDirective(string fileContent)
@@ -95,13 +87,19 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
                                  + Hws + @"*,"
                                  + Hws + @"*(.*)""";
 
+            return ReadPackageReferencesFromDirective(PackageOrigin.LoadDirective, pattern, fileContent);
+        }
+
+        private static IEnumerable<PackageReference> ReadPackageReferencesFromDirective(PackageOrigin origin,
+            string pattern, string fileContent)
+        {
             var matches = Regex.Matches(fileContent, pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
             foreach (var match in matches.Cast<Match>())
             {
                 var id = match.Groups[1].Value;
                 var version = match.Groups[2].Value;
-                var packageReference = new PackageReference(id, version, PackageOrigin.LoadDirective);
+                var packageReference = new PackageReference(id, version, origin);
                 yield return packageReference;
             }
         }

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -64,15 +64,15 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             return new ParseResult(allPackageReferences, currentTargetFramework);
         }
 
-        const string Hws = @"[\x20\t]"; // hws = horizontal whitespace
+        const string Hws = @"[\x20\t]*"; // hws = horizontal whitespace
 
         const string DirectivePatternPrefix = @"^"
-                                            + Hws + @"*#";
-        const string DirectivePatternSuffix = Hws + @"*""nuget:"
+                                            + Hws + @"#";
+        const string DirectivePatternSuffix = Hws + @"""nuget:"
                                             // https://github.com/NuGet/docs.microsoft.com-nuget/issues/543#issue-270039223
-                                            + Hws + @"*(\w+(?:[_.-]\w+)*)"
-                                            + Hws + @"*,"
-                                            + Hws + @"*(.+?)""";
+                                            + Hws + @"(\w+(?:[_.-]\w+)*)"
+                                            + Hws + @","
+                                            + Hws + @"(.+?)""";
 
         private static IEnumerable<PackageReference> ReadPackageReferencesFromReferenceDirective(string fileContent)
         {
@@ -102,7 +102,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static string ReadTargetFramework(string fileContent)
         {
-            const string pattern = @"^" + Hws + @"*#!" + Hws + @"*""(.*)""";
+            const string pattern = @"^" + Hws + @"#!" + Hws + @"""(.*)""";
             var match = Regex.Match(fileContent, pattern);
             if (match.Success)
             {

--- a/src/Dotnet.Script.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptParserTests.cs
@@ -59,6 +59,26 @@ namespace Dotnet.Script.Tests
             Assert.Equal("3.2.1", result.PackageReferences.Last().Version);
         }
 
+        [Theory]
+        [InlineData("\r #load\"nuget:Package, 1.2.3\"")]
+        [InlineData("#load\n\"nuget:Package, 1.2.3\"")]
+        [InlineData("#load \"nuget:\nPackage, 1.2.3\"")]
+        [InlineData("#load \"nuget:Package\n, 1.2.3\"")]
+        [InlineData("#load \"nuget:Package,\n1.2.3\"")]
+        [InlineData("\r #r\"nuget:Package, 1.2.3\"")]
+        [InlineData("#r\n\"nuget:Package, 1.2.3\"")]
+        [InlineData("#r \"nuget:\nPackage, 1.2.3\"")]
+        [InlineData("#r \"nuget:Package\n, 1.2.3\"")]
+        [InlineData("#r \"nuget:Package,\n1.2.3\"")]
+        public void ShouldNotMatchBadDirectives(string code)
+        {
+            var parser = CreateParser();
+
+            var result = parser.ParseFromCode(code);
+
+            Assert.Equal(0, result.PackageReferences.Count);
+        }
+
         [Fact]
         public void ShouldParseTargetFramework()
         {

--- a/src/Dotnet.Script.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptParserTests.cs
@@ -95,6 +95,20 @@ namespace Dotnet.Script.Tests
             Assert.Equal(_scriptEnvironment.TargetFramework, result.TargetFramework);            
         }
 
+        [Theory]
+        [InlineData("\n#! \"TARGET_FRAMEWORK\"")]
+        [InlineData("\r#! \"TARGET_FRAMEWORK\"")]
+        [InlineData("#!\n\"TARGET_FRAMEWORK\"")]
+        [InlineData("#!\r\"TARGET_FRAMEWORK\"")]
+        public void ShouldNotParseBadTargetFramework(string code)
+        {
+            var parser = CreateParser();
+
+            var result = parser.ParseFromCode(code.Replace("TARGET_FRAMEWORK", _scriptEnvironment.TargetFramework));
+
+            Assert.Null(result.TargetFramework);            
+        }
+
         private ScriptParser CreateParser()
         {
             return new ScriptParser(TestOutputHelper.CreateTestLogFactory());

--- a/src/Dotnet.Script.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptParserTests.cs
@@ -65,11 +65,15 @@ namespace Dotnet.Script.Tests
         [InlineData("#load \"nuget:\nPackage, 1.2.3\"")]
         [InlineData("#load \"nuget:Package\n, 1.2.3\"")]
         [InlineData("#load \"nuget:Package,\n1.2.3\"")]
+        [InlineData("#load \"nuget:P a c k a g e, 1.2.3\"")]
+        [InlineData("#load \"nuget:Pack/age, 1.2.3\"")]
         [InlineData("\r #r\"nuget:Package, 1.2.3\"")]
         [InlineData("#r\n\"nuget:Package, 1.2.3\"")]
         [InlineData("#r \"nuget:\nPackage, 1.2.3\"")]
         [InlineData("#r \"nuget:Package\n, 1.2.3\"")]
         [InlineData("#r \"nuget:Package,\n1.2.3\"")]
+        [InlineData("#r \"nuget:P a c k a g e, 1.2.3\"")]
+        [InlineData("#r \"nuget:Pack/age, 1.2.3\"")]
         public void ShouldNotMatchBadDirectives(string code)
         {
             var parser = CreateParser();

--- a/src/Dotnet.Script.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptParserTests.cs
@@ -67,6 +67,7 @@ namespace Dotnet.Script.Tests
         [InlineData("#load \"nuget:Package,\n1.2.3\"")]
         [InlineData("#load \"nuget:P a c k a g e, 1.2.3\"")]
         [InlineData("#load \"nuget:Pack/age, 1.2.3\"")]
+        [InlineData("#load \"nuget:Package,\"")]
         [InlineData("\r #r\"nuget:Package, 1.2.3\"")]
         [InlineData("#r\n\"nuget:Package, 1.2.3\"")]
         [InlineData("#r \"nuget:\nPackage, 1.2.3\"")]
@@ -74,6 +75,7 @@ namespace Dotnet.Script.Tests
         [InlineData("#r \"nuget:Package,\n1.2.3\"")]
         [InlineData("#r \"nuget:P a c k a g e, 1.2.3\"")]
         [InlineData("#r \"nuget:Pack/age, 1.2.3\"")]
+        [InlineData("#r \"nuget:Package,\"")]
         public void ShouldNotMatchBadDirectives(string code)
         {
             var parser = CreateParser();


### PR DESCRIPTION
This PR fixes a number of issues with the regular expressions in `ScriptParser`. The added tests demonstrate which invalid cases were being picked up by the patterns. By far, the biggest issue was `\s` ([white-space character][ws]) being used in patterns, which matches horizontal _and_ vertical white-space when one usually means the former. I've updated all patterns to only allow horizontal space `[\t\x20]` (tab or space) so that directives broken/wrapped on several lines don't accidentally match (because `\s` matches `\r` and `\n`).

[ws]: https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#white-space-character-s