### PR TITLE
Fix parsing of #load to be case-sensitive

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
@@ -61,7 +61,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static string[] GetLoadDirectives(string content)
         {            
-            var matches = Regex.Matches(content, @"^\s*#load\s*""\s*(.+)\s*""", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+            var matches = Regex.Matches(content, @"^\s*#load\s*""\s*(.+)\s*""", RegexOptions.Multiline);
             List<string> result = new List<string>();
             foreach (var match in matches.Cast<Match>())
             {

--- a/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
@@ -4,6 +4,8 @@ using Dotnet.Script.DependencyModel.ProjectSystem;
 
 namespace Dotnet.Script.Tests
 {
+    using System.Linq;
+
     public class ScriptFilesResolverTests
     {
         [Fact]
@@ -78,6 +80,20 @@ namespace Dotnet.Script.Tests
             }
         }
 
+        [Fact]
+        public void ShouldNotParseLoadDirectiveIgnoringCase()
+        {
+            using (var rootFolder = new DisposableFolder())
+            {
+                var rootScript = WriteScript("#LOAD \"Bar.csx\"", rootFolder.Path, "Foo.csx");
+                WriteScript(string.Empty, rootFolder.Path, "Bar.csx");
+                var scriptFilesResolver = new ScriptFilesResolver();
+
+                var files = scriptFilesResolver.GetScriptFiles(rootScript);
+
+                Assert.Equal(new[] { "Foo.csx" }, files.Select(Path.GetFileName));
+            }
+        }
 
         private static string WriteScript(string content, string folder, string name)
         {

--- a/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
@@ -1,11 +1,10 @@
 ﻿using System.IO;
+using System.Linq;
 using Xunit;
 using Dotnet.Script.DependencyModel.ProjectSystem;
 
 namespace Dotnet.Script.Tests
 {
-    using System.Linq;
-
     public class ScriptFilesResolverTests
     {
         [Fact]


### PR DESCRIPTION
The `#load` directive is case-sensitive in C# Interactive (`csi.exe`):

```
Microsoft (R) Visual C# Interactive Compiler version 2.9.0.63208
Copyright (C) Microsoft Corporation. All rights reserved.

Type "#help" for more information.
> #LOAD "foo.csx"
(1,2): error CS1024: Preprocessor directive expected
>
```
