### PR TITLE
Remove unused AUTOPUBLISH condition compilation symbol

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -1,4 +1,3 @@
-#define AUTOPUBLISH
 using Dotnet.Script.Core;
 using Dotnet.Script.DependencyModel.Context;
 using Dotnet.Script.DependencyModel.Environment;


### PR DESCRIPTION
Seems to be no longer used since 0ddbf23731b3923173d3ac85824006536083d43e.