### PR TITLE
Add help option for all commands

### DIFF
--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -81,7 +81,8 @@ namespace Dotnet.Script
             var argsBeforeDoubleHyphen = args.TakeWhile(a => a != "--").ToArray();
             var argsAfterDoubleHyphen  = args.SkipWhile(a => a != "--").Skip(1).ToArray();
 
-            app.HelpOption("-? | -h | --help");
+            const string helpOptionTemplate = "-? | -h | --help";
+            app.HelpOption(helpOptionTemplate);
 
             app.VersionOption("-v | --version", GetVersion);
 
@@ -92,6 +93,7 @@ namespace Dotnet.Script
                 c.Description = "Execute CSX code.";
                 var code = c.Argument("code", "Code to execute.");
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for the code compiler. Defaults to current directory.", CommandOptionType.SingleValue);
+                c.HelpOption(helpOptionTemplate);
                 c.OnExecute(async () =>
                 {
                     int exitCode = 0;
@@ -114,6 +116,7 @@ namespace Dotnet.Script
                 c.Description = "Creates a sample script along with the launch.json file needed to launch and debug the script.";
                 var fileName = c.Argument("filename", "(Optional) The name of the sample script file to be created during initialization. Defaults to 'main.csx'");
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for initialization. Defaults to current directory.", CommandOptionType.SingleValue);
+                c.HelpOption(helpOptionTemplate);
                 c.OnExecute(() =>
                 {
                     var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
@@ -128,6 +131,7 @@ namespace Dotnet.Script
                 c.Description = "Creates a new script file";
                 var fileNameArgument = c.Argument("filename", "The script file name");
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory the new script file to be created. Defaults to current directory.", CommandOptionType.SingleValue);
+                c.HelpOption(helpOptionTemplate);
                 c.OnExecute(() =>
                 {
                     var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
@@ -152,7 +156,7 @@ namespace Dotnet.Script
                 var commandConfig = c.Option("-c | --configuration <configuration>", "Configuration to use for publishing the script [Release/Debug]. Default is \"Debug\"", CommandOptionType.SingleValue);
                 var publishDebugMode = c.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
                 var runtime = c.Option("-r |--runtime", "The runtime used when publishing the self contained executable. Defaults to your current runtime.", CommandOptionType.SingleValue);
-
+                c.HelpOption(helpOptionTemplate);
                 c.OnExecute(() =>
                 {
                     if (fileNameArgument.Value == null)
@@ -203,6 +207,7 @@ namespace Dotnet.Script
                 c.Description = "Run a script from a DLL.";
                 var dllPath = c.Argument("dll", "Path to DLL based script");
                 var commandDebugMode = c.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
+                c.HelpOption(helpOptionTemplate);
                 c.OnExecute(async () =>
                 {
                     int exitCode = 0;


### PR DESCRIPTION
It's not possible to get help on any of the commands although it is define and therefore should be available. This PR fixes that.

Before this PR:

```ps1
PS> dotnet-script eval -h
Unrecognized option '-h'
PS> dotnet-script exec -h
Unrecognized option '-h'
PS> dotnet-script init -h
Unrecognized option '-h'
PS> dotnet-script new -h
Unrecognized option '-h'
PS> dotnet-script publish -h
Unrecognized option '-h'
```

After this PR:

```
PS> dotnet-script eval -h
Execute CSX code.

Usage:  eval [arguments] [options]

Arguments:
  code                                                Code to execute.

Options:
  -cwd |--workingdirectory <currentworkingdirectory>  Working directory for the code compiler. Defaults to current directory.
  -? | -h | --help                                    Show help information

PS> dotnet-script exec -h
Run a script from a DLL.

Usage:  exec [arguments] [options]

Arguments:
  dll               Path to DLL based script

Options:
  -d | --debug      Enables debug output.
  -? | -h | --help  Show help information

PS> dotnet-script init -h
Creates a sample script along with the launch.json file needed to launch and debug the script.

Usage:  init [arguments] [options]

Arguments:
  filename                                            (Optional) The name of the sample script file to be created during initialization. Defaults to 'main.csx'

Options:
  -cwd |--workingdirectory <currentworkingdirectory>  Working directory for initialization. Defaults to current directory.
  -? | -h | --help                                    Show help information

PS> dotnet-script new -h
Creates a new script file

Usage:  new [arguments] [options]

Arguments:
  filename                                            The script file name

Options:
  -cwd |--workingdirectory <currentworkingdirectory>  Working directory the new script file to be created. Defaults to current directory.
  -? | -h | --help                                    Show help information

PS> dotnet-script publish -h
Creates a self contained executable or DLL from a script

Usage:  publish [arguments] [options]

Arguments:
  filename                              The script file name

Options:
  -o |--output                          Directory where the published executable should be placed.  Defaults to a 'publish' folder in the current directory.
  -n |--name                            The name for the generated DLL (executable not supported at this time).  Defaults to the name of the script.
  --dll                                 Publish to a .dll instead of an executable.
  -c | --configuration <configuration>  Configuration to use for publishing the script [Release/Debug]. Default is "Debug"
  -d | --debug                          Enables debug output.
  -r |--runtime                         The runtime used when publishing the self contained executable. Defaults to your current runtime.
  -? | -h | --help                      Show help information
```
