### PR TITLE
Fix "reg add" data escaping & quoting issues

### DIFF
--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -132,7 +132,7 @@ namespace Dotnet.Script.Core
 
                 if (_commandRunner.Execute("reg", @"query HKCU\Software\classes\dotnetscript") != 0)
                 {
-                    _commandRunner.Execute("reg", $@"add HKCU\Software\Classes\dotnetscript\Shell\Open\Command /f /ve /t REG_EXPAND_SZ /d """"%ProgramFiles%\dotnet\dotnet.exe"" exec {_scriptEnvironment.InstallLocation}\dotnet-script.dll %1 -- %*""");
+                    _commandRunner.Execute("reg", $@"add HKCU\Software\Classes\dotnetscript\Shell\Open\Command /f /ve /t REG_EXPAND_SZ /d ""\""%ProgramFiles%\dotnet\dotnet.exe\"" exec \""{Path.Combine(_scriptEnvironment.InstallLocation, "dotnet-script.dll")}\"" \""%1\"" -- %*""");
                 }
             }
 

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -124,15 +124,15 @@ namespace Dotnet.Script.Core
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // check to see if .csx is mapped to dotnet-script
-                if (_commandRunner.Execute("reg", "query HKCU\\Software\\classes\\.csx") != 0)
+                if (_commandRunner.Execute("reg", @"query HKCU\Software\classes\.csx") != 0)
                 {
                     // register dotnet-script as the tool to process .csx files
-                    _commandRunner.Execute("reg", $"add HKCU\\Software\\classes\\.csx /f /ve /t REG_SZ -d dotnetscript");
+                    _commandRunner.Execute("reg", @"add HKCU\Software\classes\.csx /f /ve /t REG_SZ -d dotnetscript");
                 }
 
-                if (_commandRunner.Execute("reg", "query HKCU\\Software\\classes\\dotnetscript") != 0)
+                if (_commandRunner.Execute("reg", @"query HKCU\Software\classes\dotnetscript") != 0)
                 {
-                    _commandRunner.Execute("reg", $"add HKCU\\Software\\Classes\\dotnetscript\\Shell\\Open\\Command /f /ve /t REG_EXPAND_SZ /d \"\"%ProgramFiles%\\dotnet\\dotnet.exe\" exec {_scriptEnvironment.InstallLocation}\\dotnet-script.dll %1 -- %*\"");
+                    _commandRunner.Execute("reg", $@"add HKCU\Software\Classes\dotnetscript\Shell\Open\Command /f /ve /t REG_EXPAND_SZ /d """"%ProgramFiles%\dotnet\dotnet.exe"" exec {_scriptEnvironment.InstallLocation}\dotnet-script.dll %1 -- %*""");
                 }
             }
 

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -1,6 +1,7 @@
 ﻿using Dotnet.Script.DependencyModel.Environment;
 using Newtonsoft.Json.Linq;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 
 
@@ -41,8 +42,22 @@ namespace Dotnet.Script.Tests
                 {
                     (output, exitCode) = ProcessHelper.RunAndCaptureOutput("reg.exe", @"query HKCU\Software\Classes\.csx");
                     Assert.Equal(0, exitCode);
-                    (output, exitCode) = ProcessHelper.RunAndCaptureOutput("reg.exe", @"query HKCU\software\classes\dotnetscript");
+
+                    (output, exitCode) = ProcessHelper.RunAndCaptureOutput("reg.exe", @"query HKCU\software\classes\dotnetscript\Shell\Open\Command");
                     Assert.Equal(0, exitCode);
+
+                    Assert.Matches(new Regex(@" \b   REG_EXPAND_SZ                             # type
+                                                [ ]+ ""%ProgramFiles%\\dotnet\\dotnet.exe""    # unexpanded %ProgramFiles% + quoted
+                                                [ ]+ exec
+                                                [ ]+ ""([A-Z]:|\\)\\(.+?)\\dotnet-script.dll"" # absolute + quoted
+                                                [ ]+ ""%1""                                    # quoted
+                                                [ ]+ --
+                                                [ ]+ %\*                                       # unquoted
+                                            ",
+                                             RegexOptions.IgnoreCase |
+                                             RegexOptions.CultureInvariant |
+                                             RegexOptions.IgnorePatternWhitespace),
+                                   output);
                 }
                 else
                 {


### PR DESCRIPTION
The association of `.csx` files with `dotnet-script` on Windows via `reg add` had a number of escaping and quoting issues of the value data and honestly I'm not sure how this ever worked. It _might_ also explain the sporadic failures of `ShouldRunCsxScriptDirectly` because escaping of command-line arguments is always tricky. In any case, this PR should make the registration and its test more robust.

Before this PR, running:

    reg query HKCU\Software\Classes\dotnetscript /s

shows the quoting issues:

```
HKEY_CURRENT_USER\Software\Classes\dotnetscript\Shell

HKEY_CURRENT_USER\Software\Classes\dotnetscript\Shell\Open

HKEY_CURRENT_USER\Software\Classes\dotnetscript\Shell\Open\Command
    (Default)    REG_EXPAND_SZ    %ProgramFiles%\dotnet\dotnet.exe exec A:\dotnet-script\src\Dotnet.Script\bin\Debug\netcoreapp2.1\dotnet-script.dll %1 -- %*
```

Note that:

1. `%ProgramFiles%\dotnet\dotnet.exe` isn't quoted, which means that if `%ProgramFiles%` expands to `C:\Program Files` then there's a space that should become part of the program path, but it won't since it's unquoted.
2. The path to `dotnet-script.dll` isn't quoted so if there's a space in the installation path, it'll throw things off.
3. The script path, `%1`, is unquoted and will exhibit the same issues as 1 & 2.

For more information, see the following text section “[Shortcut Menu Verbs](https://docs.microsoft.com/en-us/windows/desktop/shell/fa-verbs#shortcut-menu-verbs)” of “[Verbs and File Associations](https://docs.microsoft.com/en-us/windows/desktop/shell/fa-verbs)”:

> The command string typically looks as follows:
>
>     "My Program.exe" "%1"
>
> If any element of the command string contains or might contain spaces, it must be enclosed in quotation marks. Otherwise, if the element contains a space, it will not parse correctly. For instance, **"My Program.exe"** starts the application properly. If you use **My Program.exe** without quotation marks, then the system attempts to launch **My** with **Program.exe** as its first command line argument. You should always use quotation marks with arguments such as **"%1"** that are expanded to strings by the Shell, because you cannot be certain that the string will not contain a space.

After applying this PR, running:

    reg query HKCU\Software\Classes\dotnetscript /s

shows proper quoting:

```
HKEY_CURRENT_USER\Software\Classes\dotnetscript\shell

HKEY_CURRENT_USER\Software\Classes\dotnetscript\shell\open

HKEY_CURRENT_USER\Software\Classes\dotnetscript\shell\open\command
    (Default)    REG_EXPAND_SZ    "%ProgramFiles%\dotnet\dotnet.exe" exec "A:\dotnet-script\src\Dotnet.Script\bin\Debug\netcoreapp2.1\dotnet-script.dll" "%1" -- %*
```
