### PR TITLE
Version/0.27.0

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>0.26.1</VersionPrefix>
+    <VersionPrefix>0.27.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.26.1</VersionPrefix>
+        <VersionPrefix>0.27.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -20,7 +20,7 @@
         <PackAsTool>false</PackAsTool>
         <IsPackable>true</IsPackable>
         <LangVersion>latest</LangVersion>
-    </PropertyGroup>    
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.2" />


### PR DESCRIPTION
This PR bumps the version to 0.27.0 for `Dotnet.Script` and `Dotnet.Script.Core`. `Dotnet.Script.DependencyModel` is bumped to 0.8.0

Also added the updated docs for caching. 