### PR TITLE
Run script packages tests without the cache

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -101,7 +101,7 @@ namespace Dotnet.Script.Tests
                 Console.SetError(stringWriter);
                 var baseDir = AppDomain.CurrentDomain.BaseDirectory;
                 var fullPathToScriptFile = Path.Combine(baseDir, "..", "..", "..", "TestFixtures", "ScriptPackage", scriptFileName);
-                Program.Main(new[] { fullPathToScriptFile });
+                Program.Main(new[] { fullPathToScriptFile , "--nocache"});
                 return output.ToString();
 
             }


### PR DESCRIPTION
This is just a small fix/workaround for executing the script packages tests. It fails when running from the cache since we delete the generated script packages from the global NuGet cache before we execute the tests. Since there is no restore the second time, the packages are missing from the global NuGet cache. 