### PR TITLE
Cache improvements

### DIFF
--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
@@ -63,7 +63,7 @@ namespace Dotnet.Script.Core.Commands
 
             string CreateLibrary()
             {
-                var options = new PublishCommandOptions(executeOptions.File,executionCacheFolder, "script", PublishType.Library,executeOptions.OptimizationLevel, null, executeOptions.NoCache);
+                var options = new PublishCommandOptions(executeOptions.File,executionCacheFolder, "script", PublishType.Library,executeOptions.OptimizationLevel, executeOptions.PackageSources, null, executeOptions.NoCache);
                 new PublishCommand(_scriptConsole, _logFactory).Execute(options);
                 if (hash != null)
                 {

--- a/src/Dotnet.Script.Core/Commands/PublishCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/PublishCommand.cs
@@ -34,7 +34,7 @@ namespace Dotnet.Script.Core.Commands
             var scriptEmitter = new ScriptEmitter(_scriptConsole, compiler);
             var publisher = new ScriptPublisher(_logFactory, scriptEmitter);
             var code = absoluteFilePath.ToSourceText();
-            var context = new ScriptContext(code, absolutePublishDirectory, Enumerable.Empty<string>(), absoluteFilePath, options.OptimizationLevel);
+            var context = new ScriptContext(code, absolutePublishDirectory, Enumerable.Empty<string>(), absoluteFilePath, options.OptimizationLevel, packageSources: options.PackageSources);
 
             if (options.PublishType == PublishType.Library)
             {

--- a/src/Dotnet.Script.Core/Commands/PublishCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/PublishCommandOptions.cs
@@ -5,13 +5,14 @@ namespace Dotnet.Script.Core.Commands
 {
     public class PublishCommandOptions
     {
-        public PublishCommandOptions(ScriptFile file, string outputDirectory, string libraryName, PublishType publishType, OptimizationLevel optimizationLevel,string runtimeIdentifier, bool noCache)
+        public PublishCommandOptions(ScriptFile file, string outputDirectory, string libraryName, PublishType publishType, OptimizationLevel optimizationLevel, string[] packageSources, string runtimeIdentifier, bool noCache)
         {
             File = file;
             OutputDirectory = outputDirectory;
             LibraryName = libraryName;
             PublishType = publishType;
             OptimizationLevel = optimizationLevel;
+            PackageSources = packageSources;
             RuntimeIdentifier = runtimeIdentifier ?? ScriptEnvironment.Default.RuntimeIdentifier;
             NoCache = noCache;
         }
@@ -21,6 +22,7 @@ namespace Dotnet.Script.Core.Commands
         public string LibraryName { get; }
         public PublishType PublishType { get; }
         public OptimizationLevel OptimizationLevel { get; }
+        public string[] PackageSources { get; }
         public string RuntimeIdentifier { get; }
         public bool NoCache { get; }
     }

--- a/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
@@ -172,7 +172,9 @@ namespace Dotnet.Script.DependencyModel.Runtime
                     return fullPath;
                 }
             }
-            throw new InvalidOperationException("Not found");
+            string message = $@"The requested dependency ({relativePath}) was not found in the global Nuget cache(s).
+. Try executing/publishing the script again with the '--nocache' option";
+            throw new InvalidOperationException(message);
         }
 
         private bool AppliesToCurrentRuntime(string runtime)

--- a/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
@@ -85,9 +85,13 @@ namespace Dotnet.Script.DependencyModel.Runtime
             packageSources = packageSources ?? new string[0];
             ScriptDependencyInfo dependencyInfo;
             if (restorePackages)
+            {
                 dependencyInfo = _scriptDependencyInfoProvider.GetDependencyInfo(pathToProjectOrDll, packageSources);
+            }
             else
+            {
                 dependencyInfo = _scriptDependencyInfoProvider.GetDependencyInfo(pathToProjectOrDll);
+            }
 
             var dependencyContext = dependencyInfo.DependencyContext;
             List<string> nuGetPackageFolders = dependencyInfo.NugetPackageFolders.ToList();
@@ -102,7 +106,7 @@ namespace Dotnet.Script.DependencyModel.Runtime
                 var runtimeDependency = new RuntimeDependency(runtimeLibrary.Name, runtimeLibrary.Version,
                     ProcessRuntimeAssemblies(runtimeLibrary, nuGetPackageFolders.ToArray()),
                     ProcessNativeLibraries(runtimeLibrary, nuGetPackageFolders.ToArray()),
-                    ProcessScriptFiles(runtimeLibrary, nuGetPackageFolders.ToArray()));
+                    ProcessScriptFiles(runtimeLibrary, nuGetPackageFolders.ToArray(), restorePackages));
 
                 runtimeDependencies.Add(runtimeDependency);
             }
@@ -110,9 +114,20 @@ namespace Dotnet.Script.DependencyModel.Runtime
             return runtimeDependencies;
         }
 
-        private string[] ProcessScriptFiles(RuntimeLibrary runtimeLibrary, string[] nugetPackageFolders)
+        private string[] ProcessScriptFiles(RuntimeLibrary runtimeLibrary, string[] nugetPackageFolders, bool restorePackages)
         {
-            return _scriptFilesDependencyResolver.GetScriptFileDependencies(runtimeLibrary.Path, nugetPackageFolders);
+            if (restorePackages)
+            {
+                return _scriptFilesDependencyResolver.GetScriptFileDependencies(runtimeLibrary.Path, nugetPackageFolders);
+            }
+            else
+            {
+                // If restorePackages are false, it means we are running from a DLL
+                // and the scripts from the script packages are already compiled into the DLL
+                // NOTE: This whole class needs some cleanup.
+                return Array.Empty<string>();
+            }
+
         }
 
         private string[] ProcessNativeLibraries(RuntimeLibrary runtimeLibrary, string[] nugetPackageFolders)

--- a/src/Dotnet.Script.DependencyModel/ScriptPackage/ScriptFilesDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/ScriptPackage/ScriptFilesDependencyResolver.cs
@@ -20,7 +20,7 @@ namespace Dotnet.Script.DependencyModel.ScriptPackage
                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public ScriptFilesDependencyResolver(LogFactory logFactory)
-        {            
+        {
             _logger = logFactory.CreateLogger<ScriptFilesDependencyResolver>();
         }
 
@@ -34,20 +34,20 @@ namespace Dotnet.Script.DependencyModel.ScriptPackage
             {
                 return Array.Empty<string>();
             }
-            
+
             _logger.Debug($"Processing script file dependencies from '{path}'");
 
-            var scriptFilesPerTargetFramework = GetScriptFilesPerTargetFramework(allScriptFiles);               
+            var scriptFilesPerTargetFramework = GetScriptFilesPerTargetFramework(allScriptFiles);
             var scriptFiles = GetScriptFilesMatchingCurrentRuntime(scriptFilesPerTargetFramework);
             if (scriptFiles.Length == 0)
             {
                 _logger.Debug("No script files found matching the current runtime.");
                 return Array.Empty<string>();
             }
-            
+
             var rootPath = GetRootPath(scriptFiles[0]);
             string entryPointScriptFile = GetEntryPointScript(rootPath);
-            if (entryPointScriptFile != null)            
+            if (entryPointScriptFile != null)
             {
                 _logger.Debug($"Adding entry point script file '{entryPointScriptFile}'");
                 result.Add(entryPointScriptFile);
@@ -62,15 +62,15 @@ namespace Dotnet.Script.DependencyModel.ScriptPackage
 
         private string GetEntryPointScript(string rootPath)
         {
-            var rootfiles = Directory.GetFiles(rootPath, "*.csx");            
+            var rootfiles = Directory.GetFiles(rootPath, "*.csx");
             if (rootfiles.Length == 1)
-            {                
+            {
                 return rootfiles[0];
             }
 
             if (rootfiles.Length > 1)
             {
-                return rootfiles.SingleOrDefault(rf => rf.ToLower() == "main.csx");                
+                return rootfiles.SingleOrDefault(rf => rf.ToLower() == "main.csx");
             }
 
             return null;
@@ -79,9 +79,9 @@ namespace Dotnet.Script.DependencyModel.ScriptPackage
         private string[] GetScriptFilesMatchingCurrentRuntime(IDictionary<string, List<string>> filesPerTargetFramework)
         {
             //We keep this super simple for now
-           
+
             if (filesPerTargetFramework.TryGetValue("any", out var files))
-            {                
+            {
                 return files.ToArray();
             }
 
@@ -97,7 +97,7 @@ namespace Dotnet.Script.DependencyModel.ScriptPackage
         private static IDictionary<string, List<string>> GetScriptFilesPerTargetFramework(string[] scriptFiles)
         {
             var result = new Dictionary<string, List<string>>(StringComparer.InvariantCultureIgnoreCase);
-                        
+
             foreach (var scriptFile in scriptFiles)
             {
                 var match = TargetFrameworkMatcher.Match(scriptFile);
@@ -116,11 +116,11 @@ namespace Dotnet.Script.DependencyModel.ScriptPackage
         }
 
         private static string GetRootPath(string pathToScriptFile)
-        {           
+        {
             var match = RootPathMatcher.Match(pathToScriptFile);
             return match.Groups[1].Value;
         }
-     
+
         private static string GetPackageFullPath(string packagePath, string[] nugetPackageFolders)
         {
             foreach (var nugetPackageFolder in nugetPackageFolders)
@@ -132,7 +132,10 @@ namespace Dotnet.Script.DependencyModel.ScriptPackage
                 }
             }
 
-            throw new InvalidOperationException("Not found");
+            string message = $@"The requested script package path ({packagePath}) was not found in the global Nuget cache(s).
+. Try executing/publishing the script again with the '--nocache' option";
+
+            throw new InvalidOperationException(message);
         }
     }
 }

--- a/src/Dotnet.Script.Tests/PackageSourceTests.cs
+++ b/src/Dotnet.Script.Tests/PackageSourceTests.cs
@@ -17,7 +17,7 @@ namespace Dotnet.Script.Tests
         {
             var fixture = "ScriptPackage/WithNoNuGetConfig";
             var pathToScriptPackages = TestPathUtils.GetPathToScriptPackages(fixture);
-            var result = ScriptTestRunner.Default.ExecuteFixture(fixture, $"-s {pathToScriptPackages}");
+            var result = ScriptTestRunner.Default.ExecuteFixture(fixture, $"--nocache -s {pathToScriptPackages}");
             Assert.Contains("Hello", result.output);
             Assert.Equal(0, result.exitCode);
         }
@@ -28,7 +28,7 @@ namespace Dotnet.Script.Tests
             var fixture = "ScriptPackage/WithNoNuGetConfig";
             var pathToScriptPackages = TestPathUtils.GetPathToScriptPackages(fixture);
             var code = @"#load \""nuget:ScriptPackageWithMainCsx,1.0.0\"" SayHello();";
-            var result = ScriptTestRunner.Default.Execute($"-s {pathToScriptPackages} eval \"{code}\"");
+            var result = ScriptTestRunner.Default.Execute($"--nocache -s {pathToScriptPackages} eval \"{code}\"");
             Assert.Contains("Hello", result.output);
             Assert.Equal(0, result.exitCode);
         }

--- a/src/Dotnet.Script.Tests/ScriptPackagesFixture.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesFixture.cs
@@ -20,7 +20,7 @@ namespace Dotnet.Script.Tests
 
         private void ClearGlobalPackagesFolder()
         {
-            var pathToGlobalPackagesFolder = GetPathToGlobalPackagesFolder();
+            var pathToGlobalPackagesFolder = TestPathUtils.GetPathToGlobalPackagesFolder();
             var scriptPackageFolders = Directory.GetDirectories(pathToGlobalPackagesFolder).Select(f => f.ToLower()).Where(f => f.Contains("scriptpackage"));
             foreach (var scriptPackageFolder in scriptPackageFolders)
             {
@@ -84,14 +84,6 @@ namespace Dotnet.Script.Tests
             {
                 Directory.Delete(path, true);
             }
-        }
-
-
-        private string GetPathToGlobalPackagesFolder()
-        {
-            var result = ProcessHelper.RunAndCaptureOutput("dotnet", "nuget locals global-packages --list");
-            var match = Regex.Match(result.output, @"^.*global-packages:\s*(.*)$");
-            return match.Groups[1].Value;
         }
 
         private static IReadOnlyList<string> GetSpecFiles()

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Dotnet.Script.DependencyModel.Compilation;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.Shared.Tests;
@@ -28,6 +26,34 @@ namespace Dotnet.Script.Tests
         {
             var result = Execute("WithMainCsx/WithMainCsx.csx");
             Assert.StartsWith("Hello from netstandard2.0", result);
+        }
+
+        [Fact]
+        public void ShouldThrowMeaningfulExceptionWhenScriptPackageIsMissing()
+        {
+            using(var scriptFolder = new DisposableFolder())
+            {
+                var code = new StringBuilder();
+                code.AppendLine("#load \"nuget:ScriptPackageWithMainCsx, 1.0.0\"");
+                code.AppendLine("SayHello();");
+                var pathToScriptFile = Path.Combine(scriptFolder.Path, "main.csx");
+                File.WriteAllText(pathToScriptFile, code.ToString());
+                var pathToScriptPackages = Path.GetFullPath(TestPathUtils.GetPathToScriptPackages("ScriptPackage/WithMainCsx"));
+
+                // Run once to ensure that it is cached.
+                var result = ScriptTestRunner.Default.Execute($"{pathToScriptFile} -s {pathToScriptPackages}");
+                Assert.StartsWith("Hello from netstandard2.0", result.output);
+
+                // Remove the package from the global NuGet cache
+                TestPathUtils.RemovePackageFromGlobalNugetCache("ScriptPackageWithMainCsx");
+
+                //Change the source to force a recompile, now with the missing package.
+                code.Append("return 0");
+                File.WriteAllText(pathToScriptFile, code.ToString());
+
+                result = ScriptTestRunner.Default.Execute($"{pathToScriptFile} -s {pathToScriptPackages}");
+                Assert.Contains("Try executing/publishing the script", result.output);
+            }
         }
 
         [Fact]
@@ -101,7 +127,7 @@ namespace Dotnet.Script.Tests
                 Console.SetError(stringWriter);
                 var baseDir = AppDomain.CurrentDomain.BaseDirectory;
                 var fullPathToScriptFile = Path.Combine(baseDir, "..", "..", "..", "TestFixtures", "ScriptPackage", scriptFileName);
-                Program.Main(new[] { fullPathToScriptFile , "--nocache"});
+                Program.Main(new[] { fullPathToScriptFile });
                 return output.ToString();
 
             }

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -69,7 +69,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldGetScriptFilesFromScriptPackage()
         {
-            var resolver = CreateResolverCompilationDependencyResolver();
+            var resolver = CreateCompilationDependencyResolver();
             var fixture = GetFullPathToTestFixture("ScriptPackage/WithMainCsx");
             var dependencies = resolver.GetDependencies(fixture, true, _scriptEnvironment.TargetFramework);
             var scriptFiles = dependencies.Single(d => d.Name == "ScriptPackageWithMainCsx").Scripts;
@@ -83,7 +83,7 @@ namespace Dotnet.Script.Tests
         }
 
 
-        private CompilationDependencyResolver CreateResolverCompilationDependencyResolver()
+        private CompilationDependencyResolver CreateCompilationDependencyResolver()
         {
             var resolver = new CompilationDependencyResolver(TestOutputHelper.CreateTestLogFactory());
             return resolver;

--- a/src/Dotnet.Script.Tests/TestPathUtils.cs
+++ b/src/Dotnet.Script.Tests/TestPathUtils.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Dotnet.Script.Tests
 {
@@ -27,6 +29,20 @@ namespace Dotnet.Script.Tests
             var fixtureFolderPath = GetPathToTestFixtureFolder(fixture);
             var pathToFixture = Path.Combine(fixtureFolderPath, $"{Path.GetFileNameWithoutExtension(fixtureFolderPath)}.csx");
             return Path.GetFullPath(pathToFixture);
+        }
+
+        public static string GetPathToGlobalPackagesFolder()
+        {
+            var result = ProcessHelper.RunAndCaptureOutput("dotnet", "nuget locals global-packages --list");
+            var match = Regex.Match(result.output, @"^.*global-packages:\s*(.*)$");
+            return match.Groups[1].Value;
+        }
+
+        public static void RemovePackageFromGlobalNugetCache(string packageName)
+        {
+            var pathToGlobalPackagesFolder = TestPathUtils.GetPathToGlobalPackagesFolder();
+            var pathToAutoMapperPackage = Directory.GetDirectories(pathToGlobalPackagesFolder).Single(d => d.Contains(packageName, StringComparison.OrdinalIgnoreCase));
+            FileUtils.RemoveDirectory(pathToAutoMapperPackage);
         }
     }
 }

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -152,6 +152,7 @@ namespace Dotnet.Script
                         dllName.Value(),
                         dllOption.HasValue() ? PublishType.Library : PublishType.Executable,
                         commandConfig.ValueEquals("release", StringComparison.OrdinalIgnoreCase) ? OptimizationLevel.Release : OptimizationLevel.Debug,
+                        packageSources.Values?.ToArray(),
                         runtime.Value() ?? ScriptEnvironment.Default.RuntimeIdentifier,
                         nocache.HasValue()
                     );


### PR DESCRIPTION
This PR improves on a couple of issues related to caching and publishing. 

* Throw a meaningful error message in the case we fail to find a dependency caused by for instance clearing the global NuGet cache. 

* No need to resolve script package references when running from the cache/dll since the code is already compiled into the DLL

* Discovered during these fixes that we don't used package sources during publish which might also help to overcome the issues discussed in #368 


