### PR TITLE
Added support for REPL command history

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>0.27.1</VersionPrefix>
+    <VersionPrefix>0.28.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -126,7 +126,7 @@ namespace Dotnet.Script.Core
 
             while (true)
             {
-                var line = Console.In.ReadLine();
+                var line = Console.ReadLine();
                 input.AppendLine(line);
 
                 var syntaxTree = SyntaxFactory.ParseSyntaxTree(input.ToString(), ParseOptions);

--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.IO;
+using RL = System.ReadLine;
 
 namespace Dotnet.Script.Core
 {
     public class ScriptConsole
     {
-        public static readonly ScriptConsole Default = new ScriptConsole(Console.Out, Console.In, Console.Error);
+        public static readonly ScriptConsole Default = new ScriptConsole(Console.Out, null, Console.Error);
 
         public virtual TextWriter Error { get; }
         public virtual TextWriter Out { get; }
@@ -39,8 +40,18 @@ namespace Dotnet.Script.Core
             Out.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
         }
 
+        public virtual string ReadLine()
+        {
+            return In == null ? RL.Read() : In.ReadLine();
+        }
+
         public ScriptConsole(TextWriter output, TextReader input, TextWriter error)
         {
+            if (input == null)
+            {
+                RL.HistoryEnabled = true;
+            }
+
             Out = output;
             Error = error;
             In = input;

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.27.1</VersionPrefix>
+        <VersionPrefix>0.28.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFramework>netcoreapp2.1</TargetFramework>


### PR DESCRIPTION
All input commands throughout the REPL session are now available using <kbd>↓</kbd> and <kbd>↑</kbd> navigation thanks to the awesome [Readline](https://www.nuget.org/packages/ReadLine/) package.

Fixes #375 