### PR TITLE
Copy pdb to execution-cache folder

### DIFF
--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -143,6 +143,13 @@ namespace Dotnet.Script.Core
                         foreach (var runtimeAssembly in runtimeDependency.Assemblies)
                         {
                             File.Copy(runtimeAssembly.Path, Path.Combine(outputDirectory, Path.GetFileName(runtimeAssembly.Path)), true);
+                            var pathToRuntimeAssemblyFolder = Path.GetDirectoryName(runtimeAssembly.Path);
+                            var pdbFileName = $"{Path.GetFileNameWithoutExtension(runtimeAssembly.Path)}.pdb";
+                            var pathToPdb = Path.Combine(pathToRuntimeAssemblyFolder, pdbFileName);
+                            if (File.Exists(pathToPdb))
+                            {
+                                File.Copy(pathToPdb, Path.Combine(outputDirectory, Path.GetFileName(pathToPdb)), true);
+                            }
                         }
                     }
                 }

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -67,13 +67,26 @@ namespace Dotnet.Script.Tests
             }
         }
 
+        [Fact]
+        public void ShouldCopyDllAndPdbToExecutionCacheFolder()
+        {
+            using (var scriptFolder = new DisposableFolder())
+            {
+                var pathToScript = Path.Combine(scriptFolder.Path, "main.csx");
+
+                WriteScript(pathToScript, "#r \"nuget:LightInject, 5.2.1\"" ,"WriteLine(42);");
+                ScriptTestRunner.Default.Execute($"{pathToScript} --nocache");
+                var pathToExecutionCache = GetPathToExecutionCache(pathToScript);
+                Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.dll")));
+                Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.pdb")));
+            }
+        }
+
         private static (string output, string hash) Execute(string pathToScript)
         {
             var result = ScriptTestRunner.Default.Execute(pathToScript);
             Assert.Equal(0, result.exitCode);
-
-            var pathToTempFolder = Path.GetDirectoryName(Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToTempFolder(pathToScript));
-            var pathToExecutionCache = Path.Combine(pathToTempFolder, "execution-cache");
+            string pathToExecutionCache = GetPathToExecutionCache(pathToScript);
             var pathToCacheFile = Path.Combine(pathToExecutionCache, "script.sha256");
             string cachedhash = null;
             if (File.Exists(pathToCacheFile))
@@ -81,6 +94,13 @@ namespace Dotnet.Script.Tests
                 cachedhash = File.ReadAllText(pathToCacheFile);
             }
             return (result.output, cachedhash);
+        }
+
+        private static string GetPathToExecutionCache(string pathToScript)
+        {
+            var pathToTempFolder = Path.GetDirectoryName(Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToTempFolder(pathToScript));
+            var pathToExecutionCache = Path.Combine(pathToTempFolder, "execution-cache");
+            return pathToExecutionCache;
         }
 
         private static void WriteScript(string path, params string[] lines)


### PR DESCRIPTION
When we publish a script, the runtime dependencies resolved from NuGet references are copied to the `execution-cache` folder.  This PR ensures that we also copy the pdb file if it is provided by the NuGet package.  So if the NuGet package for instance ships with a sourcelink enabled pdb, we can debug directly into the source of that package. 