### PR TITLE
CompilationDependencyResolver should operate on known list of CSX files

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
@@ -43,10 +43,17 @@ namespace Dotnet.Script.DependencyModel.Compilation
             return new ProfiledRestorer(new DotnetRestorer(commandRunner, logFactory),logFactory);
         }
 
+        [Obsolete("Please use the overload that takes in a list of script files")]
         public IEnumerable<CompilationDependency> GetDependencies(string targetDirectory, bool enableScriptNugetReferences, string defaultTargetFramework = "net46")
         {
-            var pathToProjectFile = _scriptProjectProvider.CreateProject(targetDirectory, defaultTargetFramework,
-                enableScriptNugetReferences);
+            return GetDependencies(targetDirectory, null, enableScriptNugetReferences, defaultTargetFramework);
+        }
+
+        public IEnumerable<CompilationDependency> GetDependencies(string targetDirectory, IEnumerable<string> scriptFiles, bool enableScriptNugetReferences, string defaultTargetFramework = "net46")
+        {
+            var pathToProjectFile = scriptFiles == null ?
+                _scriptProjectProvider.CreateProject(targetDirectory, defaultTargetFramework, enableScriptNugetReferences) :
+                _scriptProjectProvider.CreateProject(targetDirectory, scriptFiles, defaultTargetFramework, enableScriptNugetReferences);
 
             if (pathToProjectFile == null)
             {
@@ -54,11 +61,8 @@ namespace Dotnet.Script.DependencyModel.Compilation
             }
 
             var dependencyInfo = _scriptDependencyInfoProvider.GetDependencyInfo(pathToProjectFile, Array.Empty<string>());
-
             var dependencyContext = dependencyInfo.DependencyContext;
-
             var compilationAssemblyResolvers = GetCompilationAssemblyResolvers(dependencyInfo.NugetPackageFolders);
-
 
             List<CompilationDependency> result = new List<CompilationDependency>();
             var compileLibraries = dependencyContext.CompileLibraries;

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
@@ -74,6 +74,16 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         public string CreateProject(string targetDirectory, string defaultTargetFramework = "net46", bool enableNuGetScriptReferences = false)
         {
+            return CreateProject(targetDirectory, Directory.GetFiles(targetDirectory, "*.csx", SearchOption.AllDirectories), defaultTargetFramework, enableNuGetScriptReferences);
+        }
+
+        public string CreateProject(string targetDirectory, IEnumerable<string> scriptFiles, string defaultTargetFramework = "net46", bool enableNuGetScriptReferences = false)
+        {
+            if (scriptFiles == null || !scriptFiles.Any())
+            {
+                return null;
+            }
+
             var pathToProjectFile = Directory.GetFiles(targetDirectory, "*.csproj").FirstOrDefault();
             if (pathToProjectFile == null && !enableNuGetScriptReferences)
             {
@@ -82,8 +92,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
             _logger.Debug($"Creating project file for *.csx files found in {targetDirectory} using {defaultTargetFramework} as the default framework.");
 
-            var csxFiles = Directory.GetFiles(targetDirectory, "*.csx", SearchOption.AllDirectories);
-            return SaveProjectFileFromScriptFiles(targetDirectory, defaultTargetFramework, csxFiles);
+            return SaveProjectFileFromScriptFiles(targetDirectory, defaultTargetFramework, scriptFiles.ToArray());
         }
 
         public string CreateProjectForScriptFile(string scriptFile)

--- a/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
+++ b/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
@@ -1,6 +1,7 @@
 ﻿using Dotnet.Script.DependencyModel.Compilation;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.Shared.Tests;
+using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,15 +22,30 @@ namespace Dotnet.Script.Tests
         public void ShouldGetCompilationDependenciesForPackageContainingInlineNuGetPackageReference()
         {            
             var resolver = CreateResolver();
-            var dependencies =  resolver.GetDependencies(TestPathUtils.GetPathToTestFixtureFolder("InlineNugetPackage"), true, _scriptEnvironment.TargetFramework);
+            var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("InlineNugetPackage");
+            var csxFiles = Directory.GetFiles(targetDirectory, "*.csx");
+            var dependencies =  resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
             Assert.Contains(dependencies, d => d.Name == "AutoMapper");
+        }
+
+        [Fact]
+        public void ShouldGetCompilationDependenciesForPackageContainingInlineNuGetPackageReferenceButSkipExcludedCsx()
+        {
+            var resolver = CreateResolver();
+            var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("InlineNugetPackageWithFileFiltering");
+            var csxFiles = Directory.GetFiles(targetDirectory, "InlineNugetPackage.csx");
+            var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
+            Assert.DoesNotContain(dependencies, d => d.Name == "AutoMapper");
+            Assert.Contains(dependencies, d => d.Name == "Newtonsoft.Json");
         }
 
         [Fact]
         public void ShouldGetCompilationDependenciesForPackageContainingNativeLibrary()
         {
             var resolver = CreateResolver();
-            var dependencies = resolver.GetDependencies(TestPathUtils.GetPathToTestFixtureFolder("NativeLibrary"), true, _scriptEnvironment.TargetFramework);
+            var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("NativeLibrary");
+            var csxFiles = Directory.GetFiles(targetDirectory, "*.csx");
+            var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
             Assert.Contains(dependencies, d => d.Name == "Microsoft.Data.Sqlite");
         }
 
@@ -37,9 +53,12 @@ namespace Dotnet.Script.Tests
         public void ShouldGetCompilationDependenciesForIssue129()
         {
             var resolver = CreateResolver();
-            var dependencies = resolver.GetDependencies(TestPathUtils.GetPathToTestFixtureFolder("Issue129"), true, _scriptEnvironment.TargetFramework);
+            var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("Issue129");
+            var csxFiles = Directory.GetFiles(targetDirectory, "*.csx");
+            var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
             Assert.Contains(dependencies, d => d.Name == "Auth0.ManagementApi");
         }       
+
         private CompilationDependencyResolver CreateResolver()
         {
             var resolver = new CompilationDependencyResolver(TestOutputHelper.CreateTestLogFactory());

--- a/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackageWithFileFiltering/InlineNugetPackage.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackageWithFileFiltering/InlineNugetPackage.csx
@@ -1,0 +1,4 @@
+﻿#r "nuget:Newtonsoft.Json"
+
+using Newtonsoft.Json;
+Console.WriteLine(typeof(JsonConvert));

--- a/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackageWithFileFiltering/SkippedInlineNugetPackage.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackageWithFileFiltering/SkippedInlineNugetPackage.csx
@@ -1,0 +1,4 @@
+﻿#r "nuget:AutoMapper"
+
+using AutoMapper;
+Console.WriteLine(typeof(MapperConfiguration));


### PR DESCRIPTION
OmniSharp finds the CSX files once, we can avoid the extra scanning.
Also, OmniSharp allows users to exclude paths from scanning and we should respect that (at the moment we will find those CSX files).

fixes #279 