### PR TITLE
Updated to Roslyn 3.0.0 beta2 (C# 8)

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -33,9 +33,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0-beta2-final" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>0.29.0</VersionPrefix>
+    <VersionPrefix>0.29.0-beta1</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -34,6 +34,12 @@ namespace Dotnet.Script.Core
             {
                 CSharpScript.Create<object>("1", ScriptOptions.Default, typeof(CommandLineScriptGlobals), new InteractiveAssemblyLoader()).RunAsync(new CommandLineScriptGlobals(Console.Out, CSharpObjectFormatter.Instance)).GetAwaiter().GetResult();
             });
+
+            // reset default scripting mode to latest language version to enable C# 8.0 features
+            // this is not needed once Roslyn 3.0 stable ships
+            var csharpScriptCompilerType = typeof(CSharpScript).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.CSharp.Scripting.CSharpScriptCompiler");
+            var parseOptionsField = csharpScriptCompilerType?.GetField("s_defaultOptions", BindingFlags.Static | BindingFlags.NonPublic);
+            parseOptionsField?.SetValue(null, new CSharpParseOptions(LanguageVersion.CSharp8, kind: SourceCodeKind.Script));
         }
 
         protected virtual IEnumerable<string> ImportedNamespaces => new[]

--- a/src/Dotnet.Script.Core/Versioning/VersionProvider.cs
+++ b/src/Dotnet.Script.Core/Versioning/VersionProvider.cs
@@ -43,7 +43,6 @@ namespace Dotnet.Script.Core.Versioning
         public VersionInfo GetCurrentVersion()
         {
             var versionAttribute = typeof(VersionProvider).Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().Single();
-            var version = Version.Parse(versionAttribute.InformationalVersion);
             return new VersionInfo(versionAttribute.InformationalVersion, isResolved:true);
         }
     }

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>0.7.1</Version>
+    <Version>0.8.0-beta1</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -14,6 +14,6 @@
     <Company>dotnet-script</Company>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0-beta2-final" />
    </ItemGroup>
 </Project>

--- a/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
+++ b/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0-beta2-final" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.Tests/EnvironmentTests.cs
+++ b/src/Dotnet.Script.Tests/EnvironmentTests.cs
@@ -15,6 +15,12 @@ namespace Dotnet.Script.Tests
         public void ShouldPrintVersionNumber(string versionFlag)
         {
             var result = ScriptTestRunner.Default.Execute(versionFlag);
+
+            if (result.exitCode != 0)
+            {
+                Console.WriteLine(result.output);
+            }
+
             Assert.Equal(0, result.exitCode);
             // TODO test that version appears on first line of output!
             Assert.Matches(@"^[0-9]+(\.[0-9]+){2}$", result.output);

--- a/src/Dotnet.Script.Tests/EnvironmentTests.cs
+++ b/src/Dotnet.Script.Tests/EnvironmentTests.cs
@@ -15,15 +15,10 @@ namespace Dotnet.Script.Tests
         public void ShouldPrintVersionNumber(string versionFlag)
         {
             var result = ScriptTestRunner.Default.Execute(versionFlag);
-
-            if (result.exitCode != 0)
-            {
-                Console.WriteLine(result.output);
-            }
-
             Assert.Equal(0, result.exitCode);
             // TODO test that version appears on first line of output!
-            Assert.Matches(@"^[0-9]+(\.[0-9]+){2}$", result.output);
+            // semver regex from https://github.com/semver/semver/issues/232#issue-48635632
+            Assert.Matches(@"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$", result.output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -187,6 +187,14 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public void ShouldHandleCSharp80()
+        {
+            var result = ScriptTestRunner.Default.ExecuteFixture("CSharp80");
+            Assert.Equal(0, result.exitCode);
+
+        }
+
+        [Fact]
         public void ShouldEvaluateCode()
         {
             var code = "Console.WriteLine(12345);";

--- a/src/Dotnet.Script.Tests/TestFixtures/CSharp80/CSharp80.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/CSharp80/CSharp80.csx
@@ -1,0 +1,5 @@
+﻿// static local functions are C# 8.0 feature
+void Foo()
+{
+    static void Bar() { };
+}

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.29.0</VersionPrefix>
+        <VersionPrefix>0.29.0-beta1</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -22,7 +22,7 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-beta2-final" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     </ItemGroup>


### PR DESCRIPTION
We can release it as a prerelease version since the latest Roslyn is available as beta on Nuget.