### PR TITLE
Expose runner.execute to public.

### DIFF
--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -63,7 +63,7 @@ namespace Dotnet.Script.Core
             await RunLoop();
         }
 
-        protected virtual async Task Execute(string input)
+        public virtual async Task Execute(string input)
         {
             await HandleScriptErrors(async () =>
             {


### PR DESCRIPTION
I have to use the internal `run` method in my [project](https://github.com/SciSharp/ICSharpCore) which is a .NET Core based Jupyter Notebook kernel.