### PR TITLE
 bump Microsoft.Extensions.Logging.Console to latest stable

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -250,6 +250,13 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public void ShouldHandleIssue435()
+        {
+            var result = ScriptTestRunner.Default.ExecuteFixture("Issue435");
+            Assert.Contains("value:Microsoft.Extensions.Configuration.ConfigurationBuilder", result.output);
+        }
+
+        [Fact]
         public void ShouldThrowExceptionOnInvalidMediaType()
         {
             var url = "https://github.com/filipw/dotnet-script/archive/0.20.0.zip";

--- a/src/Dotnet.Script.Tests/TestFixtures/Issue435/Issue435.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Issue435/Issue435.csx
@@ -1,0 +1,6 @@
+﻿#r "nuget: Microsoft.Extensions.Configuration"
+
+using Microsoft.Extensions.Configuration;
+
+var builder = typeof(ConfigurationBuilder);
+Console.WriteLine("value:"+builder); 

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -24,7 +24,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-beta4-final" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />


### PR DESCRIPTION
Fixes #435 
This is not optimal long term to keep bumping these packages just so that CSX files can work for people, we should try to some sort of out-of-process execution (although performance might be a problem) where we'd have no impact of our own dependencies on the executed code.