### PR TITLE
Dependency bump

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0-beta4-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>0.29.0-beta1</VersionPrefix>
+    <VersionPrefix>0.29.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>0.8.0-beta1</Version>
+    <Version>0.8.0</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -14,6 +14,6 @@
     <Company>dotnet-script</Company>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0-beta4-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
    </ItemGroup>
 </Project>

--- a/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
+++ b/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
@@ -5,14 +5,14 @@
     <VersionPrefix>0.2.0</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dotnet.Script.Extras</AssemblyName>
-    <PackageId>Dotnet.Script.Extras</PackageId>    
+    <PackageId>Dotnet.Script.Extras</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>    
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0-beta4-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.29.0-beta1</VersionPrefix>
+        <VersionPrefix>0.29.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -22,7 +22,7 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-beta4-final" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     </ItemGroup>


### PR DESCRIPTION
This PR bumps the `Microsoft.CodeAnalysis.CSharp.Scripting` and `Microsoft.CodeAnalysis.CSharp` to version `3.0.0`. Also removed the beta suffix on our packages since we no longer rely on any beta packages. 