### PR TITLE
fixed the publish template and executing the published exe from a different folder

### DIFF
--- a/src/Dotnet.Script.Core/Templates/program.publish.template
+++ b/src/Dotnet.Script.Core/Templates/program.publish.template
@@ -4,12 +4,13 @@ using Microsoft.CodeAnalysis.Scripting.Hosting;
 using System.Threading.Tasks;
 using static System.Console;
 using System.Reflection;
+using System.IO;
 
 namespace dotnetPublishCode
 {
     class Program
     {
-        static async Task Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             try
             {
@@ -17,14 +18,21 @@ namespace dotnetPublishCode
                 foreach (var arg in args)
                     globals.Args.Add(arg);
 
-                var assembly = Assembly.LoadFrom("scriptAssembly.dll");
+                var path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                var assembly = Assembly.LoadFrom(Path.Combine(path, "scriptAssembly.dll"));
                 var type = assembly.GetType("Submission#0");
                 var factoryMethod = type.GetMethod("<Factory>");
                 if (factoryMethod == null) throw new Exception("couldn't find factory method to initiate script");
 
                 var invokeTask = factoryMethod.Invoke(null, new object[] { new object[] { globals, null } }) as Task<int>;
                 var invokeResult = await invokeTask;
-                if (invokeResult != 0) WritePrettyError($"Error result: '{invokeResult}'");
+                if (invokeResult != 0) 
+                {
+                    WritePrettyError($"Error result: '{invokeResult}'");
+                    return 0x1;
+                }
+
+                return 0;
             }
             catch (Exception ex)
             {
@@ -33,6 +41,7 @@ namespace dotnetPublishCode
                     ex = aggregateEx.Flatten().InnerException;
                 }
                 WritePrettyError(ex.ToString());
+                return 0x1;
             }
         }
 


### PR DESCRIPTION
1) we didn't return error code (it was always 0)
2) since we always returned 0, some of the publish-execute tests passed even when they should fail, since they were always checking for return code 0
3) after publishing, running the exe from a different folder than published one didn't work, because we'd try to load the script assembly using `Assembly.LoadFrom("scriptAssembly.dll");` which would search in the current folder, not in the published folder