### PR TITLE
include exception type in exception output in interactive

### DIFF
--- a/src/Dotnet.Script.Core/CSharpObjectFormatterExtensions.cs
+++ b/src/Dotnet.Script.Core/CSharpObjectFormatterExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
+
+namespace Dotnet.Script.Core
+{
+    internal static class CSharpObjectFormatterExtensions 
+    {
+        internal static string ToDisplayString(this CSharpObjectFormatter csharpObjectFormatter, Exception ex) 
+        {
+            var builder = new StringBuilder();
+            builder.Append(ex.GetType());
+            builder.Append(": ");
+            builder.Append(csharpObjectFormatter.FormatException(ex));
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Dotnet.Script.Core/Extensions.cs
+++ b/src/Dotnet.Script.Core/Extensions.cs
@@ -5,7 +5,7 @@ namespace Dotnet.Script.Core
 {
     public static class Extensions
     {
-         public static string GetRootedPath(this string path) => Path.IsPathRooted(path) ? path : Path.Combine(Directory.GetCurrentDirectory(), path);
+        public static string GetRootedPath(this string path) => Path.IsPathRooted(path) ? path : Path.Combine(Directory.GetCurrentDirectory(), path);
 
         public static SourceText ToSourceText(this string absoluteFilePath)
         {

--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -150,7 +150,7 @@ namespace Dotnet.Script.Core
                 await doWork();
                 if (_scriptState?.Exception != null)
                 {
-                    Console.WriteError(CSharpObjectFormatter.Instance.FormatException(_scriptState.Exception));
+                    Console.WriteError(CSharpObjectFormatter.Instance.ToDisplayString(_scriptState.Exception));
                 }
 
                 if (_scriptState?.ReturnValue != null)
@@ -169,7 +169,7 @@ namespace Dotnet.Script.Core
             }
             catch (Exception e)
             {
-                Console.WriteError(CSharpObjectFormatter.Instance.FormatException(e));
+                Console.WriteError(CSharpObjectFormatter.Instance.ToDisplayString(e));
             }
 
             return null;

--- a/src/Dotnet.Script.Shared.Tests/InteractiveRunnerTestsBase.cs
+++ b/src/Dotnet.Script.Shared.Tests/InteractiveRunnerTestsBase.cs
@@ -118,7 +118,7 @@ namespace Dotnet.Script.Shared.Tests
             var errorResult = ctx.Console.Error.ToString();
             var result = ctx.Console.Out.ToString();
             Assert.Contains("2", result);
-            Assert.Contains("die!", errorResult);
+            Assert.Contains("System.Exception: die!", errorResult);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #433 

At the moment we used Roslyn formatter, but I think the change makes sense. I will propose the same in Roslyn.