### PR TITLE
Nullable context support at compile time

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta2-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta3-final" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta2-final" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
@@ -43,7 +43,7 @@
     We need to figure out why we can't load these via the dependency context.
      -->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -116,6 +116,21 @@ namespace Dotnet.Script.Core
                 _globals.Args.Add(arg);
 
             var compilationContext = ScriptCompiler.CreateCompilationContext<object, InteractiveScriptGlobals>(scriptContext);
+            foreach (var warning in compilationContext.Warnings)
+            {
+                Console.WriteHighlighted(warning.ToString());
+            }
+
+            if (compilationContext.Errors.Any())
+            {
+                foreach (var diagnostic in compilationContext.Errors)
+                {
+                    Console.WriteError(diagnostic.ToString());
+                }
+
+                throw new CompilationErrorException("Script compilation failed due to one or more errors.", compilationContext.Errors.ToImmutableArray());
+            }
+
             _scriptState = await compilationContext.Script.RunAsync(_globals, ex => true).ConfigureAwait(false);
             _scriptOptions = compilationContext.ScriptOptions;
         }

--- a/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
+++ b/src/Dotnet.Script.Core/Interactive/InteractiveRunner.cs
@@ -21,8 +21,7 @@ namespace Dotnet.Script.Core
         private bool _shouldExit = false;
         private ScriptState<object> _scriptState;
         private ScriptOptions _scriptOptions;
-        private InteractiveScriptGlobals _globals;
-
+        private readonly InteractiveScriptGlobals _globals;
         protected Logger Logger;
         protected ScriptCompiler ScriptCompiler;
         protected ScriptConsole Console;
@@ -113,21 +112,15 @@ namespace Dotnet.Script.Core
         private async Task RunFirstScript(ScriptContext scriptContext)
         {
             foreach (var arg in scriptContext.Args)
+            {
                 _globals.Args.Add(arg);
+            }
 
             var compilationContext = ScriptCompiler.CreateCompilationContext<object, InteractiveScriptGlobals>(scriptContext);
-            foreach (var warning in compilationContext.Warnings)
-            {
-                Console.WriteHighlighted(warning.ToString());
-            }
+            Console.WriteDiagnostics(compilationContext.Warnings, compilationContext.Errors);
 
             if (compilationContext.Errors.Any())
             {
-                foreach (var diagnostic in compilationContext.Errors)
-                {
-                    Console.WriteError(diagnostic.ToString());
-                }
-
                 throw new CompilationErrorException("Script compilation failed due to one or more errors.", compilationContext.Errors.ToImmutableArray());
             }
 

--- a/src/Dotnet.Script.Core/ScriptCompilationContext.cs
+++ b/src/Dotnet.Script.Core/ScriptCompilationContext.cs
@@ -1,7 +1,9 @@
 using Dotnet.Script.DependencyModel.Runtime;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Text;
+using System.Linq;
 
 namespace Dotnet.Script.Core
 {
@@ -15,15 +17,22 @@ namespace Dotnet.Script.Core
 
         public ScriptOptions ScriptOptions { get; }
 
-        public RuntimeDependency[] RuntimeDependencies {get;}
+        public RuntimeDependency[] RuntimeDependencies { get; }
 
-        public ScriptCompilationContext(Script<TReturn> script, SourceText sourceText, InteractiveAssemblyLoader loader, ScriptOptions scriptOptions, RuntimeDependency[] runtimeDependencies)
+        public Diagnostic[] Warnings { get; }
+
+        public Diagnostic[] Errors { get; }
+
+        public ScriptCompilationContext(Script<TReturn> script, SourceText sourceText, InteractiveAssemblyLoader loader, ScriptOptions scriptOptions, RuntimeDependency[] runtimeDependencies, Diagnostic[] diagnostics)
         {
             Script = script;
             SourceText = sourceText;
             ScriptOptions = scriptOptions;
             Loader = loader;
             RuntimeDependencies = runtimeDependencies;
+
+            Warnings = diagnostics.Where(x => x.Severity == DiagnosticSeverity.Warning).ToArray();
+            Errors = diagnostics.Where(x => x.Severity == DiagnosticSeverity.Error).ToArray();
         }
     }
 }

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -29,12 +29,6 @@ namespace Dotnet.Script.Core
 
         static ScriptCompiler()
         {
-            // reset default scripting mode to latest language version to enable C# 8.0 features
-            // this is not needed once Roslyn 3.0 stable ships
-            var csharpScriptCompilerType = typeof(CSharpScript).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.CSharp.Scripting.CSharpScriptCompiler");
-            var parseOptionsField = csharpScriptCompilerType?.GetField("s_defaultOptions", BindingFlags.Static | BindingFlags.NonPublic);
-            parseOptionsField?.SetValue(null, new CSharpParseOptions(LanguageVersion.CSharp8, kind: SourceCodeKind.Script));
-
             // force Roslyn to use ReferenceManager for the first time
             Task.Run(() =>
             {
@@ -59,7 +53,7 @@ namespace Dotnet.Script.Core
         // see: https://github.com/dotnet/roslyn/issues/5501
         protected virtual IEnumerable<string> SuppressedDiagnosticIds => new[] { "CS1701", "CS1702", "CS1705" };
 
-        public CSharpParseOptions ParseOptions { get; } = new CSharpParseOptions(LanguageVersion.CSharp8, kind: SourceCodeKind.Script);
+        public CSharpParseOptions ParseOptions { get; } = new CSharpParseOptions(LanguageVersion.Preview, kind: SourceCodeKind.Script);
 
         public RuntimeDependencyResolver RuntimeDependencyResolver { get; }
 
@@ -83,6 +77,7 @@ namespace Dotnet.Script.Core
                 .WithSourceResolver(new NuGetSourceReferenceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, context.WorkingDirectory),scriptMap))
                 .WithMetadataResolver(new NuGetMetadataReferenceResolver(ScriptMetadataResolver.Default.WithBaseDirectory(context.WorkingDirectory)))
                 .WithEmitDebugInformation(true)
+                .WithLanguageVersion(LanguageVersion.Preview)
                 .WithFileEncoding(context.Code.Encoding);
 
             // if the framework is not Core CLR, add GAC references

--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Microsoft.CodeAnalysis;
 using RL = System.ReadLine;
 
 namespace Dotnet.Script.Core
@@ -38,6 +39,25 @@ namespace Dotnet.Script.Core
         public virtual void WriteNormal(string value)
         {
             Out.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
+        }
+
+        public virtual void WriteDiagnostics(Diagnostic[] warningDiagnostics, Diagnostic[] errorDiagnostics) 
+        {
+            if (warningDiagnostics != null) 
+            {
+                foreach (var warning in warningDiagnostics)
+                {
+                    WriteHighlighted(warning.ToString());
+                }
+            }
+
+            if (warningDiagnostics != null) 
+            {
+                foreach (var error in errorDiagnostics)
+                {
+                    WriteError(error.ToString());
+                }
+            }
         }
 
         public virtual string ReadLine()

--- a/src/Dotnet.Script.Core/ScriptRunner.cs
+++ b/src/Dotnet.Script.Core/ScriptRunner.cs
@@ -81,18 +81,10 @@ namespace Dotnet.Script.Core
         public virtual Task<TReturn> Execute<TReturn, THost>(ScriptContext context, THost host)
         {
             var compilationContext = ScriptCompiler.CreateCompilationContext<TReturn, THost>(context);
-            foreach (var warning in compilationContext.Warnings)
-            {
-                ScriptConsole.WriteHighlighted(warning.ToString());
-            }
+            ScriptConsole.WriteDiagnostics(compilationContext.Warnings, compilationContext.Errors);
 
             if (compilationContext.Errors.Any())
             {
-                foreach (var diagnostic in compilationContext.Errors)
-                {
-                    ScriptConsole.WriteError(diagnostic.ToString());
-                }
-
                 throw new CompilationErrorException("Script compilation failed due to one or more errors.", compilationContext.Errors.ToImmutableArray());
             }
 

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -14,6 +14,6 @@
     <Company>dotnet-script</Company>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta2-final" />
    </ItemGroup>
 </Project>

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -14,6 +14,6 @@
     <Company>dotnet-script</Company>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta2-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta3-final" />
    </ItemGroup>
 </Project>

--- a/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
+++ b/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta2-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta3-final" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
+++ b/src/Dotnet.Script.Extras/Dotnet.Script.Extras.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta2-final" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -36,6 +36,21 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public void ShouldHandleNullableContextAsError()
+        {
+            var result = ScriptTestRunner.Default.ExecuteFixture("Nullable");
+            Assert.Equal(1, result.exitCode);
+            Assert.Contains("error CS8625", result.output);
+        }
+
+        [Fact]
+        public void ShouldNotHandleDisabledNullableContextAsError()
+        {
+            var result = ScriptTestRunner.Default.ExecuteFixture("NullableDisabled");
+            Assert.Equal(0, result.exitCode);
+        }
+
+        [Fact]
         public void ShouldIncludeExceptionLineNumberAndFile()
         {
             var result = ScriptTestRunner.Default.ExecuteFixture("Exception", "--no-cache");

--- a/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackage/InlineNugetPackage.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackage/InlineNugetPackage.csx
@@ -1,4 +1,15 @@
 ﻿#r "nuget:AutoMapper, 6.1.1"
 
+#nullable enable
+#warning blah
 using AutoMapper;
+
+string x = null;
 Console.WriteLine(typeof(MapperConfiguration));
+
+void SayHi(string hi)
+{
+    Console.WriteLine(hi);
+}
+
+SayHi(null);

--- a/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackage/InlineNugetPackage.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/InlineNugetPackage/InlineNugetPackage.csx
@@ -1,10 +1,7 @@
 ﻿#r "nuget:AutoMapper, 6.1.1"
 
-#nullable enable
-#warning blah
 using AutoMapper;
 
-string x = null;
 Console.WriteLine(typeof(MapperConfiguration));
 
 void SayHi(string hi)

--- a/src/Dotnet.Script.Tests/TestFixtures/Nullable/Nullable.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Nullable/Nullable.csx
@@ -1,0 +1,4 @@
+#nullable enable
+
+string x = null;
+Console.WriteLine(x);

--- a/src/Dotnet.Script.Tests/TestFixtures/NullableDisabled/NullableDisabled.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/NullableDisabled/NullableDisabled.csx
@@ -1,0 +1,2 @@
+string x = null;
+Console.WriteLine(x);

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -22,7 +22,7 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0-beta2-final" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0-beta3-final" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     </ItemGroup>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -22,7 +22,7 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0-beta2-final" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     </ItemGroup>


### PR DESCRIPTION
Fixes #411 

We treat all nullability diagnostics as errors if the nullable analysis is enabled using the pragma (as discussed).
This should be merged only after we release the current master (so that we make a clean release from master, since this PR bring in Roslyn 3.1.0-beta).