### PR TITLE
Bugfix/azure pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ build/Chocolatey/tools/LICENSE.TXT
 build/.vscode
 build/Artifacts
 coverage.info
+# Ignore these since we download dotnet-script into the root folder on the build server.
+dotnet-script
+dotnet-script.zip
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,15 @@
 resources:
 - repo: self
 
+trigger:
+  tags:
+    include:
+      - refs/tags/*
+  branches:
+    include:
+    - '*'
+
+
 jobs:
 
 - job: Job_3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ trigger:
     include:
     - '*'
 
+variables:
+- group: dotnet-script-api-keys
 
 jobs:
 

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.3.1"
+#load "nuget:Dotnet.Build, 0.3.9"
 #load "nuget:dotnet-steps, 0.0.1"
 #load "nuget:github-changelog, 0.1.5"
 #load "Choco.csx"
@@ -54,22 +54,22 @@ private void CreateChocoPackage()
 
 private void CreateGlobalToolPackage()
 {
-    using(var globalToolBuildFolder = new DisposableFolder())
+    using (var globalToolBuildFolder = new DisposableFolder())
     {
         Copy(solutionFolder, globalToolBuildFolder.Path);
         PatchPackAsTool(globalToolBuildFolder.Path);
         PatchPackageId(globalToolBuildFolder.Path, GlobalToolPackageId);
         PatchContent(globalToolBuildFolder.Path);
-        Command.Execute("dotnet",$"pack --configuration release --output {nuGetArtifactsFolder}", Path.Combine(globalToolBuildFolder.Path,"Dotnet.Script"));
+        Command.Execute("dotnet", $"pack --configuration release --output {nuGetArtifactsFolder}", Path.Combine(globalToolBuildFolder.Path, "Dotnet.Script"));
     }
 }
 
 private void CreateNuGetPackages()
 {
-    Command.Execute("dotnet",$"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptProjectFolder);
-    Command.Execute("dotnet",$"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptCoreProjectFolder);
-    Command.Execute("dotnet",$"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptDependencyModelProjectFolder);
-    Command.Execute("dotnet",$"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptDependencyModelNuGetProjectFolder);
+    Command.Execute("dotnet", $"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptProjectFolder);
+    Command.Execute("dotnet", $"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptCoreProjectFolder);
+    Command.Execute("dotnet", $"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptDependencyModelProjectFolder);
+    Command.Execute("dotnet", $"pack --configuration release --output {nuGetArtifactsFolder}", dotnetScriptDependencyModelNuGetProjectFolder);
 }
 
 
@@ -98,8 +98,8 @@ private async Task PublishRelease()
     if (Git.Default.IsTagCommit())
     {
         Git.Default.RequreCleanWorkingTree();
-        await ReleaseManagerFor(owner, projectName,BuildEnvironment.GitHubAccessToken)
-        .CreateRelease(Git.Default.GetLatestTag(), pathToReleaseNotes, new [] { new ZipReleaseAsset(pathToGitHubReleaseAsset) });
+        await ReleaseManagerFor(owner, projectName, BuildEnvironment.GitHubAccessToken)
+        .CreateRelease(Git.Default.GetLatestTag(), pathToReleaseNotes, new[] { new ZipReleaseAsset(pathToGitHubReleaseAsset) });
         NuGet.TryPush(nuGetArtifactsFolder);
         Choco.TryPush(chocolateyArtifactsFolder, BuildEnvironment.ChocolateyApiKey);
     }
@@ -118,7 +118,7 @@ private async Task CreateReleaseNotes()
 
 private void PatchPackAsTool(string solutionFolder)
 {
-    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
+    var pathToDotnetScriptProject = Path.Combine(solutionFolder, "Dotnet.Script", "Dotnet.Script.csproj");
     var projectFile = XDocument.Load(pathToDotnetScriptProject);
     var packAsToolElement = projectFile.Descendants("PackAsTool").Single();
     packAsToolElement.Value = "true";
@@ -127,7 +127,7 @@ private void PatchPackAsTool(string solutionFolder)
 
 private void PatchPackageId(string solutionFolder, string packageId)
 {
-    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
+    var pathToDotnetScriptProject = Path.Combine(solutionFolder, "Dotnet.Script", "Dotnet.Script.csproj");
     var projectFile = XDocument.Load(pathToDotnetScriptProject);
     var packAsToolElement = projectFile.Descendants("PackageId").Single();
     packAsToolElement.Value = packageId;
@@ -136,7 +136,7 @@ private void PatchPackageId(string solutionFolder, string packageId)
 
 private void PatchContent(string solutionFolder)
 {
-    var pathToDotnetScriptProject = Path.Combine(solutionFolder,"Dotnet.Script","Dotnet.Script.csproj");
+    var pathToDotnetScriptProject = Path.Combine(solutionFolder, "Dotnet.Script", "Dotnet.Script.csproj");
     var projectFile = XDocument.Load(pathToDotnetScriptProject);
     var contentElements = projectFile.Descendants("Content").ToArray();
     foreach (var contentElement in contentElements)

--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.3.1"
+#load "nuget:Dotnet.Build, 0.3.9"
 using static FileUtils;
 using System.Xml.Linq;
 


### PR DESCRIPTION
This PR adds support for mapping the environment variables containing the api keys we need to publish to NuGet, Chocolatey and GitHub releases. Also added a tag trigger that triggers the build when a new tag is created (tag commit). This is to support the same release flow we had on AppVeyor.