### PR TITLE
Fixed bug in ScriptFilesResolver

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptFilesResolver.cs
@@ -60,13 +60,13 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         }
 
         private static string[] GetLoadDirectives(string content)
-        {            
+        {
             var matches = Regex.Matches(content, @"^\s*#load\s*""\s*(.+)\s*""", RegexOptions.Multiline);
             List<string> result = new List<string>();
             foreach (var match in matches.Cast<Match>())
             {
                 var value = match.Groups[1].Value;
-                if (value.StartsWith("nuget", StringComparison.InvariantCultureIgnoreCase))
+                if (value.StartsWith("nuget:", StringComparison.InvariantCultureIgnoreCase))
                 {
                     continue;
                 }

--- a/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptFilesResolverTests.cs
@@ -94,6 +94,23 @@ namespace Dotnet.Script.Tests
             }
         }
 
+        [Fact]
+        public void ShouldParseFilesStartingWithNuGet()
+        {
+            using (var rootFolder = new DisposableFolder())
+            {
+                var rootScript = WriteScript("#load \"NuGet.csx\"", rootFolder.Path, "Foo.csx");
+                WriteScript(string.Empty, rootFolder.Path, "NuGet.csx");
+                var scriptFilesResolver = new ScriptFilesResolver();
+
+                var files = scriptFilesResolver.GetScriptFiles(rootScript);
+
+                Assert.True(files.Count == 2);
+                Assert.Contains(files, f => f.Contains("Foo.csx"));
+                Assert.Contains(files, f => f.Contains("NuGet.csx"));
+            }
+        }
+
         private static string WriteScript(string content, string folder, string name)
         {
             var fullPath = Path.Combine(folder, name);


### PR DESCRIPTION
This fixes a bug that caused the `ScriptFilesResolver` to ignore `csx`files starting with `nuget`. 
