### PR TITLE
Fix the NRE when executing a blank file

### DIFF
--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
@@ -32,6 +32,11 @@ namespace Dotnet.Script.Core.Commands
             }
 
             var pathToLibrary = GetLibrary(options);
+            if (pathToLibrary == null)
+            {
+                return default(TReturn);
+            }
+
             return await ExecuteLibrary<TReturn>(pathToLibrary, options.Arguments, options.NoCache);
         }
 
@@ -64,7 +69,12 @@ namespace Dotnet.Script.Core.Commands
             string CreateLibrary()
             {
                 var options = new PublishCommandOptions(executeOptions.File,executionCacheFolder, "script", PublishType.Library,executeOptions.OptimizationLevel, executeOptions.PackageSources, null, executeOptions.NoCache);
-                new PublishCommand(_scriptConsole, _logFactory).Execute(options);
+                var success = new PublishCommand(_scriptConsole, _logFactory).Execute(options);
+                if (!success)
+                {
+                    return null;
+                }
+
                 if (hash != null)
                 {
                     File.WriteAllText(Path.Combine(executionCacheFolder, "script.sha256"), hash);


### PR DESCRIPTION
Closes #388.

In `var emitResult = _scriptEmitter.Emit<TReturn, THost>(context);`, `emitResult.Success` is `true` but both `PeStream` and `RuntimeDependencies` are then `null` when a blank file is fed in.

I avoided this by checking the length of the source text and adding a return value to the publish command. If the length is non-zero, everything proceeds as usual, but if it is zero, the publish command returns `false` and subsequently that is caught in the execute script command which then proceeds ignore the attempt to execute (otherwise it would fail as the script file would not exist on disk since the publish command cannot create it).

I used a `bool` return value, if you prefer me to throw an exception to control the flow (hopefully you don't) or use an enum for the return value, I am happy to adjust.

I didn't test this beyond `dotnet run empty.csx` in the `Dotnet.Script` project directory.