### PR TITLE
Fixed obsolete NuGet API

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -4,7 +4,7 @@
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
     <VersionPrefix>0.29.1</VersionPrefix>
     <Authors>filipw</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>
     <PackageId>Dotnet.Script.Core</PackageId>
     <PackageTags>script;csx;csharp;roslyn</PackageTags>
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -101,6 +101,16 @@ namespace Dotnet.Script.Core
                     "System.Xml.Linq",
                     "System.Net.Http",
                     "Microsoft.CSharp");
+
+                // on *nix load netstandard
+                if (!ScriptEnvironment.Default.IsWindows)
+                {
+                    var netstandard = Assembly.Load("netstandard");
+                    if (netstandard != null)
+                    {
+                        opts = opts.AddReferences(MetadataReference.CreateFromFile(netstandard.Location));
+                    }
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(context.FilePath))

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>
     <Description>Provides runtime and compilation dependency resolution for dotnet-script based scripts.</Description>
@@ -26,8 +26,6 @@
   <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel" Version="5.0.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All"/>
-
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="4.9.3" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.0.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
 
   </ItemGroup>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel" Version="5.0.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All"/>
 
   </ItemGroup>
 

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>
     <Description>Provides runtime and compilation dependency resolution for dotnet-script based scripts.</Description>

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/NuGetUtilities.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/NuGetUtilities.cs
@@ -26,7 +26,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static void CopySection(ISettings sourceSettings, ISettings targetSettings, string sectionName)
         {
-            var existingAddItems = sourceSettings.GetSection(sectionName)?.Items.Where(item => item is object && item is SourceItem && item.ElementName.ToLowerInvariant() == "add").Cast<AddItem>();
+            var existingAddItems = sourceSettings.GetSection(sectionName)?.Items.Where(item => item is object && (item is SourceItem || item is AddItem) && item.ElementName.ToLowerInvariant() == "add").Cast<AddItem>();
 
             if (existingAddItems == null)
             {

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/NuGetUtilities.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/NuGetUtilities.cs
@@ -1,70 +1,64 @@
 using NuGet.Configuration;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Dotnet.Script.DependencyModel.ProjectSystem
 {
     internal static class NuGetUtilities
     {
-        struct NuGetConfigSection
-        {
-            public string Name;
-            public HashSet<string> KeysForPathValues;
-            public bool AreAllValuesPaths;
-        }
-
-        static readonly NuGetConfigSection[] NuGetSections = 
-        {
-            new NuGetConfigSection { Name = "config", KeysForPathValues = new HashSet<string> { "globalPackagesFolder", "repositoryPath" } },
-            new NuGetConfigSection { Name = "bindingRedirects" },
-            new NuGetConfigSection { Name = "packageRestore" },
-            new NuGetConfigSection { Name = "solution" },
-            new NuGetConfigSection { Name = "packageSources", AreAllValuesPaths = true },
-            new NuGetConfigSection { Name = "packageSourceCredentials" },
-            new NuGetConfigSection { Name = "apikeys" },
-            new NuGetConfigSection { Name = "disabledPackageSources" },
-            new NuGetConfigSection { Name = "activePackageSource" },
-        };
-
-        // Create a NuGet file containing all properties with resolved absolute paths
         public static void CreateNuGetConfigFromLocation(string pathToEvaluate, string targetDirectory)
         {
-            var settings = Settings.LoadDefaultSettings(pathToEvaluate);
-            var target = new Settings(targetDirectory);
+            var sourceSettings = Settings.LoadDefaultSettings(pathToEvaluate);
+            var targetSettings = new Settings(targetDirectory);
 
-            var valuesToSet = new List<SettingValue>();
-            foreach (var section in NuGetSections)
+            CopySection(sourceSettings, targetSettings, "config");
+            CopySection(sourceSettings, targetSettings, "bindingRedirects");
+            CopySection(sourceSettings, targetSettings, "packageRestore");
+            CopySection(sourceSettings, targetSettings, "solution");
+            CopySection(sourceSettings, targetSettings, "packageSources");
+            CopySection(sourceSettings, targetSettings, "packageSourceCredentials");
+            CopySection(sourceSettings, targetSettings, "apikeys");
+            CopySection(sourceSettings, targetSettings, "disabledPackageSources");
+            CopySection(sourceSettings, targetSettings, "activePackageSource");
+
+            targetSettings.SaveToDisk();
+        }
+
+        private static void CopySection(ISettings sourceSettings, ISettings targetSettings, string sectionName)
+        {
+            var existingAddItems = sourceSettings.GetSection(sectionName)?.Items.Cast<AddItem>();
+
+            if (existingAddItems == null)
             {
-                // Resolve properly path values
-                valuesToSet.Clear();
-                if (section.AreAllValuesPaths)
+                return;
+            }
+
+            foreach (var addItem in existingAddItems)
+            {
+                if (ShouldResolvePath(sectionName, addItem.Key))
                 {
-                    // All values are paths
-                    var values = settings.GetSettingValues(section.Name, true);
-                    valuesToSet.AddRange(values);
+                    targetSettings.AddOrUpdate(sectionName, new AddItem(addItem.Key, addItem.GetValueAsPath()));
                 }
                 else
                 {
-                    var values = settings.GetSettingValues(section.Name, false);
-                    if (section.KeysForPathValues != null)
-                    {
-                        // Some values are path
-                        foreach (var value in values)
-                        {
-                            if (section.KeysForPathValues.Contains(value.Key))
-                            {
-                                var val = settings.GetValue(section.Name, value.Key, true);
-                                value.Value = val;
-                            }
-
-                            valuesToSet.Add(value);
-                        }
-                    }
-                    else
-                        // All values are not path
-                        valuesToSet.AddRange(values);
+                    targetSettings.AddOrUpdate(sectionName, addItem);
                 }
-                target.SetValues(section.Name, valuesToSet);
             }
+        }
+
+        private static bool ShouldResolvePath(string sectionName, string key)
+        {
+            if (sectionName == "packageSources")
+            {
+                return true;
+            }
+
+            if (sectionName == "config")
+            {
+                return key == "globalPackagesFolder" || key == "repositoryPath";
+            }
+
+            return false;
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/NuGetUtilities.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/NuGetUtilities.cs
@@ -26,7 +26,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         private static void CopySection(ISettings sourceSettings, ISettings targetSettings, string sectionName)
         {
-            var existingAddItems = sourceSettings.GetSection(sectionName)?.Items.Cast<AddItem>();
+            var existingAddItems = sourceSettings.GetSection(sectionName)?.Items.Where(item => item is object && item is SourceItem && item.ElementName.ToLowerInvariant() == "add").Cast<AddItem>();
 
             if (existingAddItems == null)
             {

--- a/src/Dotnet.Script.Desktop.Tests/Dotnet.Script.Desktop.Tests.csproj
+++ b/src/Dotnet.Script.Desktop.Tests/Dotnet.Script.Desktop.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/src/Dotnet.Script.Tests/NuGetUtilitiesTests.cs
+++ b/src/Dotnet.Script.Tests/NuGetUtilitiesTests.cs
@@ -2,6 +2,7 @@ using Dotnet.Script.DependencyModel.ProjectSystem;
 using NuGet.Configuration;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -213,9 +214,9 @@ namespace Dotnet.Script.Tests
                 {
                     foreach (var expectedSetting in expectedSettings.Value)
                     {
-                        var value = settings.GetValue(expectedSettings.Key, expectedSetting.Key);
+                        var value = settings.GetSection(expectedSettings.Key).Items.Cast<AddItem>().First(i => i.Key == expectedSetting.Key);
                         var resolvedExpectedSetting = string.Format(expectedSetting.Value, sourceFolder, rootTokens);
-                        Assert.Equal(resolvedExpectedSetting, value);
+                        Assert.Equal(resolvedExpectedSetting, value.Value);
                     }
                 }
             }

--- a/src/Dotnet.Script.Tests/TestFixtures/LocalNuGetConfig/NuGet.Config
+++ b/src/Dotnet.Script.Tests/TestFixtures/LocalNuGetConfig/NuGet.Config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     </packageSources>
 </configuration>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.29.1</VersionPrefix>
+        <VersionPrefix>0.30.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFramework>netcoreapp2.1</TargetFramework>


### PR DESCRIPTION
This PR fixes #460 and we now use `Nuget.ProjectModel 5.0.0` which is compatible with the version used in OmniSharp. 

Also bumped the version numbers for the next release. 

