### PR TITLE
Unified launch config

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -19,17 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Templates\helloworld.csx.template" />
-    <None Remove="Templates\launch.json.template" />
-    <None Remove="Templates\omnisharp.json.template" />
-    <None Remove="Templates\program.publish.template" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Templates\helloworld.csx.template" />
-    <EmbeddedResource Include="Templates\launch.json.template" />
-    <EmbeddedResource Include="Templates\omnisharp.json.template" />
-    <EmbeddedResource Include="Templates\program.publish.template" />
+    <EmbeddedResource Include="**/*.template" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -14,15 +14,20 @@ namespace Dotnet.Script.Core
 {
     public class Scaffolder
     {
-        private ScriptEnvironment _scriptEnvironment;
+        private readonly ScriptEnvironment _scriptEnvironment;
         private const string DefaultScriptFileName = "main.csx";
-        private ScriptConsole _scriptConsole = ScriptConsole.Default;
-        private CommandRunner _commandRunner;
+        private readonly ScriptConsole _scriptConsole;
+        private readonly CommandRunner _commandRunner;
 
-        public Scaffolder(LogFactory logFactory)
+        public Scaffolder(LogFactory logFactory) : this(logFactory, ScriptConsole.Default, ScriptEnvironment.Default)
+        {
+        }
+
+        public Scaffolder(LogFactory logFactory, ScriptConsole scriptConsole, ScriptEnvironment scriptEnvironment)
         {
             _commandRunner = new CommandRunner(logFactory);
-            _scriptEnvironment = ScriptEnvironment.Default;
+            _scriptConsole = scriptConsole;
+            _scriptEnvironment = scriptEnvironment;
         }
 
         public void InitializerFolder(string fileName, string currentWorkingDirectory)

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -174,7 +174,7 @@ namespace Dotnet.Script.Core
                 }
                 else
                 {
-                    string pattern = @"^(\s*"")(.*dotnet-script.dll)("").*$";
+                    string pattern = @"^(\s*"")(.*dotnet-script.dll)(""\s*,).*$";
                     if (Regex.IsMatch(launchFileContent, pattern, RegexOptions.Multiline))
                     {
                         var newLaunchFileContent = Regex.Replace(launchFileContent, pattern, $"$1{dotnetScriptPath}$3", RegexOptions.Multiline);

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -169,7 +169,7 @@ namespace Dotnet.Script.Core
                     if (template != launchFileContent)
                     {
                         File.WriteAllText(pathToLaunchFile, template);
-                        _scriptConsole.WriteHighlighted("...Use global tool [Updated]");
+                        _scriptConsole.WriteHighlighted("...Use global tool launch config [Updated]");
                     }
                 }
                 else

--- a/src/Dotnet.Script.Core/Templates/globaltool.launch.json.template
+++ b/src/Dotnet.Script.Core/Templates/globaltool.launch.json.template
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Script Debug",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${env:HOME}/.dotnet/tools/dotnet-script",
+      "args": ["${file}"],
+      "windows": {
+        "program": "${env:USERPROFILE}/.dotnet/tools/dotnet-script.exe",
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": true,
+    }
+  ]
+}

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -216,9 +216,7 @@ namespace Dotnet.Script.Tests
             var scriptEnvironment = (ScriptEnvironment)Activator.CreateInstance(typeof(ScriptEnvironment), nonPublic: true);
             var installLocationField = typeof(ScriptEnvironment).GetField("_installLocation", BindingFlags.NonPublic | BindingFlags.Instance);
             installLocationField.SetValue(scriptEnvironment, new Lazy<string>(() => installLocation));
-            StringWriter output = new StringWriter();
-            StringWriter error = new StringWriter();
-            var scriptConsole = new ScriptConsole(output, StringReader.Null, error);
+            var scriptConsole = new ScriptConsole(StringWriter.Null, StringReader.Null, StreamWriter.Null);
             var scaffolder = new Scaffolder(TestOutputHelper.CreateTestLogFactory(), scriptConsole, scriptEnvironment);
             return scaffolder;
         }

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -5,7 +5,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -172,7 +171,7 @@ namespace Dotnet.Script.Tests
                 var pathToLaunchConfiguration = Path.Combine(scriptFolder.Path, ".vscode/launch.json");
                 var config = JObject.Parse(File.ReadAllText(pathToLaunchConfiguration));
 
-                config.SelectToken("configurations[0].args[1]").Replace("InvalidPath/dotnet-script.dll,");
+                config.SelectToken("configurations[0].args[1]").Replace("InvalidPath/dotnet-script.dll");
 
                 File.WriteAllText(pathToLaunchConfiguration, config.ToString());
 


### PR DESCRIPTION
This PR fixes #441 and #308 by creating an unified `launch.json` file when `dotnet-script` is installed as a global tool.  Since installing as a global tool is the preferred way of installing `dotnet-script`, this should cover most of the cases. 

Note that this makes it possible to use the same `launch.json` file across operating systems as well as between versions of `dotnet-script`.

The solution is based on the comments by @Ishearer and @natemcmaster in issue #308. 

I have tested that it works on Mac, Linux and Windows.

Also fixed a bug that caused the `launch.json` file to be corrupted when the path tp `dotnet-script.dll` is updated. So this is now fixed for non global tool installs. 

See https://github.com/filipw/dotnet-script/issues/441#issuecomment-489390075 for details on the file corruption. 


