### PR TITLE
Use quotes around output folder

### DIFF
--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -85,7 +85,7 @@ namespace Dotnet.Script.Core
 
             var commandRunner = new CommandRunner(logFactory);
             // todo: may want to add ability to return dotnet.exe errors
-            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o {context.WorkingDirectory}");
+            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o \"{context.WorkingDirectory}\"");
             if (exitcode != 0)
             {
                 throw new Exception($"dotnet publish failed with result '{exitcode}'");

--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -46,7 +46,7 @@ namespace Dotnet.Script.DependencyModel.Context
             {
                 return string.IsNullOrWhiteSpace(projectFileInfo.NuGetConfigFile)
                     ? string.Empty
-                    : $"--configfile {projectFileInfo.NuGetConfigFile}";
+                    : $"--configfile \"{projectFileInfo.NuGetConfigFile}\"";
 
             }
         }


### PR DESCRIPTION
This PR fixes #456 by making sure we put quotes around the publishing output folder 