### PR TITLE
Handle version number with more than 3 subparts

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/PackageVersion.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/PackageVersion.cs
@@ -8,7 +8,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
     /// </summary>
     public class PackageVersion : IEquatable<PackageVersion>
     {
-        private static Regex IsPinnedRegex = new Regex(@"^(?>\[\d+[^,\]]+(?<!\.)\]|\d+\.\d+\.\d+)$", RegexOptions.Compiled);
+        private static Regex IsPinnedRegex = new Regex(@"^(?>\[\d+[^,\]]+(?<!\.)\]|\d+(\.\d+){2,})$", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PackageVersion"/> class.
@@ -29,7 +29,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         /// <summary>
         /// Gets a <see cref="bool"/> value that indicates whether the <see cref="PackageVersion"/> is "pinned".
         /// </summary>
-        public bool IsPinned {get;}
+        public bool IsPinned { get; }
 
         /// <inheritdoc/>
         public bool Equals(PackageVersion other)

--- a/src/Dotnet.Script.Tests/PackageVersionTests.cs
+++ b/src/Dotnet.Script.Tests/PackageVersionTests.cs
@@ -11,6 +11,7 @@ namespace Dotnet.Script.Tests
     {
         [Theory]
         [InlineData("1.2.3")]
+        [InlineData("1.2.3.4")]
         [InlineData("[1.2]")]
         [InlineData("[1.2.3]")]
         [InlineData("[1.2.3-beta1]")]


### PR DESCRIPTION
This PR fixes #477 by allowing more than 3 subparts of a version number when determining of we are dealing with a pinned version. 

