### PR TITLE
Install .Net Core Preview 9 in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,8 @@ jobs:
   pool:
     name: Hosted Ubuntu 1604
   steps:
-  - bash: 'curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.0.100-preview-010184'
-    displayName: 'Install 3.0.100-preview-010184'
+  - bash: 'curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.0.100-preview9-014004'
+    displayName: 'Install 3.0.100-preview9-014004'
 
   - bash: 'curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 2.1.402'
     displayName: 'Install 2.1.402'
@@ -45,9 +45,9 @@ jobs:
     name: Hosted macOS
   steps:
   - bash: |
-       curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.0.100-preview-010184
+       curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.0.100-preview9-014004
 
-    displayName: 'Install 3.0.100-preview-010184'
+    displayName: 'Install 3.0.100-preview9-014004'
 
   - bash: |
        curl -L https://github.com/filipw/dotnet-script/releases/download/0.28.0/dotnet-script.0.28.0.zip > dotnet-script.zip
@@ -66,15 +66,15 @@ jobs:
   steps:
   - powershell: |
        iwr https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1 -outfile dotnet-install.ps1
-       .\dotnet-install.ps1 -Version  3.0.100-preview-010184
+       .\dotnet-install.ps1 -Version  3.0.100-preview9-014004
 
-    displayName: 'Install 3.0.100-preview-010184 SDK'
+    displayName: 'Install 3.0.100-preview9-014004'
 
   - powershell: |
        iwr https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1 -outfile dotnet-install.ps1
        .\dotnet-install.ps1 -Version  2.1.402
 
-    displayName: 'Install 3.0.100-preview-010184 2.1.402 SDK'
+    displayName: 'Install 3.0.100-preview9-014004 2.1.402 SDK'
 
   # NuGet Tool Installer
 # Acquires a specific version of NuGet from the internet or the tools cache and adds it to the PATH. Use this task to change the version of NuGet used in the NuGet tasks.

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="5.0.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.2.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR bumps the installation of .Net Core 3.0 in Azure Pipelines to the latest version (preview 9)

NB: Also had to bump NuGet.ProjectModel to 5.2.0 since the desktop tests started to fail when preview 9 was installed. 

