### PR TITLE
Fix compilation dependencies

### DIFF
--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -45,7 +45,7 @@ namespace Dotnet.Script.Core
 
             assemblyFileName = assemblyFileName ?? Path.GetFileNameWithoutExtension(context.FilePath);
             var scriptAssemblyPath = CreateScriptAssembly<TReturn, THost>(context, context.WorkingDirectory, assemblyFileName);
-            var tempProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath));
+            var tempProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), ScriptEnvironment.Default.TargetFramework);
             var tempProjectDirecory = Path.GetDirectoryName(tempProjectPath);
 
             var sourceProjectAssetsPath = Path.Combine(tempProjectDirecory, "obj", "project.assets.json");
@@ -72,7 +72,7 @@ namespace Dotnet.Script.Core
 
             const string AssemblyName = "scriptAssembly";
 
-            var tempProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath));
+            var tempProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), ScriptEnvironment.Default.TargetFramework);
             var tempProjectDirectory = Path.GetDirectoryName(tempProjectPath);
 
             var scriptAssemblyPath = CreateScriptAssembly<TReturn, THost>(context, tempProjectDirectory, AssemblyName);

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>0.9.0</Version>
+    <Version>0.50.0</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependency.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependency.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+public class CompilationDependency
+{
+    public CompilationDependency(string name, string version, IReadOnlyList<string> assemblyPaths, IReadOnlyList<string> scripts)
+    {
+        Name = name;
+        Version = version;
+        AssemblyPaths = assemblyPaths;
+        Scripts = scripts;
+    }
+
+    public string Name { get; }
+
+    public string Version { get; }
+
+    public IReadOnlyList<string> AssemblyPaths { get; }
+
+    public IReadOnlyList<string> Scripts { get; }
+
+    public override string ToString()
+    {
+        return $"Name: {Name} , Version: {Version}";
+    }
+}

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
@@ -1,5 +1,11 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Dotnet.Script.DependencyModel.Context;
+using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.Logging;
+using Dotnet.Script.DependencyModel.Process;
 using Dotnet.Script.DependencyModel.ProjectSystem;
 
 namespace Dotnet.Script.DependencyModel.Compilation
@@ -7,22 +13,50 @@ namespace Dotnet.Script.DependencyModel.Compilation
     public class CompilationDependencyResolver
     {
         private readonly ScriptProjectProvider _scriptProjectProvider;
+        private readonly ScriptDependencyContextReader _scriptDependencyContextReader;
         private readonly ICompilationReferenceReader _compilationReferenceReader;
 
-        public CompilationDependencyResolver(LogFactory logFactory) : this(new ScriptProjectProvider(logFactory), new CompilationReferencesReader(logFactory), logFactory)
+        private readonly IRestorer _restorer;
+
+        public CompilationDependencyResolver(LogFactory logFactory) : this(new ScriptProjectProvider(logFactory), new ScriptDependencyContextReader(logFactory), new CompilationReferencesReader(logFactory), logFactory)
         {
         }
 
-        public CompilationDependencyResolver(ScriptProjectProvider scriptProjectProvider, ICompilationReferenceReader compilationReferenceReader, LogFactory logFactory)
+        public CompilationDependencyResolver(ScriptProjectProvider scriptProjectProvider, ScriptDependencyContextReader scriptDependencyContextReader, ICompilationReferenceReader compilationReferenceReader, LogFactory logFactory)
         {
             _scriptProjectProvider = scriptProjectProvider;
+            this._scriptDependencyContextReader = scriptDependencyContextReader;
             _compilationReferenceReader = compilationReferenceReader;
+            _restorer = CreateRestorer(logFactory);
         }
 
-        public IEnumerable<CompilationReference> GetDependencies(string targetDirectory, IEnumerable<string> scriptFiles, bool enableScriptNugetReferences, string defaultTargetFramework = "net46")
+        public IEnumerable<CompilationDependency> GetDependencies(string targetDirectory, IEnumerable<string> scriptFiles, bool enableScriptNugetReferences, string defaultTargetFramework = "net46")
         {
             var projectFileInfo = _scriptProjectProvider.CreateProject(targetDirectory, scriptFiles, defaultTargetFramework, enableScriptNugetReferences);
-            return _compilationReferenceReader.Read(projectFileInfo);
+            _restorer.Restore(projectFileInfo, packageSources: Array.Empty<string>());
+            var pathToAssetsFile = Path.Combine(Path.GetDirectoryName(projectFileInfo.Path), "obj", "project.assets.json");
+            var dependencyContext = _scriptDependencyContextReader.ReadDependencyContext(pathToAssetsFile);
+            var result = new List<CompilationDependency>();
+            foreach (var scriptDependency in dependencyContext.Dependencies)
+            {
+                var compilationDependency = new CompilationDependency(scriptDependency.Name, scriptDependency.Version, scriptDependency.CompileTimeDependencyPaths, scriptDependency.ScriptPaths);
+                result.Add(compilationDependency);
+            }
+
+            // On .Net Core, we need to fetch the compilation references for framework assemblies separately.
+            if (ScriptEnvironment.Default.NetCoreVersion.Version.StartsWith("3"))
+            {
+                var compilationreferences = _compilationReferenceReader.Read(projectFileInfo);
+                result.Add(new CompilationDependency("Microsoft.NETCore.App", ScriptEnvironment.Default.NetCoreVersion.Version, compilationreferences.Select(cr => cr.Path).ToArray(), Array.Empty<string>()));
+            }
+
+            return result;
+        }
+
+        private static IRestorer CreateRestorer(LogFactory logFactory)
+        {
+            var commandRunner = new CommandRunner(logFactory);
+            return new ProfiledRestorer(new DotnetRestorer(commandRunner, logFactory), logFactory);
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
@@ -44,7 +44,7 @@ namespace Dotnet.Script.DependencyModel.Compilation
             }
 
             // On .Net Core, we need to fetch the compilation references for framework assemblies separately.
-            if (ScriptEnvironment.Default.NetCoreVersion.Version.StartsWith("3"))
+            if (defaultTargetFramework.StartsWith("netcoreapp3", StringComparison.InvariantCultureIgnoreCase))
             {
                 var compilationreferences = _compilationReferenceReader.Read(projectFileInfo);
                 result.Add(new CompilationDependency("Microsoft.NETCore.App", ScriptEnvironment.Default.NetCoreVersion.Version, compilationreferences.Select(cr => cr.Path).ToArray(), Array.Empty<string>()));

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
@@ -47,7 +47,7 @@ namespace Dotnet.Script.DependencyModel.Compilation
             if (defaultTargetFramework.StartsWith("netcoreapp3", StringComparison.InvariantCultureIgnoreCase))
             {
                 var compilationreferences = _compilationReferenceReader.Read(projectFileInfo);
-                result.Add(new CompilationDependency("Microsoft.NETCore.App", ScriptEnvironment.Default.NetCoreVersion.Version, compilationreferences.Select(cr => cr.Path).ToArray(), Array.Empty<string>()));
+                result.Add(new CompilationDependency("Microsoft.NETCore.App", "3.0", compilationreferences.Select(cr => cr.Path).ToArray(), Array.Empty<string>()));
             }
 
             return result;

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationReferencesReader.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationReferencesReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Process;
 using Dotnet.Script.DependencyModel.ProjectSystem;
@@ -39,6 +40,9 @@ namespace Dotnet.Script.DependencyModel.Compilation
             string pathToCompilationProjectFile = Path.Combine(workingDirectory, outputDirectory, Path.GetFileName(projectFile.Path));
             File.Copy(projectFile.Path, pathToCompilationProjectFile, true);
 
+            // We remove any third party package references since we are only after the framework assemblies here.
+            RemovePackageReferences(pathToCompilationProjectFile);
+
             var referencePathsFile = Path.Combine(workingDirectory, outputDirectory, "ReferencePaths.txt");
             if (File.Exists(referencePathsFile))
             {
@@ -52,6 +56,13 @@ namespace Dotnet.Script.DependencyModel.Compilation
             var referenceAssemblies = File.ReadAllLines(referencePathsFile);
             var compilationReferences = referenceAssemblies.Select(ra => new CompilationReference(ra)).ToArray();
             return compilationReferences;
+        }
+
+        private static void RemovePackageReferences(string projectFile)
+        {
+            var document = XDocument.Load(projectFile);
+            document.Descendants("PackageReference").Remove();
+            document.Save(projectFile);
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/Context/CachedRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/CachedRestorer.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.ProjectSystem;
 
@@ -31,6 +32,7 @@ namespace Dotnet.Script.DependencyModel.Context
         public void Restore(ProjectFileInfo projectFileInfo, string[] packageSources)
         {
             var projectFile = new ProjectFile(File.ReadAllText(projectFileInfo.Path));
+
             var pathToCachedProjectFile = $"{projectFileInfo.Path}.cache";
             if (File.Exists(pathToCachedProjectFile))
             {

--- a/src/Dotnet.Script.DependencyModel/Context/ScriptDependency.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/ScriptDependency.cs
@@ -8,6 +8,7 @@ namespace Dotnet.Script.DependencyModel.Context
             Version = version;
             RuntimeDependencyPaths = runtimeDependencyPaths;
             NativeAssetPaths = nativeAssetPaths;
+            CompileTimeDependencyPaths = compileTimeDependencyPaths;
             ScriptPaths = scriptPaths;
         }
 
@@ -15,6 +16,7 @@ namespace Dotnet.Script.DependencyModel.Context
         public string Version { get; }
         public string[] RuntimeDependencyPaths { get; }
         public string[] NativeAssetPaths { get; }
+        public string[] CompileTimeDependencyPaths { get; }
         public string[] ScriptPaths { get; }
 
         public override string ToString()

--- a/src/Dotnet.Script.DependencyModel/Context/ScriptDependencyContextReader.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/ScriptDependencyContextReader.cs
@@ -53,6 +53,7 @@ namespace Dotnet.Script.DependencyModel.Context
                 if (
                     scriptDependency.NativeAssetPaths.Any() ||
                     scriptDependency.RuntimeDependencyPaths.Any() ||
+                    scriptDependency.CompileTimeDependencyPaths.Any() ||
                     scriptDependency.ScriptPaths.Any())
                 {
                     scriptDependencies.Add(scriptDependency);

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>0.11.0</Version>
+    <Version>0.50.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -8,9 +8,9 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 {
     public static class FileUtils
     {
-        public static string CreateTempFolder(string targetDirectory)
+        public static string CreateTempFolder(string targetDirectory, string targetFramework)
         {
-            string pathToProjectDirectory = GetPathToTempFolder(targetDirectory);
+            string pathToProjectDirectory = Path.Combine(GetPathToTempFolder(targetDirectory), targetFramework);
 
             if (!Directory.Exists(pathToProjectDirectory))
             {

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
@@ -50,7 +50,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             }
 
             targetDirectory = Path.Combine(targetDirectory, "interactive");
-            var pathToProjectFile = GetPathToProjectFile(targetDirectory);
+            var pathToProjectFile = GetPathToProjectFile(targetDirectory, defaultTargetFramework);
             var projectFile = new ProjectFile();
 
             foreach (var packageReference in allPackageReferences)
@@ -108,7 +108,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         {
             ProjectFile projectFile = CreateProjectFileFromScriptFiles(defaultTargetFramework, csxFiles);
 
-            var pathToProjectFile = GetPathToProjectFile(targetDirectory);
+            var pathToProjectFile = GetPathToProjectFile(targetDirectory, defaultTargetFramework);
             projectFile.Save(pathToProjectFile);
 
             LogProjectFileInfo(pathToProjectFile);
@@ -132,9 +132,9 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         }
 
 
-        public static string GetPathToProjectFile(string targetDirectory)
+        public static string GetPathToProjectFile(string targetDirectory, string targetFramework)
         {
-            var pathToProjectDirectory = FileUtils.CreateTempFolder(targetDirectory);
+            var pathToProjectDirectory = FileUtils.CreateTempFolder(targetDirectory, targetFramework);
             var pathToProjectFile = Path.Combine(pathToProjectDirectory, "script.csproj");
             return pathToProjectFile;
         }

--- a/src/Dotnet.Script.Tests/CachedRestorerTests.cs
+++ b/src/Dotnet.Script.Tests/CachedRestorerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Dotnet.Script.DependencyModel.Context;
+using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.ProjectSystem;
 using Dotnet.Script.Shared.Tests;
 using Moq;
@@ -26,7 +27,7 @@ namespace Dotnet.Script.Tests
             {
 
                 var pathToProjectFile = Path.Combine(projectFolder.Path, "script.csproj");
-                var pathToCachedProjectFile = Path.Combine(projectFolder.Path, "script.csproj.cache");
+                var pathToCachedProjectFile = Path.Combine(projectFolder.Path, $"script.csproj.cache");
 
                 var projectFile = new ProjectFile();
                 projectFile.PackageReferences.Add(new PackageReference("SomePackage", "1.2.3"));
@@ -56,7 +57,7 @@ namespace Dotnet.Script.Tests
             {
                 var projectFile = new ProjectFile();
                 var pathToProjectFile = Path.Combine(projectFolder.Path, "script.csproj");
-                var pathToCachedProjectFile = Path.Combine(projectFolder.Path, "script.csproj.cache");
+                var pathToCachedProjectFile = Path.Combine(projectFolder.Path, $"script.csproj.cache");
 
                 projectFile.PackageReferences.Add(new PackageReference("SomePackage", "1.2.3"));
                 projectFile.PackageReferences.Add(new PackageReference("AnotherPackage", "3.2"));
@@ -86,7 +87,7 @@ namespace Dotnet.Script.Tests
             {
                 var projectFile = new ProjectFile();
                 var pathToProjectFile = Path.Combine(projectFolder.Path, "script.csproj");
-                var pathToCachedProjectFile = Path.Combine(projectFolder.Path, "script.csproj.cache");
+                var pathToCachedProjectFile = Path.Combine(projectFolder.Path, $"script.csproj.cache");
 
                 projectFile.PackageReferences.Add(new PackageReference("SomePackage", "1.2.3"));
                 projectFile.PackageReferences.Add(new PackageReference("AnotherPackage", "1.2.3"));

--- a/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
+++ b/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
@@ -3,6 +3,7 @@ using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.Shared.Tests;
 using System;
 using System.IO;
+using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -26,7 +27,7 @@ namespace Dotnet.Script.Tests
             var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("InlineNugetPackage");
             var csxFiles = Directory.GetFiles(targetDirectory, "*.csx");
             var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
-            Assert.Contains(dependencies, d => d.Path.Contains("AutoMapper", StringComparison.InvariantCultureIgnoreCase));
+            Assert.Contains(dependencies, d => d.Name == "AutoMapper");
         }
 
         [Fact]
@@ -36,8 +37,8 @@ namespace Dotnet.Script.Tests
             var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("InlineNugetPackageWithFileFiltering");
             var csxFiles = Directory.GetFiles(targetDirectory, "InlineNugetPackage.csx");
             var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
-            Assert.DoesNotContain(dependencies, d => d.Path.Contains("AutoMapper", StringComparison.InvariantCultureIgnoreCase));
-            Assert.Contains(dependencies, d => d.Path.Contains("Newtonsoft.Json", StringComparison.InvariantCultureIgnoreCase));
+            Assert.DoesNotContain(dependencies, d => d.Name == "AutoMapper");
+            Assert.Contains(dependencies, d => d.Name == "Newtonsoft.Json");
         }
 
         [Fact]
@@ -47,7 +48,7 @@ namespace Dotnet.Script.Tests
             var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("NativeLibrary");
             var csxFiles = Directory.GetFiles(targetDirectory, "*.csx");
             var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
-            Assert.Contains(dependencies, d => d.Path.Contains("Microsoft.Data.Sqlite.Core", StringComparison.InvariantCultureIgnoreCase));
+            Assert.Contains(dependencies, d => d.Name == "Microsoft.Data.Sqlite.Core");
         }
 
         [Fact]
@@ -57,9 +58,9 @@ namespace Dotnet.Script.Tests
             var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("InlineNugetPackageWithRefFolder");
             var csxFiles = Directory.GetFiles(targetDirectory, "*.csx");
             var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
-            Assert.Contains(dependencies, d => d.Path.Replace("\\", "/").Contains("system.data.sqlclient/4.6.1/ref/"));
+            var sqlClientDependency = dependencies.Single(d => d.Name.Equals("System.Data.SqlClient", StringComparison.InvariantCultureIgnoreCase));
+            Assert.Contains(sqlClientDependency.AssemblyPaths, d => d.Replace("\\", "/").Contains("system.data.sqlclient/4.6.1/ref/"));
         }
-
 
         [Fact]
         public void ShouldGetCompilationDependenciesForIssue129()
@@ -68,7 +69,7 @@ namespace Dotnet.Script.Tests
             var targetDirectory = TestPathUtils.GetPathToTestFixtureFolder("Issue129");
             var csxFiles = Directory.GetFiles(targetDirectory, "*.csx");
             var dependencies = resolver.GetDependencies(targetDirectory, csxFiles, true, _scriptEnvironment.TargetFramework);
-            Assert.Contains(dependencies, d => d.Path.Contains("Auth0.ManagementApi", StringComparison.InvariantCultureIgnoreCase));
+            Assert.Contains(dependencies, d => d.Name == "Auth0.ManagementApi");
         }
 
         private CompilationDependencyResolver CreateResolver()

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks> -->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <!-- <TargetFramework>netcoreapp3.0</TargetFramework> -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <!-- <TargetFramework>netcoreapp3.0</TargetFramework> -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <!-- <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks> -->
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -31,16 +31,16 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldExecuteScriptWithInlineNugetPackage()
         {
-            var result = ScriptTestRunner.Default.ExecuteFixtureInProcess("InlineNugetPackage");
-            //Assert.Contains("AutoMapper.MapperConfiguration", result.output);
+            var result = ScriptTestRunner.Default.ExecuteFixture("InlineNugetPackage");
+            Assert.Contains("AutoMapper.MapperConfiguration", result.output);
         }
 
         [Fact]
         public void ShouldHandleNullableContextAsError()
         {
-            var result = ScriptTestRunner.Default.ExecuteFixture("Nullable");
-            Assert.Equal(1, result.exitCode);
-            Assert.Contains("error CS8625", result.output);
+            var result = ScriptTestRunner.Default.ExecuteFixtureInProcess("Nullable");
+            // Assert.Equal(1, result.exitCode);
+            // Assert.Contains("error CS8625", result.output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -38,9 +38,9 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldHandleNullableContextAsError()
         {
-            var result = ScriptTestRunner.Default.ExecuteFixtureInProcess("Nullable");
-            // Assert.Equal(1, result.exitCode);
-            // Assert.Contains("error CS8625", result.output);
+            var result = ScriptTestRunner.Default.ExecuteFixture("Nullable");
+            Assert.Equal(1, result.exitCode);
+            Assert.Contains("error CS8625", result.output);
         }
 
         [Fact]


### PR DESCRIPTION
This PR brings back the `CompilationDepenency` class as it turned out we need more that just the path to the reference assembly in OmnSharp.

In addition this PR makes sure that we create a temporary csproj file per target framework. This is crucial to machines that might have `netcoreapp2.1`  caches (project.assets.json). We could end up running a `netcoreapp3.0` with `netcoreapp2.1` dependencies. Same goes for compilation dependencies.

So this PR also ensures that we get isolated runtime and compilation dependencies per target framework. 
This was not really a problem before as we only had `netcoreapp2.1`. We now have both.  