### PR TITLE
Fixedd Chocolatey build

### DIFF
--- a/build/Build.csx
+++ b/build/Build.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.3.9"
+#load "nuget:Dotnet.Build, 0.7.1"
 #load "nuget:dotnet-steps, 0.0.1"
 #load "nuget:github-changelog, 0.1.5"
 #load "Choco.csx"
@@ -100,7 +100,7 @@ private async Task PublishRelease()
 
     if (Git.Default.IsTagCommit())
     {
-        Git.Default.RequreCleanWorkingTree();
+        Git.Default.RequireCleanWorkingTree();
         await ReleaseManagerFor(owner, projectName, BuildEnvironment.GitHubAccessToken)
         .CreateRelease(Git.Default.GetLatestTag(), pathToReleaseNotes, new[] { new ZipReleaseAsset(pathToGitHubReleaseAsset) });
         NuGet.TryPush(nuGetArtifactsFolder);

--- a/build/BuildContext.csx
+++ b/build/BuildContext.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.3.9"
+#load "nuget:Dotnet.Build, 0.7.1"
 using static FileUtils;
 using System.Xml.Linq;
 

--- a/build/Choco.csx
+++ b/build/Choco.csx
@@ -1,4 +1,4 @@
-#load "nuget:Dotnet.Build, 0.3.1"
+#load "nuget:Dotnet.Build, 0.7.1"
 
 using System.Xml.Linq;
 
@@ -11,7 +11,6 @@ public static class Choco
     /// <param name="outputFolder">The path to the output folder (*.nupkg)</param>
     public static void Pack(string pathToProjectFolder, string pathToBinaries, string outputFolder)
     {
-        File.Copy(Path.Combine(pathToProjectFolder, "../../LICENSE"), Path.Combine("Chocolatey","tools","LICENSE.TXT"), true);
         string pathToProjectFile = Directory.GetFiles(pathToProjectFolder, "*.csproj").Single();
         CreateSpecificationFromProject(pathToProjectFile, pathToBinaries);
         Command.Execute("choco.exe", $@"pack Chocolatey\chocolatey.nuspec  --outputdirectory {outputFolder}");
@@ -20,7 +19,7 @@ public static class Choco
     public static void Push(string packagesFolder, string apiKey, string source = "https://push.chocolatey.org/")
     {
         var packageFiles = Directory.GetFiles(packagesFolder, "*.nupkg");
-        foreach(var packageFile in packageFiles)
+        foreach (var packageFile in packageFiles)
         {
             Command.Execute("choco.exe", $"push {packageFile} --source {source} --key {apiKey}");
         }
@@ -29,7 +28,7 @@ public static class Choco
     public static void TryPush(string packagesFolder, string apiKey, string source = "https://push.chocolatey.org/")
     {
         var packageFiles = Directory.GetFiles(packagesFolder, "*.nupkg");
-        foreach(var packageFile in packageFiles)
+        foreach (var packageFile in packageFiles)
         {
             Command.Execute("choco.exe", $"push {packageFile} --source {source} --key {apiKey}");
         }
@@ -77,11 +76,11 @@ public static class Choco
         packageElement.Add(filesElement);
 
         // Add the tools folder that contains "ChocolateyInstall.ps1"
-        filesElement.Add(CreateFileElement(@"tools\*.*",$@"{packageId}\tools"));
+        filesElement.Add(CreateFileElement(@"tools\*.*", $@"{packageId}\tools"));
         var srcGlobPattern = $@"{pathToBinaries}\**\*";
-        filesElement.Add(CreateFileElement(srcGlobPattern,packageId));
+        filesElement.Add(CreateFileElement(srcGlobPattern, packageId));
 
-        using (var fileStream = new FileStream("Chocolatey/chocolatey.nuspec",FileMode.Create))
+        using (var fileStream = new FileStream("Chocolatey/chocolatey.nuspec", FileMode.Create))
         {
             new XDocument(packageElement).Save(fileStream);
         }


### PR DESCRIPTION
This PR fixes a bug in the build system that copied the license file into the Chocolatey tools folder. 
That caused the git to have unstaged changes. We require a clean working tree to be able to create a release