### PR TITLE
publish to single file on .NET Core 3.0

### DIFF
--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -85,7 +85,8 @@ namespace Dotnet.Script.Core
 
             var commandRunner = new CommandRunner(logFactory);
             // todo: may want to add ability to return dotnet.exe errors
-            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o \"{context.WorkingDirectory}\"");
+            var exitcode = commandRunner.Execute("dotnet", $"publish \"{tempProjectPath}\" -c Release -r {runtimeIdentifier} -o \"{context.WorkingDirectory}\" {(ScriptEnvironment.Default.TargetFramework == "netcoreapp3.0" ? "/p:PublishSingleFile=true" : "")} /p:DebugType=Embedded");
+
             if (exitcode != 0)
             {
                 throw new Exception($"dotnet publish failed with result '{exitcode}'");
@@ -151,7 +152,7 @@ namespace Dotnet.Script.Core
             return assemblyPath;
         }
 
-        private void CopyProgramTemplate(string tempProjectDirecory)
+        private static void CopyProgramTemplate(string tempProjectDirecory)
         {
             const string resourceName = "Dotnet.Script.Core.Templates.program.publish.template";
 

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -40,9 +40,8 @@ namespace Dotnet.Script.Tests
 
                 Assert.Equal(0, executableRunResult);
 
-                var publishedFiles = Directory.EnumerateFiles(Path.Combine(workspaceFolder.Path, "publish", _scriptEnvironment.RuntimeIdentifier));
-
 #if NETCOREAPP3_0
+                var publishedFiles = Directory.EnumerateFiles(Path.Combine(workspaceFolder.Path, "publish", _scriptEnvironment.RuntimeIdentifier));
                 Assert.True(1 == publishedFiles.Count(), "There should be only a single published file on .NET Core 3.0");
 #endif
             }

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -5,6 +5,7 @@ using Dotnet.Script.DependencyModel.Process;
 using Dotnet.Script.Shared.Tests;
 using System;
 using System.IO;
+using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,6 +39,12 @@ namespace Dotnet.Script.Tests
                 var executableRunResult = _commandRunner.Execute(exePath);
 
                 Assert.Equal(0, executableRunResult);
+
+                var publishedFiles = Directory.EnumerateFiles(Path.Combine(workspaceFolder.Path, "publish", _scriptEnvironment.RuntimeIdentifier));
+
+#if NETCOREAPP3_0
+                Assert.True(1 == publishedFiles.Count(), "There should be only a single published file on .NET Core 3.0");
+#endif
             }
         }
 


### PR DESCRIPTION
single script.exe instead of 200 files