### PR TITLE
Bumped Microsoft.Extensions.Logging to 3.0.1

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -272,6 +272,13 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public void ShouldLoadMicrosoftExtensionsDependencyInjection()
+        {
+            var result = ScriptTestRunner.Default.ExecuteFixture("MicrosoftExtensionsDependencyInjection");
+            Assert.Contains("Microsoft.Extensions.DependencyInjection.IServiceCollection", result.output);
+        }
+
+        [Fact]
         public void ShouldThrowExceptionOnInvalidMediaType()
         {
             var url = "https://github.com/filipw/dotnet-script/archive/0.20.0.zip";

--- a/src/Dotnet.Script.Tests/TestFixtures/MicrosoftExtensionsDependencyInjection/MicrosoftExtensionsDependencyInjection.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/MicrosoftExtensionsDependencyInjection/MicrosoftExtensionsDependencyInjection.csx
@@ -1,0 +1,4 @@
+#!/usr/bin/env dotnet-script
+#r "nuget:Microsoft.Extensions.DependencyInjection, 3.0.1"
+using Microsoft.Extensions.DependencyInjection;
+Console.WriteLine(typeof(IServiceCollection));

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>0.50.1</VersionPrefix>
+        <VersionPrefix>0.50.2</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
         <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
@@ -24,7 +24,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.1" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />


### PR DESCRIPTION
This PR bumps `Microsoft.Extensions.Logging` to 3.0.1 so ensure compatibility with other `Microsoft.Extensions.xxx` packages that now has begun to ship under the `3.0.1` version 