### PR TITLE
User spesific temp folder

### DIFF
--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
@@ -45,7 +45,7 @@ namespace Dotnet.Script.Core.Commands
 
         private string GetLibrary(ExecuteScriptCommandOptions executeOptions)
         {
-            var projectFolder = FileUtils.GetPathToTempFolder(Path.GetDirectoryName(executeOptions.File.Path));
+            var projectFolder = FileUtils.GetPathToScriptTempFolder(Path.GetDirectoryName(executeOptions.File.Path));
             var executionCacheFolder = Path.Combine(projectFolder, "execution-cache");
             var pathToLibrary = Path.Combine(executionCacheFolder, "script.dll");
 
@@ -54,7 +54,7 @@ namespace Dotnet.Script.Core.Commands
                 return CreateLibrary();
             }
 
-            if (!string.Equals(hash,cachedHash))
+            if (!string.Equals(hash, cachedHash))
             {
                 return CreateLibrary();
             }
@@ -63,7 +63,7 @@ namespace Dotnet.Script.Core.Commands
 
             string CreateLibrary()
             {
-                var options = new PublishCommandOptions(executeOptions.File,executionCacheFolder, "script", PublishType.Library,executeOptions.OptimizationLevel, executeOptions.PackageSources, null, executeOptions.NoCache);
+                var options = new PublishCommandOptions(executeOptions.File, executionCacheFolder, "script", PublishType.Library, executeOptions.OptimizationLevel, executeOptions.PackageSources, null, executeOptions.NoCache);
                 new PublishCommand(_scriptConsole, _logFactory).Execute(options);
                 if (hash != null)
                 {

--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -57,7 +57,7 @@ namespace Dotnet.Script.Core
             File.Copy(sourceNugetPropsPath, destinationNugetPropsPath, overwrite: true);
 
             // only display published if we aren't auto publishing to temp folder
-            if (!scriptAssemblyPath.StartsWith(Path.GetTempPath()))
+            if (!scriptAssemblyPath.StartsWith(FileUtils.GetTempPath()))
             {
                 _scriptConsole.WriteSuccess($"Published {context.FilePath} to { scriptAssemblyPath}");
             }

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -12,7 +12,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
     {
         public static string CreateTempFolder(string targetDirectory, string targetFramework)
         {
-            string pathToProjectDirectory = Path.Combine(GetPathToTempFolder(targetDirectory), targetFramework);
+            string pathToProjectDirectory = Path.Combine(GetPathToScriptTempFolder(targetDirectory), targetFramework);
 
             if (!Directory.Exists(pathToProjectDirectory))
             {
@@ -22,7 +22,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             return pathToProjectDirectory;
         }
 
-        public static string GetPathToTempFolder(string targetDirectory)
+        public static string GetPathToScriptTempFolder(string targetDirectory)
         {
             if (!Path.IsPathRooted(targetDirectory))
             {
@@ -47,7 +47,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             return pathToProjectDirectory;
         }
 
-        private static string GetTempPath()
+        public static string GetTempPath()
         {
             var userFolder = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
 

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -1,7 +1,9 @@
 ﻿using Dotnet.Script.DependencyModel.Environment;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Dotnet.Script.DependencyModel.ProjectSystem
@@ -27,7 +29,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
                 throw new ArgumentOutOfRangeException(nameof(targetDirectory), "Must be a root path");
             }
 
-            var tempDirectory = Path.GetTempPath();
+            var tempDirectory = GetTempPath();
             var pathRoot = Path.GetPathRoot(targetDirectory);
             var targetDirectoryWithoutRoot = targetDirectory.Substring(pathRoot.Length);
             if (pathRoot.Length > 0 && ScriptEnvironment.Default.IsWindows)
@@ -41,8 +43,25 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
                 targetDirectoryWithoutRoot = Path.Combine(driveLetter, targetDirectoryWithoutRoot);
             }
-            var pathToProjectDirectory = Path.Combine(tempDirectory, "scripts", targetDirectoryWithoutRoot);
+            var pathToProjectDirectory = Path.Combine(tempDirectory, "dotnet-script", targetDirectoryWithoutRoot);
             return pathToProjectDirectory;
+        }
+
+        private static string GetTempPath()
+        {
+            var userFolder = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Path.Combine(userFolder, ".cache");
+            }
+            else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return Path.Combine(userFolder, "Library/Caches/");
+            }
+
+            return Path.GetTempPath();
         }
     }
 }

--- a/src/Dotnet.Script.Shared.Tests/TestPathUtils.cs
+++ b/src/Dotnet.Script.Shared.Tests/TestPathUtils.cs
@@ -16,7 +16,7 @@ namespace Dotnet.Script.Shared.Tests
 
         public static string GetPathToTempFolder(string path)
         {
-            return DependencyModel.ProjectSystem.FileUtils.GetPathToTempFolder(path);
+            return DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(path);
         }
 
         public static string GetPathToScriptPackages(string fixture)

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -18,7 +18,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldNotUpdateHashWhenSourceIsNotChanged()
         {
-             using (var scriptFolder = new DisposableFolder())
+            using (var scriptFolder = new DisposableFolder())
             {
                 var pathToScript = Path.Combine(scriptFolder.Path, "main.csx");
 
@@ -61,7 +61,7 @@ namespace Dotnet.Script.Tests
             {
                 var pathToScript = Path.Combine(scriptFolder.Path, "main.csx");
 
-                WriteScript(pathToScript, "#r \"nuget:AutoMapper, *\"" ,"WriteLine(42);");
+                WriteScript(pathToScript, "#r \"nuget:AutoMapper, *\"", "WriteLine(42);");
 
                 var result = Execute(pathToScript);
                 Assert.Contains("42", result.output);
@@ -77,7 +77,7 @@ namespace Dotnet.Script.Tests
             {
                 var pathToScript = Path.Combine(scriptFolder.Path, "main.csx");
 
-                WriteScript(pathToScript, "#r \"nuget:LightInject, 5.2.1\"" ,"WriteLine(42);");
+                WriteScript(pathToScript, "#r \"nuget:LightInject, 5.2.1\"", "WriteLine(42);");
                 ScriptTestRunner.Default.Execute($"{pathToScript} --nocache");
                 var pathToExecutionCache = GetPathToExecutionCache(pathToScript);
                 Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.dll")));
@@ -103,7 +103,7 @@ namespace Dotnet.Script.Tests
 
         private static string GetPathToExecutionCache(string pathToScript)
         {
-            var pathToTempFolder = Path.GetDirectoryName(Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToTempFolder(pathToScript));
+            var pathToTempFolder = Path.GetDirectoryName(Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript));
             var pathToExecutionCache = Path.Combine(pathToTempFolder, "execution-cache");
             return pathToExecutionCache;
         }


### PR DESCRIPTION
This PR adds support for user specific temp folders to be using when caching the result of script compilation.

We used to always do `Path.GetTempPath` for this where as this PR now uses `~ /.cache/dotnet-script` on Linux and `~/Library/Caches/dotnet-script` on MacOS.