### PR TITLE
Bump to netcoreapp3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ Run C# scripts from the .NET CLI, define NuGet packages inline and edit/debug th
 
 ## NuGet Packages
 
-| Name                                  | Version                                                                                                                                                             | Framework(s)                     |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `dotnet-script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/)                                             | `netcoreapp2.1`, `netcoreapp3.0` |
-| `Dotnet.Script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/)                                             | `netcoreapp2.1`, `netcoreapp3.0` |
-| `Dotnet.Script.Core`                  | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.Core.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.Core/)                                   | `netstandard2.0`                 |
-| `Dotnet.Script.DependencyModel`       | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel/)             | `netstandard2.0`                 |
+| Name                                  | Version                                                      | Framework(s)                     |
+| ------------------------------------- | ------------------------------------------------------------ | -------------------------------- |
+| `dotnet-script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/) | `netcoreapp2.1`, `netcoreapp3.1` |
+| `Dotnet.Script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/) | `netcoreapp2.1`, `netcoreapp3.1` |
+| `Dotnet.Script.Core`                  | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.Core.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.Core/) | `netstandard2.0`                 |
+| `Dotnet.Script.DependencyModel`       | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel/) | `netstandard2.0`                 |
 | `Dotnet.Script.DependencyModel.Nuget` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.Nuget.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel.Nuget/) | `netstandard2.0`                 |
 
 ## Installing
 
 ### Prerequisites
 
-The only thing we need to install is [.NET Core 2.1+ SDK](https://www.microsoft.com/net/download/core). In order to use C# 8.0 features, [.NET Core 3.0+ SDK](https://www.microsoft.com/net/download/core) must be installed.
+The only thing we need to install is [.NET Core 2.1+ SDK](https://www.microsoft.com/net/download/core). In order to use C# 8.0 features, [.NET Core 3.1+ SDK](https://www.microsoft.com/net/download/core) must be installed.
 
 ### .NET Core Global Tool
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 resources:
-- repo: self
+  - repo: self
 
 trigger:
   tags:
@@ -7,108 +7,104 @@ trigger:
       - refs/tags/*
   branches:
     include:
-    - '*'
+      - "*"
 
 variables:
-- group: dotnet-script-api-keys
+  - group: dotnet-script-api-keys
 
 jobs:
+  - job: Job_3
+    displayName: Ubuntu Agent
+    condition: succeeded()
+    pool:
+      name: Hosted Ubuntu 1604
+    steps:
+      - bash: "curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.1.102"
+        displayName: "Install 3.0.100"
 
-- job: Job_3
-  displayName: Ubuntu Agent
-  condition: succeeded()
-  pool:
-    name: Hosted Ubuntu 1604
-  steps:
-  - bash: 'curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.0.100'
-    displayName: 'Install 3.0.100'
+      - bash: "curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 2.1.402"
+        displayName: "Install 2.1.402"
 
-  - bash: 'curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 2.1.402'
-    displayName: 'Install 2.1.402'
+      - bash: |
+          export PATH=/home/vsts/.dotnet:$PATH
+          curl -L https://github.com/filipw/dotnet-script/releases/download/0.28.0/dotnet-script.0.28.0.zip > dotnet-script.zip
+          unzip -o dotnet-script.zip -d ./
+        displayName: "Install dotnet-script"
 
-  - bash: |
-       export PATH=/home/vsts/.dotnet:$PATH
-       curl -L https://github.com/filipw/dotnet-script/releases/download/0.28.0/dotnet-script.0.28.0.zip > dotnet-script.zip
-       unzip -o dotnet-script.zip -d ./
-    displayName: 'Install dotnet-script'
+      - bash: |
+          export PATH=/home/vsts/.dotnet:$PATH
+          dotnet dotnet-script/dotnet-script.dll build/Build.csx
+        displayName: "Run build.csx"
 
-  - bash: |
-       export PATH=/home/vsts/.dotnet:$PATH
-       dotnet dotnet-script/dotnet-script.dll build/Build.csx
-    displayName: 'Run build.csx'
+  - job: Job_1
+    displayName: Mac Agent
+    condition: succeeded()
+    pool:
+      name: Hosted macOS
+    steps:
+      - bash: |
+          curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.1.102
 
+        displayName: "Install 3.0.100"
 
-- job: Job_1
-  displayName: Mac Agent
-  condition: succeeded()
-  pool:
-    name: Hosted macOS
-  steps:
-  - bash: |
-       curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -version 3.0.100
+      - bash: |
+          curl -L https://github.com/filipw/dotnet-script/releases/download/0.28.0/dotnet-script.0.28.0.zip > dotnet-script.zip
+          unzip -o dotnet-script.zip -d ./
+        displayName: "Install dotnet-script"
 
-    displayName: 'Install 3.0.100'
+      - bash: "dotnet dotnet-script/dotnet-script.dll build/build.csx"
+        displayName: "Run build.csx"
 
-  - bash: |
-       curl -L https://github.com/filipw/dotnet-script/releases/download/0.28.0/dotnet-script.0.28.0.zip > dotnet-script.zip
-       unzip -o dotnet-script.zip -d ./
-    displayName: 'Install dotnet-script'
+  - job: Job_2
+    displayName: Windows Agent
+    condition: succeeded()
+    pool:
+      name: Hosted Windows 2019 with VS2019
+    steps:
+      - powershell: |
+          iwr https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1 -outfile dotnet-install.ps1
+          .\dotnet-install.ps1 -Version  3.1.102
 
-  - bash: 'dotnet dotnet-script/dotnet-script.dll build/build.csx'
-    displayName: 'Run build.csx'
+        displayName: "Install 3.0.100"
 
+      - powershell: |
+          iwr https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1 -outfile dotnet-install.ps1
+          .\dotnet-install.ps1 -Version  2.1.402
 
-- job: Job_2
-  displayName: Windows Agent
-  condition: succeeded()
-  pool:
-    name: Hosted Windows 2019 with VS2019
-  steps:
-  - powershell: |
-       iwr https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1 -outfile dotnet-install.ps1
-       .\dotnet-install.ps1 -Version  3.0.100
+        displayName: "Install 2.1.402 SDK"
 
-    displayName: 'Install 3.0.100'
+      # NuGet Tool Installer
+      # Acquires a specific version of NuGet from the internet or the tools cache and adds it to the PATH. Use this task to change the version of NuGet used in the NuGet tasks.
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: "4.8.2"
 
-  - powershell: |
-       iwr https://raw.githubusercontent.com/dotnet/cli/release/2.1.3xx/scripts/obtain/dotnet-install.ps1 -outfile dotnet-install.ps1
-       .\dotnet-install.ps1 -Version  2.1.402
+        #checkLatest: false # Optional
+      - bash: |
+          export PATH=/c/Users/VssAdministrator/AppData/Local/Microsoft/dotnet:$PATH
+          dotnet --info
 
-    displayName: 'Install 2.1.402 SDK'
+        displayName: "Show installed sdk"
 
-  # NuGet Tool Installer
-# Acquires a specific version of NuGet from the internet or the tools cache and adds it to the PATH. Use this task to change the version of NuGet used in the NuGet tasks.
-  - task: NuGetToolInstaller@0
-    inputs:
-      versionSpec: '4.8.2'
-    #checkLatest: false # Optional
+      - bash: |
+          export PATH=/c/Users/VssAdministrator/AppData/Local/Microsoft/dotnet:$PATH
+          cd build
+          curl -L https://github.com/filipw/dotnet-script/releases/download/0.28.0/dotnet-script.0.28.0.zip > dotnet-script.zip
+          unzip -o dotnet-script.zip -d ./
+        displayName: "Install dotnet-script"
 
-  - bash: |
-       export PATH=/c/Users/VssAdministrator/AppData/Local/Microsoft/dotnet:$PATH
-       dotnet --info
+      - bash: |
+          export PATH=/c/Users/VssAdministrator/AppData/Local/Microsoft/dotnet:$PATH
+          cd build
+          dotnet dotnet-script/dotnet-script.dll build.csx
+        displayName: "Run build.csx"
+        env:
+          IS_SECURE_BUILDENVIRONMENT: $(IS_SECURE_BUILDENVIRONMENT)
+          GITHUB_REPO_TOKEN: $(GITHUB_REPO_TOKEN)
+          NUGET_APIKEY: $(NUGET_APIKEY)
+          CHOCOLATEY_APIKEY: $(CHOCOLATEY_APIKEY)
 
-    displayName: 'Show installed sdk'
-
-  - bash: |
-       export PATH=/c/Users/VssAdministrator/AppData/Local/Microsoft/dotnet:$PATH
-       cd build
-       curl -L https://github.com/filipw/dotnet-script/releases/download/0.28.0/dotnet-script.0.28.0.zip > dotnet-script.zip
-       unzip -o dotnet-script.zip -d ./
-    displayName: 'Install dotnet-script'
-
-  - bash: |
-       export PATH=/c/Users/VssAdministrator/AppData/Local/Microsoft/dotnet:$PATH
-       cd build
-       dotnet dotnet-script/dotnet-script.dll build.csx
-    displayName: 'Run build.csx'
-    env:
-      IS_SECURE_BUILDENVIRONMENT: $(IS_SECURE_BUILDENVIRONMENT)
-      GITHUB_REPO_TOKEN: $(GITHUB_REPO_TOKEN)
-      NUGET_APIKEY: $(NUGET_APIKEY)
-      CHOCOLATEY_APIKEY: $(CHOCOLATEY_APIKEY)
-
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Pipeline Artifact'
-    inputs:
-      targetPath: build/Artifacts
-
+      - task: PublishPipelineArtifact@0
+        displayName: "Publish Pipeline Artifact"
+        inputs:
+          targetPath: build/Artifacts

--- a/src/.vscode/tasks.json
+++ b/src/.vscode/tasks.json
@@ -24,7 +24,7 @@
         "-c",
         "release",
         "-f",
-        "netcoreapp3.0",
+        "netcoreapp3.1",
         "${workspaceFolder}/Dotnet.Script.Tests/DotNet.Script.Tests.csproj"
       ],
       "problemMatcher": "$msCompile",
@@ -42,7 +42,7 @@
         "-c",
         "release",
         "-f",
-        "netcoreapp3.0",
+        "netcoreapp3.1",
         "/p:CollectCoverage=true",
         "/p:Exclude=\"[xunit*]*\"",
         "/p:CoverletOutputFormat=lcov",

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -4,7 +4,7 @@
         <VersionPrefix>0.50.2</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
-        <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>dotnet-script</AssemblyName>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
This PR bumps `dotnet-script` from `netcoreapp3.0` to `netcoreapp3.1` as discussed internally