### PR TITLE
Fix: "publish to single file"-feature not working on .NET Core 3.1 or higher

### DIFF
--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -88,7 +88,7 @@ namespace Dotnet.Script.Core
 
             var commandRunner = new CommandRunner(logFactory);
             // todo: may want to add ability to return dotnet.exe errors
-            var exitcode = commandRunner.Execute("dotnet", $"publish \"{renamedProjectPath}\" -c Release -r {runtimeIdentifier} -o \"{context.WorkingDirectory}\" {(ScriptEnvironment.Default.TargetFramework == "netcoreapp3.0" ? "/p:PublishSingleFile=true" : "")} /p:DebugType=Embedded");
+            var exitcode = commandRunner.Execute("dotnet", $"publish \"{renamedProjectPath}\" -c Release -r {runtimeIdentifier} -o \"{context.WorkingDirectory}\" {(ScriptEnvironment.Default.NetCoreVersion.Major >= 3 ? "/p:PublishSingleFile=true" : string.Empty)} /p:DebugType=Embedded");
 
             if (exitcode != 0)
             {

--- a/src/Dotnet.Script.DependencyModel/Context/ScriptDependencyContextReader.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/ScriptDependencyContextReader.cs
@@ -60,7 +60,7 @@ namespace Dotnet.Script.DependencyModel.Context
                 }
             }
 
-            if (ScriptEnvironment.Default.NetCoreVersion.Version.StartsWith("3"))
+            if (ScriptEnvironment.Default.NetCoreVersion.Major >= 3)
             {
                 var netcoreAppRuntimeAssemblyLocation = Path.GetDirectoryName(typeof(object).Assembly.Location);
                 var netcoreAppRuntimeAssemblies = Directory.GetFiles(netcoreAppRuntimeAssemblyLocation, "*.dll").Where(IsAssembly).ToArray();

--- a/src/Dotnet.Script.DependencyModel/Environment/ScriptEnvironment.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/ScriptEnvironment.cs
@@ -76,7 +76,7 @@ namespace Dotnet.Script.DependencyModel.Environment
         {
             // https://github.com/dotnet/BenchmarkDotNet/blob/94863ab4d024eca04d061423e5aad498feff386b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs#L156
             var codeBase = typeof(System.Runtime.GCSettings).GetTypeInfo().Assembly.CodeBase;
-            var pattern = @"^.*Microsoft\.NETCore\.App\/(\d\.\d)(.*?)\/";
+            var pattern = @"^.*Microsoft\.NETCore\.App\/(\d+\.\d+)(.*?)\/";
             var match = Regex.Match(codeBase, pattern, RegexOptions.IgnoreCase);
             if (!match.Success)
             {

--- a/src/Dotnet.Script.DependencyModel/Environment/ScriptEnvironment.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/ScriptEnvironment.cs
@@ -139,9 +139,17 @@ namespace Dotnet.Script.DependencyModel.Environment
         {
             Version = version;
             Tfm = tfm;
+
+            var versionMatch = Regex.Match(input: Version, pattern: @"^(\d+)(?:\.(\d+))?");
+            if (versionMatch.Success && versionMatch.Groups[1].Success)
+                Major = int.Parse(versionMatch.Groups[1].Value);
+            if (versionMatch.Success && versionMatch.Groups[2].Success)
+                Minor = int.Parse(versionMatch.Groups[2].Value);
         }
 
         public string Version { get; }
         public string Tfm { get; }
+        public int Major { get; }
+        public int Minor { get; }
     }
 }

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -40,10 +40,11 @@ namespace Dotnet.Script.Tests
 
                 Assert.Equal(0, executableRunResult);
 
-#if NETCOREAPP3_0
                 var publishedFiles = Directory.EnumerateFiles(Path.Combine(workspaceFolder.Path, "publish", _scriptEnvironment.RuntimeIdentifier));
-                Assert.True(1 == publishedFiles.Count(), "There should be only a single published file on .NET Core 3.0");
-#endif
+                if (_scriptEnvironment.NetCoreVersion.Major >= 3)
+                    Assert.True(publishedFiles.Count() == 1, "There should be only a single published file");
+                else
+                    Assert.True(publishedFiles.Count() > 1, "There should be multiple published files");
             }
         }
 


### PR DESCRIPTION
The latest release 0.51.0 added the "publish to single file"-feature (#496), but it only works with .NET Core 3.0.

This pull request enables PublishSingleFile on all .NET Core Version equal or greater than 3.0.

Additional future proof changes:
- ScriptEnvironment.GetNetCoreAppVersion handling .NET Core Version-Numbers with more than one digit
- ScriptDependencyContextReader.ReadDependencyContext handling .NET Core Versions greater than 3