### PR TITLE
downgrade NuGet.ProjectModel to 5.2.0

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="5.5.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.2.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
OmniSharp needs to stay on 5.2.0 so we have to be aligned accordingly.