### PR TITLE
Recognize pinned pre-release package references

### DIFF
--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -12,7 +12,12 @@
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Dotnet.Script.DependencyModel\ProjectSystem\ScriptParserInternal.cs" Link="ScriptParserInternal.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.6.0" />
   </ItemGroup>

--- a/src/Dotnet.Script.DependencyModel.Nuget/NuGetSourceReferenceResolver.cs
+++ b/src/Dotnet.Script.DependencyModel.Nuget/NuGetSourceReferenceResolver.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
+using Dotnet.Script.DependencyModel.ProjectSystem;
 
 namespace Dotnet.Script.DependencyModel.NuGet
 {
@@ -15,7 +14,6 @@ namespace Dotnet.Script.DependencyModel.NuGet
     {
         private readonly SourceReferenceResolver _sourceReferenceResolver;
         private readonly IDictionary<string, IReadOnlyList<string>> _scriptMap;
-        private static readonly Regex PackageNameMatcher = new Regex(@"\s*nuget\s*:\s*(.*)\s*,", RegexOptions.Compiled | RegexOptions.IgnoreCase); 
 
         public NuGetSourceReferenceResolver(SourceReferenceResolver sourceReferenceResolver, IDictionary<string, IReadOnlyList<string>> scriptMap)
         {
@@ -48,9 +46,8 @@ namespace Dotnet.Script.DependencyModel.NuGet
 
         public override string ResolveReference(string path, string baseFilePath)
         {
-            if (path.StartsWith("nuget:", StringComparison.OrdinalIgnoreCase))
+            if (ScriptParser.TryParseNuGetPackageReference(path, out var packageName, out _))
             {
-                var packageName = PackageNameMatcher.Match(path).Groups[1].Value;
                 if (_scriptMap.TryGetValue(packageName, out var scripts))
                 {
                     if (scripts.Count == 1)
@@ -66,9 +63,8 @@ namespace Dotnet.Script.DependencyModel.NuGet
 
         public override Stream OpenRead(string resolvedPath)
         {
-            if (resolvedPath.StartsWith("nuget:", StringComparison.OrdinalIgnoreCase))
+            if (ScriptParser.TryParseNuGetPackageReference(resolvedPath, out var packageName, out _))
             {
-                var packageName = PackageNameMatcher.Match(resolvedPath).Groups[1].Value;
                 var scripts = _scriptMap[packageName];
                 if (scripts.Count == 1)
                 {

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -20,6 +20,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="ProjectSystem\ScriptParserInternal.cs">
+      <DependentUpon>ScriptParser.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="ProjectSystem\csproj.template" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/PackageVersion.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/PackageVersion.cs
@@ -8,7 +8,38 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
     /// </summary>
     public class PackageVersion : IEquatable<PackageVersion>
     {
-        private static readonly Regex IsPinnedRegex = new Regex(@"^(?>\[\d+[^,\]]+(?<!\.)\]|\d+(\.\d+){2,})$", RegexOptions.Compiled);
+        // Following patterns are "inspired" from SemVer 2.0 grammar:
+        //
+        // Source: https://semver.org/spec/v2.0.0.html#backusnaur-form-grammar-for-valid-semver-versions
+
+        //   <numeric identifier> ::= "0"
+        //                          | <positive digit>
+        //                          | <positive digit> <digits>
+        //
+        //   <digits> ::= <digit>
+        //              | <digit> <digits>
+        //
+        //   <digit> ::= "0"
+        //             | <positive digit>
+        //
+        //   <positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+        const string NumericPattern = @"(?:0|[1-9][0-9]*)";
+
+        //   <valid semver> ::= <version core>
+        //          | <version core> "-" <pre-release>
+        //          | <version core> "+" <build>
+        //          | <version core> "-" <pre-release> "+" <build>
+        //
+        //   <version core> ::= <major> "." <minor> "." <patch>
+
+        const string MajorPlusVersionPattern = NumericPattern + @"(?:\." + NumericPattern + @")";
+        const string VersionSuffixPattern = @"(?:[+-][\w][\w+.-]*)?";
+
+        private static readonly Regex IsPinnedRegex =
+            new Regex(@"^(?>\[" + MajorPlusVersionPattern + @"{1,4}" + VersionSuffixPattern + @"\]"
+                         + @"|" + MajorPlusVersionPattern + @"{2,3}" + VersionSuffixPattern + @")$",
+                      RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PackageVersion"/> class.

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParser.cs
@@ -6,7 +6,7 @@ using Dotnet.Script.DependencyModel.Logging;
 
 namespace Dotnet.Script.DependencyModel.ProjectSystem
 {
-    public class ScriptParser
+    public partial class ScriptParser
     {
         private readonly Logger _logger;
 
@@ -36,15 +36,6 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
             return new ParseResult(allPackageReferences);
         }
-
-        const string Hws = @"[\x20\t]*"; // hws = horizontal whitespace
-
-        const string DirectivePatternPrefix = @"^"
-                                            + Hws + @"#";
-        const string DirectivePatternSuffix = Hws + @"""nuget:"
-                                            // https://github.com/NuGet/docs.microsoft.com-nuget/issues/543#issue-270039223
-                                            + Hws + @"(\w+(?:[_.-]\w+)*)"
-                                            + @"(?:" + Hws + "," + Hws + @"(.+?))?""";
 
         private static IEnumerable<PackageReference> ReadPackageReferencesFromReferenceDirective(string fileContent)
         {

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParserInternal.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptParserInternal.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+
+namespace Dotnet.Script.DependencyModel.ProjectSystem
+{
+    partial class ScriptParser
+    {
+        const string Hws = @"[\x20\t]*"; // hws = horizontal whitespace
+
+        const string NuGetPattern = @"nuget:"
+                                    // https://github.com/NuGet/docs.microsoft.com-nuget/issues/543#issue-270039223
+                                  + Hws + @"(\w+(?:[_.-]\w+)*)"
+                                  + @"(?:" + Hws + "," + Hws + @"(.+?))?";
+
+        const string WholeNuGetPattern = @"^" + NuGetPattern + @"$";
+
+        const string DirectivePatternPrefix = @"^" + Hws + @"#";
+        const string DirectivePatternSuffix = Hws + @"""" + NuGetPattern + @"""";
+
+        internal static bool TryParseNuGetPackageReference(string input,
+                                                           out string id, out string version)
+        {
+            bool success;
+            (success, id, version) =
+                Regex.Match(input, WholeNuGetPattern, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)
+                is {} match && match.Success
+                ? (true, match.Groups[1].Value, match.Groups[2].Value)
+                : default;
+            return success;
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/PackageVersionTests.cs
+++ b/src/Dotnet.Script.Tests/PackageVersionTests.cs
@@ -12,6 +12,10 @@ namespace Dotnet.Script.Tests
         [Theory]
         [InlineData("1.2.3")]
         [InlineData("1.2.3.4")]
+        [InlineData("1.2.3-beta1")]
+        [InlineData("0.1.4-beta")]             // See: https://github.com/filipw/dotnet-script/issues/407#issuecomment-563363947
+        [InlineData("2.0.0-preview3.20122.2")] // See: https://github.com/filipw/dotnet-script/issues/407#issuecomment-631122591
+        [InlineData("1.0.0-ci-20180920T1656")]
         [InlineData("[1.2]")]
         [InlineData("[1.2.3]")]
         [InlineData("[1.2.3-beta1]")]


### PR DESCRIPTION
This PR addresses #407 by fixing the regular expression used to determine whether a package reference is pinned or not.

### Steps to Test

Before this PR, using the [latest version (0.52.0)](https://www.nuget.org/packages/dotnet-script/0.52.0), the following:

    PS> dotnet script eval '#r \"nuget: Microsoft.Data.SqlClient,2.0.0-preview3.20122.2\"'

would issue the warning:

    warn: Dotnet.Script.DependencyModel.Context.CachedRestorer[0]
          Unable to cache C:\Users\johndoe\AppData\Local\Temp\dotnet-script\A\Dotnet.Script\Eval\interactive\interactive\netcoreapp3.1\script.csproj. For caching and optimal performance, ensure that the script(s) references Nuget packages with a pinned version.

After checking out this PR's branch, the following:

    PS> dotnet run -p .\src\Dotnet.Script -f netcoreapp3.1 -- eval '#r \"nuget: Microsoft.Data.SqlClient,2.0.0-preview3.20122.2\"'

will issue no warning about non-cache-ability of a floating (or an unpinned) reference.


## Additional Notes

This PR also refactored parts to share the regular expressions for package references more consistently between `ScriptParser` and `NuGetSourceReferenceResolver`. Since these two reside in separate projects, I avoided a dependency between the two by rendering `ScriptParser` partial, moving shared parts to another partial definition of the same class in a separate file called `ScriptParserInternals.cs`, and finally linking that into the Dotnet.Script.DependencyModel.NuGet project. The partial definition in `ScriptParserInternals.cs` has no `public` modifier so `ScriptParser` will not get introduced into the public API of Dotnet.Script.DependencyModel.NuGet.
