### PR TITLE
Discard script submission result (intentionally)

### DIFF
--- a/src/Dotnet.Script.Core/ScriptRunner.cs
+++ b/src/Dotnet.Script.Core/ScriptRunner.cs
@@ -47,10 +47,9 @@ namespace Dotnet.Script.Core
             submissionStates[0] = globals;
 
             var resultTask = method.Invoke(null, new[] { submissionStates }) as Task<TReturn>;
-            TReturn returnValue;
             try
             {
-                returnValue = await resultTask;
+                _ = await resultTask;
             }
             catch (System.Exception ex)
             {


### PR DESCRIPTION
A non-game-changing PR to use native syntax for discarding the submission result, which makes it more obvious that it was intended.
