### PR TITLE
Simplify cache check (in "ExecuteScriptCommand.GetLibrary")

### DIFF
--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
@@ -49,28 +49,20 @@ namespace Dotnet.Script.Core.Commands
             var executionCacheFolder = Path.Combine(projectFolder, "execution-cache");
             var pathToLibrary = Path.Combine(executionCacheFolder, "script.dll");
 
-            if (!TryCreateHash(executeOptions, out var hash) || !TryGetHash(executionCacheFolder, out var cachedHash))
+            if (TryCreateHash(executeOptions, out var hash)
+                && TryGetHash(executionCacheFolder, out var cachedHash)
+                && string.Equals(hash, cachedHash))
             {
-                return CreateLibrary();
+                return pathToLibrary;
             }
 
-            if (!string.Equals(hash, cachedHash))
+            var options = new PublishCommandOptions(executeOptions.File, executionCacheFolder, "script", PublishType.Library, executeOptions.OptimizationLevel, executeOptions.PackageSources, null, executeOptions.NoCache);
+            new PublishCommand(_scriptConsole, _logFactory).Execute(options);
+            if (hash != null)
             {
-                return CreateLibrary();
+                File.WriteAllText(Path.Combine(executionCacheFolder, "script.sha256"), hash);
             }
-
-            return pathToLibrary;
-
-            string CreateLibrary()
-            {
-                var options = new PublishCommandOptions(executeOptions.File, executionCacheFolder, "script", PublishType.Library, executeOptions.OptimizationLevel, executeOptions.PackageSources, null, executeOptions.NoCache);
-                new PublishCommand(_scriptConsole, _logFactory).Execute(options);
-                if (hash != null)
-                {
-                    File.WriteAllText(Path.Combine(executionCacheFolder, "script.sha256"), hash);
-                }
-                return Path.Combine(executionCacheFolder, "script.dll");
-            }
+            return Path.Combine(executionCacheFolder, "script.dll");
         }
 
         public bool TryCreateHash(ExecuteScriptCommandOptions options, out string hash)


### PR DESCRIPTION
This PR simplifies the cache check code in `Dotnet.Script.Core.Commands.ExecuteScriptCommand.GetLibrary`.

It combines multiple `if` statements into one with a _positive condition_ that is easier to read: _if_ a hash can be generated _and_ the last cached hash can be retrieved _and_ both hashes compare equal _then_ return the path of the previously compiled library. Doing so also gets rid of the local `CreateLibrary` that can be completely in-lined. The code then reads very linear; that is a library is created when there's a cache miss.