### PR TITLE
Add aggressive caching via C# minification

### DIFF
--- a/src/Dotnet.Script.Core/Commands/CommandScriptCompilationCacheLevel.cs
+++ b/src/Dotnet.Script.Core/Commands/CommandScriptCompilationCacheLevel.cs
@@ -1,0 +1,24 @@
+namespace Dotnet.Script.Core.Commands
+{
+    public enum CommandScriptCompilationCacheLevel
+    {
+        Default,
+        None,
+        Simple,
+        Aggressive,
+    }
+
+    public static class CommandScriptCompilationCacheLevelDefault
+    {
+        public static CommandScriptCompilationCacheLevel Value = CommandScriptCompilationCacheLevel.Aggressive;
+
+        public static CommandScriptCompilationCacheLevel Normalize(this CommandScriptCompilationCacheLevel level) =>
+            level == CommandScriptCompilationCacheLevel.Default ? Value : level;
+    }
+
+    internal static class CommandScriptCompilationCacheLevelConverter
+    {
+        public static CommandScriptCompilationCacheLevel ToCommandScriptCompilationCacheLevel(this bool value) =>
+            value ? CommandScriptCompilationCacheLevel.None : CommandScriptCompilationCacheLevel.Default;
+    }
+}

--- a/src/Dotnet.Script.Core/Commands/ExecuteCodeCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteCodeCommandOptions.cs
@@ -1,16 +1,21 @@
+using System;
 using Microsoft.CodeAnalysis;
 
 namespace Dotnet.Script.Core.Commands
 {
     public class ExecuteCodeCommandOptions
     {
-        public ExecuteCodeCommandOptions(string code, string workingDirectory, string[] arguments, OptimizationLevel optimizationLevel, bool noCache, string[] packageSources)
+        [Obsolete("Use the constructor overload that accepts a " + nameof(CommandScriptCompilationCacheLevel) + " argument instead.")]
+        public ExecuteCodeCommandOptions(string code, string workingDirectory, string[] arguments, OptimizationLevel optimizationLevel, bool noCache, string[] packageSources) :
+            this(code, workingDirectory, arguments, optimizationLevel, noCache.ToCommandScriptCompilationCacheLevel(), packageSources) {}
+
+        public ExecuteCodeCommandOptions(string code, string workingDirectory, string[] arguments, OptimizationLevel optimizationLevel, CommandScriptCompilationCacheLevel cacheLevel, string[] packageSources)
         {
             Code = code;
             WorkingDirectory = workingDirectory;
             Arguments = arguments;
             OptimizationLevel = optimizationLevel;
-            NoCache = noCache;
+            CacheLevel = cacheLevel;
             PackageSources = packageSources;
         }
 
@@ -18,7 +23,9 @@ namespace Dotnet.Script.Core.Commands
         public string WorkingDirectory { get; }
         public string[] Arguments { get; }
         public OptimizationLevel OptimizationLevel { get; }
-        public bool NoCache { get; }
+        public bool NoCache => CacheLevel == CommandScriptCompilationCacheLevel.None;
+        public CommandScriptCompilationCacheLevel CacheLevel { get; }
+        public CommandScriptCompilationCacheLevel NormalCacheLevel => CacheLevel.Normalize();
         public string[] PackageSources { get; }
     }
 }

--- a/src/Dotnet.Script.Core/Commands/ExecuteLibraryCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteLibraryCommandOptions.cs
@@ -1,16 +1,24 @@
+using System;
+
 namespace Dotnet.Script.Core.Commands
 {
     public class ExecuteLibraryCommandOptions
     {
-        public ExecuteLibraryCommandOptions(string libraryPath, string[] arguments, bool noCache)
+        [Obsolete("Use the constructor overload that accepts a " + nameof(CommandScriptCompilationCacheLevel) + " argument instead.")]
+        public ExecuteLibraryCommandOptions(string libraryPath, string[] arguments, bool noCache) :
+            this(libraryPath, arguments, noCache.ToCommandScriptCompilationCacheLevel()) {}
+
+        public ExecuteLibraryCommandOptions(string libraryPath, string[] arguments, CommandScriptCompilationCacheLevel cacheLevel)
         {
             LibraryPath = libraryPath;
             Arguments = arguments;
-            NoCache = noCache;
+            CacheLevel = cacheLevel;
         }
 
         public string LibraryPath { get; }
         public string[] Arguments { get; }
-        public bool NoCache { get; }
+        public bool NoCache => CacheLevel == CommandScriptCompilationCacheLevel.None;
+        public CommandScriptCompilationCacheLevel CacheLevel { get; }
+        public CommandScriptCompilationCacheLevel NormalCacheLevel => CacheLevel.Normalize();
     }
 }

--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommandOptions.cs
@@ -1,17 +1,22 @@
+using System;
 using Microsoft.CodeAnalysis;
 
 namespace Dotnet.Script.Core.Commands
 {
     public class ExecuteScriptCommandOptions
     {
-        public ExecuteScriptCommandOptions(ScriptFile file, string[] arguments, OptimizationLevel optimizationLevel, string[] packageSources, bool isInteractive ,bool noCache)
+        [Obsolete("Use the constructor overload that accepts a " + nameof(CommandScriptCompilationCacheLevel) + " argument instead.")]
+        public ExecuteScriptCommandOptions(ScriptFile file, string[] arguments, OptimizationLevel optimizationLevel, string[] packageSources, bool isInteractive, bool noCache) :
+            this(file, arguments, optimizationLevel, packageSources, isInteractive, noCache.ToCommandScriptCompilationCacheLevel()) {}
+
+        public ExecuteScriptCommandOptions(ScriptFile file, string[] arguments, OptimizationLevel optimizationLevel, string[] packageSources, bool isInteractive, CommandScriptCompilationCacheLevel cacheLevel)
         {
             File = file;
             Arguments = arguments;
             OptimizationLevel = optimizationLevel;
             PackageSources = packageSources;
             IsInteractive = isInteractive;
-            NoCache = noCache;
+            CacheLevel = cacheLevel;
         }
 
         public ScriptFile File { get; }
@@ -19,6 +24,8 @@ namespace Dotnet.Script.Core.Commands
         public OptimizationLevel OptimizationLevel { get; }
         public string[] PackageSources { get; }
         public bool IsInteractive { get; }
-        public bool NoCache { get; }
+        public bool NoCache => CacheLevel == CommandScriptCompilationCacheLevel.None;
+        public CommandScriptCompilationCacheLevel CacheLevel { get; }
+        public CommandScriptCompilationCacheLevel NormalCacheLevel => CacheLevel.Normalize();
     }
 }

--- a/src/Dotnet.Script.Core/Commands/PublishCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/PublishCommandOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using Dotnet.Script.DependencyModel.Environment;
 using Microsoft.CodeAnalysis;
 
@@ -5,7 +6,11 @@ namespace Dotnet.Script.Core.Commands
 {
     public class PublishCommandOptions
     {
-        public PublishCommandOptions(ScriptFile file, string outputDirectory, string libraryName, PublishType publishType, OptimizationLevel optimizationLevel, string[] packageSources, string runtimeIdentifier, bool noCache)
+        [Obsolete("Use the constructor overload that accepts a " + nameof(CommandScriptCompilationCacheLevel) + " argument instead.")]
+        public PublishCommandOptions(ScriptFile file, string outputDirectory, string libraryName, PublishType publishType, OptimizationLevel optimizationLevel, string[] packageSources, string runtimeIdentifier, bool noCache) :
+            this(file, outputDirectory, libraryName, publishType, optimizationLevel, packageSources, runtimeIdentifier, noCache.ToCommandScriptCompilationCacheLevel()) {}
+
+        public PublishCommandOptions(ScriptFile file, string outputDirectory, string libraryName, PublishType publishType, OptimizationLevel optimizationLevel, string[] packageSources, string runtimeIdentifier, CommandScriptCompilationCacheLevel cacheLevel)
         {
             File = file;
             OutputDirectory = outputDirectory;
@@ -14,7 +19,7 @@ namespace Dotnet.Script.Core.Commands
             OptimizationLevel = optimizationLevel;
             PackageSources = packageSources;
             RuntimeIdentifier = runtimeIdentifier ?? ScriptEnvironment.Default.RuntimeIdentifier;
-            NoCache = noCache;
+            CacheLevel = cacheLevel;
         }
 
         public ScriptFile File { get; }
@@ -24,7 +29,9 @@ namespace Dotnet.Script.Core.Commands
         public OptimizationLevel OptimizationLevel { get; }
         public string[] PackageSources { get; }
         public string RuntimeIdentifier { get; }
-        public bool NoCache { get; }
+        public bool NoCache => CacheLevel == CommandScriptCompilationCacheLevel.None;
+        public CommandScriptCompilationCacheLevel CacheLevel { get; }
+        public CommandScriptCompilationCacheLevel NormalCacheLevel => CacheLevel.Normalize();
     }
 
     public enum PublishType

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -21,6 +21,7 @@
     <EmbeddedResource Include="**/*.template" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CSharpMinifier" Version="1.2.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ReadLine" Version="2.0.1" />

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -68,6 +68,10 @@ namespace Dotnet.Script
             var nocache = app.Option("--no-cache", "Disable caching (Restore and Dll cache)", CommandOptionType.NoValue);
             var infoOption = app.Option("--info", "Displays environmental information", CommandOptionType.NoValue);
 
+            CommandScriptCompilationCacheLevel GetCacheLevel() =>
+                nocache.HasValue() ? CommandScriptCompilationCacheLevel.None
+                                   : CommandScriptCompilationCacheLevel.Default;
+
             var argsBeforeDoubleHyphen = args.TakeWhile(a => a != "--").ToArray();
             var argsAfterDoubleHyphen  = args.SkipWhile(a => a != "--").Skip(1).ToArray();
 
@@ -89,7 +93,7 @@ namespace Dotnet.Script
                         return 0;
                     }
                     var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
-                    var options = new ExecuteCodeCommandOptions(code.Value,cwd.Value(), app.RemainingArguments.Concat(argsAfterDoubleHyphen).ToArray(),configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase) ? OptimizationLevel.Release : OptimizationLevel.Debug, nocache.HasValue(),packageSources.Values?.ToArray());
+                    var options = new ExecuteCodeCommandOptions(code.Value,cwd.Value(), app.RemainingArguments.Concat(argsAfterDoubleHyphen).ToArray(),configuration.ValueEquals("release", StringComparison.OrdinalIgnoreCase) ? OptimizationLevel.Release : OptimizationLevel.Debug, GetCacheLevel(), packageSources.Values?.ToArray());
                     return await new ExecuteCodeCommand(ScriptConsole.Default, logFactory).Execute<int>(options);
                 });
             });
@@ -172,7 +176,7 @@ namespace Dotnet.Script
                         commandConfig.ValueEquals("release", StringComparison.OrdinalIgnoreCase) ? OptimizationLevel.Release : OptimizationLevel.Debug,
                         packageSources.Values?.ToArray(),
                         runtime.Value() ?? ScriptEnvironment.Default.RuntimeIdentifier,
-                        nocache.HasValue()
+                        GetCacheLevel()
                     );
 
                     var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
@@ -199,7 +203,7 @@ namespace Dotnet.Script
                     (
                         dllPath.Value,
                         app.RemainingArguments.Concat(argsAfterDoubleHyphen).ToArray(),
-                        nocache.HasValue()
+                        GetCacheLevel()
                     );
                     var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
                     return await new ExecuteLibraryCommand(ScriptConsole.Default, logFactory).Execute<int>(options);
@@ -235,7 +239,7 @@ namespace Dotnet.Script
                         optimizationLevel,
                         packageSources.Values?.ToArray(),
                         interactive.HasValue(),
-                        nocache.HasValue()
+                        GetCacheLevel()
                     );
 
                     var fileCommand = new ExecuteScriptCommand(ScriptConsole.Default, logFactory);


### PR DESCRIPTION
With this PR, I'd like to suggest a more aggressive caching strategy where the hash is built on _minified_ C# sources. Minification (not uglification) removes extraneous whitespace, comments and region markers from the source code. Since these cannot affect a program's behaviour, indentation/whitespace styling changes and add/removing/updating comments/regions won't constitute as a change that invalidates a cached execution. Otherwise and presently, even a change of a single space to a script or its `#load`-ed parts will generate a new hash and lead to a cache miss.

The PR uses [C# Minifier](https://github.com/atifaziz/CSharpMinifier) for minification. It's been released since a year and battle/field-tested in production against thousands of C# programs. C# Minifier is a hand-authored lexer written, ground-up, from the [C# specification](https://github.com/dotnet/csharplang/blob/892af9016b3317a8fae12d195014dc38ba51cf16/spec/lexical-structure.md). It does not use Roslyn so it is extremely lightweight to use and in processing. It only needs to understand the lexical structure and practically makes no heap allocations (no syntax trees). As a result, there should be no noticeable impact on performance. If you're curious, you can [try C# Minifier online and in your browser](https://atifaziz.github.io/CSharpMinifierDemo/) (via Blazor WebAssembly). It shows changes in compression and hash computation in real-time.

This PR maintains 100% backward compatibility, including (with painstaking care) at the public API surface level. It introduces a new `enum` called `CommandScriptCompilationCacheLevel`:

```c#
public enum CommandScriptCompilationCacheLevel { Default, None, Simple, Aggressive }
```

`Simple` represents the present behaviour where any physical change to the source will miss the cache. `Aggressive` is the goal of this PR that uses minification. `Default` is defined to be `Aggressive`. This provides a risk-free approach for the future where should you ever choose to revert, you can simply redirect `Default` to `Simple`. The interpretation of `Default` is done at run-time. If it was done at the level of the `enum` member (e.g. `Default = Aggressive`) then a change to the default level could cause binary breaking changes.

I've marked constructors taking a Boolean for caching as obsolete. Since this project is still following the 0.x lineage, we can drop those constructors now or in the future. If you think cache levels is an overkill then we can drop it and maintain just a Boolean flag for caching. Most of the changes in this PR are to maintain the public API compatibility. The actual change to enable caching over minified sources is tiny and limited to the `TryCreateHash` method of [`ExecuteScriptCommand`](https://github.com/filipw/dotnet-script/pull/552/files#diff-89e9a03adb6336108d6faab08143a23f).