### PR TITLE
Validate remote script MIME type early

### DIFF
--- a/src/Dotnet.Script.Core/ScriptDownloader.cs
+++ b/src/Dotnet.Script.Core/ScriptDownloader.cs
@@ -13,7 +13,7 @@ namespace Dotnet.Script.Core
             const string plainTextMediaType = "text/plain";
             using (HttpClient client = new HttpClient())
             {
-                using (HttpResponseMessage response = await client.GetAsync(uri))
+                using (HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead))
                 {
                     response.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
This PR makes a small change that will make sure that the MIME type of the URL will be validated as soon as the HTTP headers are available and before the content is touched.

Suppose by a copy-paste error, the user supplies the URL of the wrong resource that's very large (taking the example of [.NET Core 3.1 Runtime for Windows x64](https://download.visualstudio.microsoft.com/download/pr/518aafee-1285-4153-a30a-e4eefd538c90/6437d77a67b9c6b8cf0b7b3323004229/dotnet-runtime-3.1.6-win-x64.exe)). Before this PR, it takes substantial time (shy of a minute on my good bandwidth) before the media type error is reported:

```
❯ Measure-Command { dotnet src\Dotnet.Script\bin\Release\netcoreapp3.1\dotnet-script.dll https://download.visualstudio.microsoft.com/download/pr/518aafee-1285-4153-a30a-e4eefd538c90/6437d77a67b9c6b8cf0b7b3323004229/dotnet-runtime-3.1.6-win-x64.exe }
The media type 'application/octet-stream' is not supported when executing a script over http/https

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 54
Milliseconds      : 787
Ticks             : 547878720
TotalDays         : 0.000634118888888889
TotalHours        : 0.0152188533333333
TotalMinutes      : 0.9131312
TotalSeconds      : 54.787872
TotalMilliseconds : 54787.872
```

After this PR, the error is reported in just over ½ of a second and no further bandwidth, time & memory (even money 😉) is wasted downloading the resource:

```
❯ Measure-Command { dotnet src\Dotnet.Script\bin\Release\netcoreapp3.1\dotnet-script.dll https://download.visualstudio.microsoft.com/download/pr/518aafee-1285-4153-a30a-e4eefd538c90/6437d77a67b9c6b8cf0b7b3323004229/dotnet-runtime-3.1.6-win-x64.exe }
The media type 'application/octet-stream' is not supported when executing a script over http/https

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 570
Ticks             : 5702311
TotalDays         : 6.59989699074074E-06
TotalHours        : 0.000158397527777778
TotalMinutes      : 0.00950385166666667
TotalSeconds      : 0.5702311
TotalMilliseconds : 570.2311
```