### PR TITLE
Fix Dockerfile to use .NET Core SDK 3.1 as base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 # https://www.nuget.org/packages/dotnet-script/
 RUN dotnet tool install dotnet-script --tool-path /usr/bin


### PR DESCRIPTION
Build the image:

```
❯ cd build
❯ docker build -t dotnet-script -f Dockerfile .
```

Running a container with the image fails:

```
❯ docker run --rm -it dotnet-script
It was not possible to find any compatible framework version
The specified framework 'Microsoft.NETCore.App', version '2.1.0' was not found.
  - The following frameworks were found:
      3.0.0 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The .NET Core frameworks can be found at:
  - https://aka.ms/dotnet-download
```

This PR fixes the base image referenced in `Dockerfile` to use .NET Core SDK 3.1.

Perhaps this was missed as part of PR #523?
