### PR TITLE
Include command output in restore exception message

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -31,11 +31,13 @@ namespace Dotnet.Script.DependencyModel.Context
 
             _logger.Debug($"Restoring {projectFileInfo.Path} using the dotnet cli. RuntimeIdentifier : {runtimeIdentifier} NugetConfigFile: {projectFileInfo.NuGetConfigFile}");
 
-            var exitcode = _commandRunner.Execute("dotnet", $"restore \"{projectFileInfo.Path}\" -r {runtimeIdentifier} {packageSourcesArgument} {configFileArgument}", workingDirectory);
-            if (exitcode != 0)
+            var commandPath = "dotnet";
+            var commandArguments = $"restore \"{projectFileInfo.Path}\" -r {runtimeIdentifier} {packageSourcesArgument} {configFileArgument}";
+            var commandResult = _commandRunner.Capture(commandPath, commandArguments, workingDirectory);
+            if (commandResult.ExitCode != 0)
             {
                 // We must throw here, otherwise we may incorrectly run with the old 'project.assets.json'
-                throw new Exception($"Unable to restore packages from '{projectFileInfo.Path}'. Make sure that all script files contains valid NuGet references");
+                throw new Exception($"Unable to restore packages from '{projectFileInfo.Path}'{System.Environment.NewLine}Make sure that all script files contains valid NuGet references{System.Environment.NewLine}{System.Environment.NewLine}Details:{System.Environment.NewLine}{workingDirectory} : {commandPath} {commandArguments}{System.Environment.NewLine}{commandResult.StandardOut}");
             }
 
             string CreatePackageSourcesArguments()

--- a/src/Dotnet.Script.Tests/DotnetRestorerTests.cs
+++ b/src/Dotnet.Script.Tests/DotnetRestorerTests.cs
@@ -1,0 +1,80 @@
+﻿using Dotnet.Script.DependencyModel.Context;
+using Dotnet.Script.DependencyModel.Process;
+using Dotnet.Script.DependencyModel.ProjectSystem;
+using Dotnet.Script.Shared.Tests;
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dotnet.Script.Tests
+{
+    public class DotnetRestorerTests
+    {
+        private PackageReference ValidPackageReferenceA => new PackageReference("Newtonsoft.Json", "12.0.3");
+        private PackageReference ValidPackageReferenceB => new PackageReference("Moq", "4.14.5");
+
+        private PackageReference InvalidPackageReferenceA => new PackageReference("7c63e1f5-2248-ed31-9480-e4cb5ac322fe", "1.0.0");
+
+        public DotnetRestorerTests(ITestOutputHelper testOutputHelper)
+        {
+            testOutputHelper.Capture();
+        }
+
+        [Fact]
+        public void ShouldRestoreProjectPackageReferences()
+        {
+            using (var projectFolder = new DisposableFolder())
+            {
+                var pathToProjectFile = Path.Combine(projectFolder.Path, "script.csproj");
+
+                var projectFile = new ProjectFile();
+                projectFile.PackageReferences.Add(ValidPackageReferenceA);
+                projectFile.PackageReferences.Add(ValidPackageReferenceB);
+                projectFile.Save(pathToProjectFile);
+
+                var projectFileInfo = new ProjectFileInfo(pathToProjectFile, string.Empty);
+
+                var logFactory = TestOutputHelper.CreateTestLogFactory();
+                var commandRunner = new CommandRunner(logFactory);
+                var restorer = new DotnetRestorer(commandRunner, logFactory);
+
+                var pathToProjectObjDirectory = Path.Combine(projectFolder.Path, "obj");
+
+                Assert.False(Directory.Exists(pathToProjectObjDirectory));
+
+                restorer.Restore(projectFileInfo, Array.Empty<string>());
+
+                Assert.True(Directory.Exists(pathToProjectObjDirectory));
+            }
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionOnRestoreError()
+        {
+            using (var projectFolder = new DisposableFolder())
+            {
+                var pathToProjectFile = Path.Combine(projectFolder.Path, "script.csproj");
+
+                var projectFile = new ProjectFile();
+                projectFile.PackageReferences.Add(ValidPackageReferenceA);
+                projectFile.PackageReferences.Add(InvalidPackageReferenceA);
+                projectFile.PackageReferences.Add(ValidPackageReferenceB);
+                projectFile.Save(pathToProjectFile);
+
+                var projectFileInfo = new ProjectFileInfo(pathToProjectFile, string.Empty);
+
+                var logFactory = TestOutputHelper.CreateTestLogFactory();
+                var commandRunner = new CommandRunner(logFactory);
+                var restorer = new DotnetRestorer(commandRunner, logFactory);
+
+                var exception = Assert.Throws<Exception>(() =>
+                {
+                    restorer.Restore(projectFileInfo, Array.Empty<string>());
+                });
+
+                Assert.Contains("NU1101", exception.Message); // unable to find package 
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

The error message currently displayed when `DotnetRestorer.Restore` fails does not provide enough information to resolve the issue.

This PR adds the executed command and the command's output to the current error message

Current error message example:
```
Unable to restore packages from 'C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\.\netcoreapp3.1\script.csproj'. Make sure that all script files contains valid NuGet references
```

New improved error message example:
```
Unable to restore packages from 'C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\.\netcoreapp3.1\script.csproj'
Make sure that all script files contains valid NuGet references

Details:
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1 : dotnet restore "C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\.\netcoreapp3.1\script.csproj" -r win10-x64  --configfile "C:\Users\user\AppData\Roaming\NuGet\NuGet.Config"
  Determining projects to restore...
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605: Detected package downgrade: Microsoft.Win32.Primitives from 4.3.0 to 4.0.1. Reference the package directly from the project to select a different version.
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605:  script -> AngleSharp.Js 0.14.0 -> jint 2.10.4 -> NETStandard.Library 1.6.0 -> System.Net.Primitives 4.0.11 -> runtime.win.System.Net.Primitives 4.3.0 -> Microsoft.Win32.Primitives (>= 4.3.0)
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605:  script -> AngleSharp.Js 0.14.0 -> jint 2.10.4 -> NETStandard.Library 1.6.0 -> Microsoft.Win32.Primitives (>= 4.0.1)
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605: Detected package downgrade: System.Net.Primitives from 4.3.0 to 4.0.11. Reference the package directly from the project to select a different version.
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605:  script -> AngleSharp.Js 0.14.0 -> jint 2.10.4 -> NETStandard.Library 1.6.0 -> System.Net.Sockets 4.1.0 -> runtime.win.System.Net.Sockets 4.3.0 -> System.Net.Primitives (>= 4.3.0)
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605:  script -> AngleSharp.Js 0.14.0 -> jint 2.10.4 -> NETStandard.Library 1.6.0 -> System.Net.Primitives (>= 4.0.11)
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605: Detected package downgrade: Microsoft.Win32.Primitives from 4.3.0 to 4.0.1. Reference the package directly from the project to select a different version.
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605:  script -> AngleSharp.Js 0.14.0 -> jint 2.10.4 -> NETStandard.Library 1.6.0 -> System.Net.Sockets 4.1.0 -> runtime.win.System.Net.Sockets 4.3.0 -> System.Security.Principal.Windows 4.3.0 -> Microsoft.Win32.Primitives (>= 4.3.0)
C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj : error NU1605:  script -> AngleSharp.Js 0.14.0 -> jint 2.10.4 -> NETStandard.Library 1.6.0 -> Microsoft.Win32.Primitives (>= 4.0.1)
  Failed to restore C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\netcoreapp3.1\script.csproj (in 769 ms).
```

## Motivation and Context
I had a problem which I could not solve with the current error message

### Problem:
1. Create a script with this content
```
#r "nuget: AngleSharp.Js, 0.14.0"
#r "nuget: Microsoft.SyndicationFeed.ReaderWriter, 1.0.2"
Console.WriteLine("it works");
```
2. Execute the script (using the .net core 3.1 binary of dotnet-script. with .net core 2.5 binary it would work)
3. It fails and the current error message example from above is displayed
- Both nuget packages exist
- Running `dotnet restore` manually on `C:\Users\user\AppData\Local\Temp\dotnet-script\D\scripts\.\netcoreapp3.1\script.csproj` works
4. At this point there is no way to resolve the issue without having to build and debug dotnet-script

### How does this change help?
- Knowing the executed command would help because then I would notice that `dotnet restore` is run with `-r win10-x64`. With this argument it fails, without it it works
- Knowing the output of the executed command you can easily tell why the restore fails and how to fix it. Nuget cannot determine the version of two dependencies.

With these information I can finally run the script by changing it to this:
```
#r "nuget: Microsoft.Win32.Primitives, 4.3.0"
#r "nuget: System.Net.Primitives, 4.3.1"
#r "nuget: AngleSharp.Js, 0.14.0"
#r "nuget: Microsoft.SyndicationFeed.ReaderWriter, 1.0.2"
Console.WriteLine("it works");
```
