### PR TITLE
fixed CompilationDependencyResolver for .NET 5.0

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
@@ -44,10 +44,11 @@ namespace Dotnet.Script.DependencyModel.Compilation
             }
 
             // On .Net Core, we need to fetch the compilation references for framework assemblies separately.
-            if (defaultTargetFramework.StartsWith("netcoreapp3", StringComparison.InvariantCultureIgnoreCase))
+            if (defaultTargetFramework.StartsWith("netcoreapp3", StringComparison.InvariantCultureIgnoreCase) ||
+                defaultTargetFramework.StartsWith("net5", StringComparison.InvariantCultureIgnoreCase))
             {
                 var compilationreferences = _compilationReferenceReader.Read(projectFileInfo);
-                result.Add(new CompilationDependency("Microsoft.NETCore.App", "3.0", compilationreferences.Select(cr => cr.Path).ToArray(), Array.Empty<string>()));
+                result.Add(new CompilationDependency("Dotnet.Script.Default.Dependencies", "99.0", compilationreferences.Select(cr => cr.Path).ToArray(), Array.Empty<string>()));
             }
 
             return result;

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationReferencesReader.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationReferencesReader.cs
@@ -48,7 +48,7 @@ namespace Dotnet.Script.DependencyModel.Compilation
             {
                 File.Delete(referencePathsFile);
             }
-            var exitCode = _commandRunner.Execute("dotnet", $"build \"{pathToCompilationProjectFile}\" /p:OutputType=Library -o {outputDirectory}", workingDirectory);
+            var exitCode = _commandRunner.Execute("dotnet", $"build \"{pathToCompilationProjectFile}\" /p:OutputType=Library -o {outputDirectory} --nologo", workingDirectory);
             if (exitCode != 0)
             {
                 throw new Exception($"Unable to read compilation dependencies for '{projectFile.Path}'. Make sure that all script files contains valid NuGet references");

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
also renamed the compilation dependency name to avoid confusion that this is a real package
I only bumped the version of that project - we don't need to release everything, I think