### PR TITLE
cache script per file instead of per directory

### DIFF
--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
@@ -45,7 +45,7 @@ namespace Dotnet.Script.Core.Commands
 
         private string GetLibrary(ExecuteScriptCommandOptions executeOptions)
         {
-            var projectFolder = FileUtils.GetPathToScriptTempFolder(Path.GetDirectoryName(executeOptions.File.Path));
+            var projectFolder = FileUtils.GetPathToScriptTempFolder(executeOptions.File.Path);
             var executionCacheFolder = Path.Combine(projectFolder, "execution-cache");
             var pathToLibrary = Path.Combine(executionCacheFolder, "script.dll");
 

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -1,5 +1,6 @@
-using System.IO;
 using Dotnet.Script.Shared.Tests;
+using System;
+using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -86,6 +87,61 @@ namespace Dotnet.Script.Tests
                 var pathToExecutionCache = GetPathToExecutionCache(pathToScript);
                 Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.dll")));
                 Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.pdb")));
+            }
+        }
+
+        [Fact]
+        public void ShouldCacheScriptsFromSameFolderIndividually()
+        {
+            (string Output, bool Cached) Execute(string pathToScript)
+            {
+                var result = ScriptTestRunner.Default.Execute($"{pathToScript} --debug");
+                return (Output: result.output, Cached: result.output.Contains("Using cached compilation"));
+            }
+
+            using (var scriptFolder = new DisposableFolder())
+            {
+                var pathToScriptA = Path.Combine(scriptFolder.Path, "script.csx");
+                var pathToScriptB = Path.Combine(scriptFolder.Path, "script");
+
+
+                var idScriptA = Guid.NewGuid().ToString();
+                File.AppendAllText(pathToScriptA, $@"WriteLine(""{idScriptA}"");");
+
+                var idScriptB = Guid.NewGuid().ToString();
+                File.AppendAllText(pathToScriptB, $@"WriteLine(""{idScriptB}"");");
+
+
+                var firstResultOfScriptA = Execute(pathToScriptA);
+                Assert.Contains(idScriptA, firstResultOfScriptA.Output);
+                Assert.False(firstResultOfScriptA.Cached);
+
+                var firstResultOfScriptB = Execute(pathToScriptB);
+                Assert.Contains(idScriptB, firstResultOfScriptB.Output);
+                Assert.False(firstResultOfScriptB.Cached);
+
+
+                var secondResultOfScriptA = Execute(pathToScriptA);
+                Assert.Contains(idScriptA, secondResultOfScriptA.Output);
+                Assert.True(secondResultOfScriptA.Cached);
+
+                var secondResultOfScriptB = Execute(pathToScriptB);
+                Assert.Contains(idScriptB, secondResultOfScriptB.Output);
+                Assert.True(secondResultOfScriptB.Cached);
+
+
+                var idScriptB2 = Guid.NewGuid().ToString();
+                File.AppendAllText(pathToScriptB, $@"WriteLine(""{idScriptB2}"");");
+
+
+                var thirdResultOfScriptA = Execute(pathToScriptA);
+                Assert.Contains(idScriptA, thirdResultOfScriptA.Output);
+                Assert.True(thirdResultOfScriptA.Cached);
+
+                var thirdResultOfScriptB = Execute(pathToScriptB);
+                Assert.Contains(idScriptB, thirdResultOfScriptB.Output);
+                Assert.Contains(idScriptB2, thirdResultOfScriptB.Output);
+                Assert.False(thirdResultOfScriptB.Cached);
             }
         }
 

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -25,10 +25,12 @@ namespace Dotnet.Script.Tests
                 WriteScript(pathToScript, "WriteLine(42);");
                 var firstResult = Execute(pathToScript);
                 Assert.Contains("42", firstResult.output);
+                Assert.NotNull(firstResult.hash);
 
                 WriteScript(pathToScript, "WriteLine(42);");
                 var secondResult = Execute(pathToScript);
                 Assert.Contains("42", secondResult.output);
+                Assert.NotNull(secondResult.hash);
 
                 Assert.Equal(firstResult.hash, secondResult.hash);
             }
@@ -45,10 +47,12 @@ namespace Dotnet.Script.Tests
                 WriteScript(pathToScript, "WriteLine(42);");
                 var firstResult = Execute(pathToScript);
                 Assert.Contains("42", firstResult.output);
+                Assert.NotNull(firstResult.hash);
 
                 WriteScript(pathToScript, "WriteLine(84);");
                 var secondResult = Execute(pathToScript);
                 Assert.Contains("84", secondResult.output);
+                Assert.NotNull(secondResult.hash);
 
                 Assert.NotEqual(firstResult.hash, secondResult.hash);
             }
@@ -103,7 +107,7 @@ namespace Dotnet.Script.Tests
 
         private static string GetPathToExecutionCache(string pathToScript)
         {
-            var pathToTempFolder = Path.GetDirectoryName(Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript));
+            var pathToTempFolder = Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript);
             var pathToExecutionCache = Path.Combine(pathToTempFolder, "execution-cache");
             return pathToExecutionCache;
         }


### PR DESCRIPTION
## Description

Currently only one script per directory is cached.

This PR adds the script file name into the cache directory path, therefore caching scripts per file instead of per directory.

Example:
|Script|Current Cache|New Cache|
|-|-|-|
|```D:\scriptA.csx```|```%tmp%\dotnet-script\D\execution-cache\script.dll```|```%tmp%\dotnet-script\D\scriptA.csx\execution-cache\script.dll```|
|```D:\scriptB.csx```|```%tmp%\dotnet-script\D\execution-cache\script.dll```|```%tmp%\dotnet-script\D\scriptB.csx\execution-cache\script.dll```|

## Motivation and Context
I would like to benefit from the execution speed up by caching without having to separate every script into its own directory.