### PR TITLE
Bugfix-Initialize folder with whitespace

### DIFF
--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -63,7 +63,7 @@ namespace Dotnet.Script.Core
                     RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     // mark .csx file as executable, this activates the shebang to run dotnet-script as interpreter
-                    _commandRunner.Execute($"/bin/chmod", $"+x {pathToScriptFile}");
+                    _commandRunner.Execute($"/bin/chmod", $"+x \"{pathToScriptFile}\"");
                 }
                 _scriptConsole.WriteSuccess($"...'{pathToScriptFile}' [Created]");
             }

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -25,8 +25,6 @@ namespace Dotnet.Script.Tests
         {
             using (var scriptFolder = new DisposableFolder())
             {
-                ScriptTestRunner.Default.ExecuteInProcess($"init {scriptFolder.Path}");
-
                 var (output, exitCode) = ScriptTestRunner.Default.Execute("init", scriptFolder.Path);
 
                 Assert.Equal(0, exitCode);

--- a/src/Dotnet.Script.Tests/ScaffoldingTests.cs
+++ b/src/Dotnet.Script.Tests/ScaffoldingTests.cs
@@ -25,12 +25,32 @@ namespace Dotnet.Script.Tests
         {
             using (var scriptFolder = new DisposableFolder())
             {
+                ScriptTestRunner.Default.ExecuteInProcess($"init {scriptFolder.Path}");
+
                 var (output, exitCode) = ScriptTestRunner.Default.Execute("init", scriptFolder.Path);
 
                 Assert.Equal(0, exitCode);
                 Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "main.csx")));
                 Assert.True(File.Exists(Path.Combine(scriptFolder.Path, "omnisharp.json")));
                 Assert.True(File.Exists(Path.Combine(scriptFolder.Path, ".vscode", "launch.json")));
+            }
+        }
+
+        [Fact]
+        public void ShouldInitializeScriptFolderContainingWhitespace()
+        {
+            using (var scriptFolder = new DisposableFolder())
+            {
+                var path = Path.Combine(scriptFolder.Path, "Folder with whitespace");
+                Directory.CreateDirectory(path);
+
+                var (output, exitCode) = ScriptTestRunner.Default.Execute("init", path);
+
+                Assert.Equal(0, exitCode);
+                Assert.DoesNotContain("No such file or directory", output, StringComparison.OrdinalIgnoreCase);
+                Assert.True(File.Exists(Path.Combine(path, "main.csx")));
+                Assert.True(File.Exists(Path.Combine(path, "omnisharp.json")));
+                Assert.True(File.Exists(Path.Combine(path, ".vscode", "launch.json")));
             }
         }
 


### PR DESCRIPTION
This PR fixes #605 by ensuring that we quote the filename before calling into `chmod`
