### PR TITLE
Update Microsoft.Extensions.Logging.Console to 5.0.0

### DIFF
--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -24,7 +24,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.12" Condition="'$(TargetFramework)' != 'net5.0'"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -24,7 +24,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.6" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -24,8 +24,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.12" Condition="'$(TargetFramework)' != 'net5.0'"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />


### PR DESCRIPTION
I have a NuGet dependency that uses Microsoft.Extensions.Logging.Abstractions 5.0.0, scripts using it won't compile due to Dotnet.Script's version differing. 5.0.0 is the latest stable version of the logging packages.