### PR TITLE
Add Dockerfile for networkless container support; Add ghcr docker auto deploy workflow

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -1,0 +1,41 @@
+name: Docker CD
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    
+      - name: checkout code
+        uses: actions/checkout@v2
+    
+      - name: Log in to ghcr
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+    
+      - if: startsWith(github.ref, 'refs/heads/master')
+        run: echo "TAG=latest" >> $GITHUB_ENV
+        
+      - if: startsWith(github.ref, 'refs/tags')
+        run: echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
+    
+      - name: Build & Push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./build
+          file: ./build/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ env.TAG }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 # https://www.nuget.org/packages/dotnet-script/
 RUN dotnet tool install dotnet-script --tool-path /usr/bin

--- a/build/prerestore.Dockerfile
+++ b/build/prerestore.Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+
+# https://www.nuget.org/packages/dotnet-script/
+RUN dotnet tool install dotnet-script --tool-path /usr/bin
+
+# Create a simple script, execute it and cleanup after
+# to create the script project dir, which requires
+# 'dotnet restore' to be run.
+# This is necessary if you want to run this in a networkless
+# docker container.
+RUN echo "return;" > tmpscript.cs
+RUN dotnet script tmpscript.cs
+RUN rm tmpscript.cs
+
+ENTRYPOINT [ "dotnet", "script" ]

--- a/build/prerestore.Dockerfile
+++ b/build/prerestore.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 # https://www.nuget.org/packages/dotnet-script/
 RUN dotnet tool install dotnet-script --tool-path /usr/bin
@@ -8,8 +8,6 @@ RUN dotnet tool install dotnet-script --tool-path /usr/bin
 # 'dotnet restore' to be run.
 # This is necessary if you want to run this in a networkless
 # docker container.
-RUN echo "return;" > tmpscript.cs
-RUN dotnet script tmpscript.cs
-RUN rm tmpscript.cs
+RUN dotnet script eval "Console.WriteLine(\"☑️ Prepared env for offline usage\")"
 
 ENTRYPOINT [ "dotnet", "script" ]


### PR DESCRIPTION
Hey 👋

## TL;DR 
I've added a `prerestore.Dockerfile` which allows running the script wrapper in a networkless Docker container by restoring the required dependencies for the script environment inside the image creation. 
> This *might* cause some problems when the target system has not the same architecture as the system where the image was created.

Also, I've added a Workflow script to build and deploy the docker image to [ghcr.io](https://ghcr.io).

## Details
I discovered the project when I was looking for a script engine/wrapper Docker image for .NET, so I can use it for my current little project [ranna-go/ranna](https://github.com/ranna-go/ranna). ranna is using networkless Docker containers for code execution to dodge various kind of problems you can run into with arbitrary code execution in network attached containers. But when doing so with the provided image, I ran into the following problem:
```
$ docker run --name test -v $PWD/main.cs:/var/tmp/scripts/main.cs --network none dotnet-script /var/tmp/scripts/main.cs
Unable to restore packages from '/root/.cache/dotnet-script/var/tmp/scripts/netcoreapp3.1/script.csproj'
Make sure that all script files contains valid NuGet references

Details:
/root/.cache/dotnet-script/var/tmp/scripts/netcoreapp3.1 : dotnet restore "/root/.cache/dotnet-script/var/tmp/scripts/netcoreapp3.1/script.csproj" -r linux-x64  --configfile "/root/.nuget/NuGet/NuGet.Config"
  Determining projects to restore...
/usr/share/dotnet/sdk/3.1.408/NuGet.targets(128,5): error : Unable to load the service index for source https://api.nuget.org/v3/index.json. [/root/.cache/dotnet-script/var/tmp/scripts/netcoreapp3.1/script.csproj]
/usr/share/dotnet/sdk/3.1.408/NuGet.targets(128,5): error :   Resource temporarily unavailable [/root/.cache/dotnet-script/var/tmp/scripts/netcoreapp3.1/script.csproj]
```
So, I've created a kind of hacky way to solve this by running an "empty" script during the image build process to embed the restored dependencies in the image. This workaround seems to work consistently.

Also, because I need to be able to fetch the image from a package registry, I've created an Actions Workflow to build and push the image to the GitHub Container Registry, which is kind of handy because you need no DockerHub credentials in your workflow and the image is directly highlighted on the repository page.

So I want to share these findings and changes I've made with you. Maybe it comes in handy for you, so you can merge them if you want to. 😄