### PR TITLE
Don't stop at entry when debugging in VS Code

### DIFF
--- a/src/Dotnet.Script.Core/Templates/launch.json.template
+++ b/src/Dotnet.Script.Core/Templates/launch.json.template
@@ -12,7 +12,7 @@
                 "${file}"
             ],
             "cwd": "${workspaceRoot}",
-            "stopAtEntry": true
+            "stopAtEntry": false
         }
     ]
 }


### PR DESCRIPTION
This PR changes the default for `stopAtEntry` from `true` to `false`. Recent versions of the debugger shipped with VS Code seems to respect this flag which it did not when we initially created this. The behaviour is unfortunate since the user might think te breakpoint is not being hit. Changing this to `false` ensures that the debugger does not pause until it sees an actual breakpoint.  