### PR TITLE
Test issues when running from a folder containing a space character in its name

### DIFF
--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -2,6 +2,7 @@
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Process;
 using Dotnet.Script.DependencyModel.ProjectSystem;
+using Gapotchenko.FX.Diagnostics;
 using System;
 using System.IO;
 using System.Linq;
@@ -44,7 +45,7 @@ namespace Dotnet.Script.DependencyModel.Context
             {
                 return packageSources.Length == 0
                     ? string.Empty
-                    : packageSources.Select(s => $"-s {s}")
+                    : packageSources.Select(s => $"-s {CommandLine.EscapeArgument(s)}")
                         .Aggregate((current, next) => $"{current} {next}");
             }
 

--- a/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
+++ b/src/Dotnet.Script.DependencyModel/Context/DotnetRestorer.cs
@@ -1,8 +1,8 @@
 ﻿using Dotnet.Script.DependencyModel.Environment;
+using Dotnet.Script.DependencyModel.Internal;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Process;
 using Dotnet.Script.DependencyModel.ProjectSystem;
-using Gapotchenko.FX.Diagnostics;
 using System;
 using System.IO;
 using System.Linq;

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Gapotchenko.FX.Diagnostics.CommandLine" Version="2021.1.5" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.2.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
   </ItemGroup>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gapotchenko.FX.Diagnostics.CommandLine" Version="2021.1.5" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.2.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
   </ItemGroup>

--- a/src/Dotnet.Script.DependencyModel/Internal/CommandLine.cs
+++ b/src/Dotnet.Script.DependencyModel/Internal/CommandLine.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Dotnet.Script.DependencyModel.Internal
+{
+    /// <summary>
+    /// <para>
+    /// Performs operations on <see cref="System.String"/> instances that contain command line information.
+    /// </para>
+    /// <para>
+    /// Tip: a ready-to-use package with this functionality is available at https://www.nuget.org/packages/Gapotchenko.FX.Diagnostics.CommandLine.
+    /// </para>
+    /// </summary>
+    /// <summary>
+    /// Available
+    /// </summary>
+    static class CommandLine
+    {
+        /// <summary>
+        /// Escapes and optionally quotes a command line argument.
+        /// </summary>
+        /// <param name="value">The command line argument.</param>
+        /// <returns>The escaped and optionally quoted command line argument.</returns>
+        public static string EscapeArgument(string value)
+        {
+            if (value == null)
+                return null;
+
+            int length = value.Length;
+            if (length == 0)
+                return string.Empty;
+
+            var sb = new StringBuilder();
+            Escape.AppendQuotedText(sb, value);
+
+            if (sb.Length == length)
+                return value;
+
+            return sb.ToString();
+        }
+
+        static class Escape
+        {
+            public static void AppendQuotedText(StringBuilder sb, string text)
+            {
+                bool quotingRequired = IsQuotingRequired(text);
+                if (quotingRequired)
+                    sb.Append('"');
+
+                int numberOfQuotes = 0;
+                for (int i = 0; i < text.Length; i++)
+                {
+                    if (text[i] == '"')
+                        numberOfQuotes++;
+                }
+
+                if (numberOfQuotes > 0)
+                {
+                    if ((numberOfQuotes % 2) != 0)
+                        throw new Exception("Command line parameter cannot contain an odd number of double quotes.");
+                    text = text.Replace("\\\"", "\\\\\"").Replace("\"", "\\\"");
+                }
+
+                sb.Append(text);
+
+                if (quotingRequired && text.EndsWith("\\"))
+                    sb.Append('\\');
+
+                if (quotingRequired)
+                    sb.Append('"');
+            }
+
+            static bool IsQuotingRequired(string parameter) =>
+                !AllowedUnquotedRegex.IsMatch(parameter) ||
+                DefinitelyNeedQuotesRegex.IsMatch(parameter);
+
+            static Regex m_CachedAllowedUnquotedRegex;
+
+            static Regex AllowedUnquotedRegex =>
+                m_CachedAllowedUnquotedRegex ??= new Regex(
+                    @"^[a-z\\/:0-9\._\-+=]*$",
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+            static Regex m_CachedDefinitelyNeedQuotesRegex;
+
+            static Regex DefinitelyNeedQuotesRegex =>
+                m_CachedDefinitelyNeedQuotesRegex ??= new Regex(
+                    "[|><\\s,;\"]+",
+                    RegexOptions.CultureInvariant);
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/PackageSourceTests.cs
+++ b/src/Dotnet.Script.Tests/PackageSourceTests.cs
@@ -17,7 +17,7 @@ namespace Dotnet.Script.Tests
         {
             var fixture = "ScriptPackage/WithNoNuGetConfig";
             var pathToScriptPackages = ScriptPackagesFixture.GetPathToPackagesFolder();
-            var result = ScriptTestRunner.Default.ExecuteFixture(fixture, $"--no-cache -s {pathToScriptPackages}");
+            var result = ScriptTestRunner.Default.ExecuteFixture(fixture, $"--no-cache -s \"{pathToScriptPackages}\"");
             Assert.Contains("Hello", result.output);
             Assert.Equal(0, result.exitCode);
         }
@@ -27,7 +27,7 @@ namespace Dotnet.Script.Tests
         {
             var pathToScriptPackages = ScriptPackagesFixture.GetPathToPackagesFolder();
             var code = @"#load \""nuget:ScriptPackageWithMainCsx,1.0.0\"" SayHello();";
-            var result = ScriptTestRunner.Default.Execute($"--no-cache -s {pathToScriptPackages} eval \"{code}\"");
+            var result = ScriptTestRunner.Default.Execute($"--no-cache -s \"{pathToScriptPackages}\" eval \"{code}\"");
             Assert.Contains("Hello", result.output);
             Assert.Equal(0, result.exitCode);
         }

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.Shared.Tests;
-using Gapotchenko.FX.Diagnostics;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -140,7 +139,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldHandleIssue189()
         {
-            var result = ScriptTestRunner.Default.Execute(CommandLine.Build(Path.Combine(TestPathUtils.GetPathToTestFixtureFolder("Issue189"), "SomeFolder", "Script.csx")));
+            var result = ScriptTestRunner.Default.Execute($"\"{Path.Combine(TestPathUtils.GetPathToTestFixtureFolder("Issue189"), "SomeFolder", "Script.csx")}\"");
             Assert.Contains("Newtonsoft.Json.JsonConvert", result.output);
         }
 

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.Shared.Tests;
+using Gapotchenko.FX.Diagnostics;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -139,7 +140,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldHandleIssue189()
         {
-            var result = ScriptTestRunner.Default.Execute(Path.Combine(TestPathUtils.GetPathToTestFixtureFolder("Issue189"), "SomeFolder", "Script.csx"));
+            var result = ScriptTestRunner.Default.Execute(CommandLine.Build(Path.Combine(TestPathUtils.GetPathToTestFixtureFolder("Issue189"), "SomeFolder", "Script.csx")));
             Assert.Contains("Newtonsoft.Json.JsonConvert", result.output);
         }
 

--- a/src/Dotnet.Script.Tests/ScriptPackagesFixture.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesFixture.cs
@@ -43,12 +43,12 @@ namespace Dotnet.Script.Tests
                 if (_scriptEnvironment.IsWindows)
                 {
                     command = pathtoNuget430;
-                    var result = ProcessHelper.RunAndCaptureOutput(command, $"pack {specFile} -OutputDirectory {pathToPackagesOutputFolder}");
+                    var result = ProcessHelper.RunAndCaptureOutput(command, $"pack \"{specFile}\" -OutputDirectory \"{pathToPackagesOutputFolder}\"");
                 }
                 else
                 {
                     command = "mono";
-                    var result = ProcessHelper.RunAndCaptureOutput(command, $"{pathtoNuget430} pack {specFile} -OutputDirectory {pathToPackagesOutputFolder}");
+                    var result = ProcessHelper.RunAndCaptureOutput(command, $"\"{pathtoNuget430}\" pack \"{specFile}\" -OutputDirectory \"{pathToPackagesOutputFolder}\"");
                 }
 
             }

--- a/src/Dotnet.Script.Tests/ScriptTestRunner.cs
+++ b/src/Dotnet.Script.Tests/ScriptTestRunner.cs
@@ -88,7 +88,7 @@ namespace Dotnet.Script.Tests
             configuration = "Release";
 #endif
 
-            var allArgs = $"exec {Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", configuration, _scriptEnvironment.TargetFramework, "dotnet-script.dll")} {arguments}";
+            var allArgs = $"exec \"{Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "Dotnet.Script", "bin", configuration, _scriptEnvironment.TargetFramework, "dotnet-script.dll")}\" {arguments}";
 
             return allArgs;
         }

--- a/src/Dotnet.Script.Tests/ScriptTestRunner.cs
+++ b/src/Dotnet.Script.Tests/ScriptTestRunner.cs
@@ -38,7 +38,7 @@ namespace Dotnet.Script.Tests
         public (string output, int exitCode) ExecuteFixture(string fixture, string arguments = null, string workingDirectory = null)
         {
             var pathToFixture = TestPathUtils.GetPathToTestFixture(fixture);
-            var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments($"{pathToFixture} {arguments}"), workingDirectory);
+            var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments($"\"{pathToFixture}\" {arguments}"), workingDirectory);
             return result;
         }
 
@@ -46,7 +46,7 @@ namespace Dotnet.Script.Tests
         {
             var pathToScriptPackageFixtures = TestPathUtils.GetPathToTestFixtureFolder("ScriptPackage");
             var pathToFixture = Path.Combine(pathToScriptPackageFixtures, fixture, $"{fixture}.csx");
-            return ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments($"{pathToFixture} {arguments}"), workingDirectory);
+            return ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments($"\"{pathToFixture}\" {arguments}"), workingDirectory);
         }
 
         public int ExecuteFixtureInProcess(string fixture, string arguments = null)


### PR DESCRIPTION
When the DotNet.Script solution resides in a folder containing a space character in its name, an avalanche of test failures occurs due to the absence of escaping of command line arguments.

The enclosed pull request fixes all those issues.

Besides tests, there was a similar issue in `DotNetRestorer` class that was fixed as well by employing a batte-tested string escaping algorithm from [Gapotchenko.FX.Diagnostics.CommandLine](https://github.com/gapotchenko/Gapotchenko.FX/tree/master/Source/Gapotchenko.FX.Diagnostics.CommandLine) package.

An intricate detail of NuGet's `-s` argument is that it may end with `\` character (e.g. the last separator in a folder path), so such a naive escaping approach as `$"-s \"{s}\""` would not work here, as it will cause an unanticipated escape of the escape character `"`.  Hence the usage of a proper escape function here to isolate the customer-supplied data.