### PR TITLE
drop support for .NET Core 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ To consume a script package all we need to do specify the NuGet package in the `
 The following example loads the [simple-targets](https://www.nuget.org/packages/simple-targets-csx) package that contains script files to be included in our script.
 
 ```C#
-#! "netcoreapp3.1"
 #load "nuget:simple-targets-csx, 6.0.0"
 
 using static SimpleTargets;
@@ -463,7 +462,6 @@ The following example shows how we can pipe data in and out of a script.
 The `UpperCase.csx` script simply converts the standard input to upper case and writes it back out to standard output.
 
 ```csharp
-#! "netcoreapp3.1"
 using (var streamReader = new StreamReader(Console.OpenStandardInput()))
 {
     Write(streamReader.ReadToEnd().ToUpper());

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Run C# scripts from the .NET CLI, define NuGet packages inline and edit/debug th
 
 | Name                                  | Version                                                      | Framework(s)                     |
 | ------------------------------------- | ------------------------------------------------------------ | -------------------------------- |
-| `dotnet-script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/) | `netcoreapp2.1`, `netcoreapp3.1` |
-| `Dotnet.Script`                       | [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/) | `netcoreapp2.1`, `netcoreapp3.1` |
+| `dotnet-script` (global tool)         | [![Nuget](http://img.shields.io/nuget/v/dotnet-script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet-script/) | `net5.0`, `netcoreapp3.1` |
+| `Dotnet.Script` (CLI as Nuget)        | [![Nuget](http://img.shields.io/nuget/v/dotnet.script.svg?maxAge=10800)](https://www.nuget.org/packages/dotnet.script/) | `net5.0`, `netcoreapp3.1` |
 | `Dotnet.Script.Core`                  | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.Core.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.Core/) | `netstandard2.0`                 |
 | `Dotnet.Script.DependencyModel`       | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel/) | `netstandard2.0`                 |
 | `Dotnet.Script.DependencyModel.Nuget` | [![Nuget](http://img.shields.io/nuget/v/Dotnet.Script.DependencyModel.Nuget.svg?maxAge=10800)](https://www.nuget.org/packages/Dotnet.Script.DependencyModel.Nuget/) | `netstandard2.0`                 |
@@ -316,7 +316,7 @@ To consume a script package all we need to do specify the NuGet package in the `
 The following example loads the [simple-targets](https://www.nuget.org/packages/simple-targets-csx) package that contains script files to be included in our script.
 
 ```C#
-#! "netcoreapp2.1"
+#! "netcoreapp3.1"
 #load "nuget:simple-targets-csx, 6.0.0"
 
 using static SimpleTargets;
@@ -466,7 +466,7 @@ The following example shows how we can pipe data in and out of a script.
 The `UpperCase.csx` script simply converts the standard input to upper case and writes it back out to standard output.
 
 ```csharp
-#! "netcoreapp2.1"
+#! "netcoreapp3.1"
 using (var streamReader = new StreamReader(Console.OpenStandardInput()))
 {
     Write(streamReader.ReadToEnd().ToUpper());

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Run C# scripts from the .NET CLI, define NuGet packages inline and edit/debug th
 
 ### Prerequisites
 
-The only thing we need to install is [.NET Core 2.1+ SDK](https://www.microsoft.com/net/download/core). In order to use C# 8.0 features, [.NET Core 3.1+ SDK](https://www.microsoft.com/net/download/core) must be installed.
+The only thing we need to install is [.NET Core 3.1 or .NET 5.0 SDK](https://www.microsoft.com/net/download/core).
 
 ### .NET Core Global Tool
 
-.NET Core 2.1 introduces the concept of global tools meaning that you can install `dotnet-script` using nothing but the .NET CLI.
+.NET Core 2.1 introduced the concept of global tools meaning that you can install `dotnet-script` using nothing but the .NET CLI.
 
 ```shell
 dotnet tool install -g dotnet-script
@@ -34,9 +34,6 @@ Tool 'dotnet-script' (version '0.22.0') was successfully installed.
 ```
 
 The advantage of this approach is that you can use the same command for installation across all platforms.
-
-> ⚠️ In order to use the global tool you need [.NET Core SDK 2.1.300](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300) or higher. The earlier previews and release candidates of .NET Core 2.1 are not supported.
-
 .NET Core SDK also supports viewing a list of installed tools and their uninstallation.
 
 ```shell

--- a/build/Build.csx
+++ b/build/Build.csx
@@ -35,7 +35,7 @@ await StepRunner.Execute(Args);
 
 private void CreateGitHubReleaseAsset()
 {
-    DotNet.Publish(dotnetScriptProjectFolder, publishArtifactsFolder, "netcoreapp2.1");
+    DotNet.Publish(dotnetScriptProjectFolder, publishArtifactsFolder, "netcoreapp3.1");
     Zip(publishArchiveFolder, pathToGitHubReleaseAsset);
 }
 

--- a/build/omnisharp.json
+++ b/build/omnisharp.json
@@ -1,6 +1,6 @@
 {
   "script": {
     "enableScriptNuGetReferences": true,
-    "defaultTargetFramework": "netcoreapp2.1"
+    "defaultTargetFramework": "netcoreapp3.1"
   }
 }

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/filipw/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../dotnet-script.snk</AssemblyOriginatorKeyFile>

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/csproj.template
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/csproj.template
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dotnet.Script.Desktop.Tests/CompilationDepenencyTests.cs
+++ b/src/Dotnet.Script.Desktop.Tests/CompilationDepenencyTests.cs
@@ -15,8 +15,8 @@ namespace Dotnet.Script.Desktop.Tests
         }
 
         [Theory]
-        [InlineData("netcoreapp2.1")]
-        [InlineData("netcoreapp3.0")]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("net5.0")]
         public void ShouldGetCompilationDependenciesForNetCoreApp(string targetFramework)
         {
             var resolver = CreateResolver();

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../dotnet-script.snk</AssemblyOriginatorKeyFile>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-        <VersionPrefix>1.1.0</VersionPrefix>
+        <VersionPrefix>1.2.0</VersionPrefix>
         <Authors>filipw</Authors>
         <PackageId>Dotnet.Script</PackageId>
-        <TargetFrameworks>net5.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>dotnet-script</AssemblyName>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
.NET Core 2.1 reached end of life 2 days ago https://dotnet.microsoft.com/platform/support/policy/dotnet-core 