### PR TITLE
Updated McMaster.Extensions.CommandLineUtils to 3.0.0

### DIFF
--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -25,7 +25,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -55,8 +55,9 @@ namespace Dotnet.Script
 
         private static int Wain(string[] args)
         {
-            var app = new CommandLineApplication(throwOnUnexpectedArg: false)
+            var app = new CommandLineApplication()
             {
+                UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
                 ExtendedHelpText = "Starting without a path to a CSX file or a command, starts the REPL (interactive) mode."
             };
 
@@ -83,7 +84,7 @@ namespace Dotnet.Script
                 var code = c.Argument("code", "Code to execute.");
                 var cwd = c.Option("-cwd |--workingdirectory <currentworkingdirectory>", "Working directory for the code compiler. Defaults to current directory.", CommandOptionType.SingleValue);
                 c.HelpOption(helpOptionTemplate);
-                c.OnExecute(async () =>
+                c.OnExecuteAsync(async (cancellationToken) =>
                 {
                     var source = code.Value;
                     if (string.IsNullOrWhiteSpace(source))
@@ -198,7 +199,7 @@ namespace Dotnet.Script
                 var dllPath = c.Argument("dll", "Path to DLL based script");
                 var commandDebugMode = c.Option(DebugFlagShort + " | " + DebugFlagLong, "Enables debug output.", CommandOptionType.NoValue);
                 c.HelpOption(helpOptionTemplate);
-                c.OnExecute(async () =>
+                c.OnExecuteAsync(async (cancellationToken) =>
                 {
                     if (string.IsNullOrWhiteSpace(dllPath.Value))
                     {
@@ -217,7 +218,7 @@ namespace Dotnet.Script
                 });
             });
 
-            app.OnExecute(async () =>
+            app.OnExecuteAsync(async (cancellationToken) =>
             {
                 int exitCode = 0;
 


### PR DESCRIPTION
Updated the command line utils package.

I have done this as my .csx scripts pull a package that references a more recent version of McMaster.Extensions.CommandLineUtils. This causes the script to fail:

```
FileLoadException:Could not load file or assembly 'McMaster.Extensions.CommandLineUtils, Version=3.0.0.0, Culture=neutral, PublicKeyToken=6f71cb76b82f055d'. Could not find or load a specific file. (0x80131621)
at Microsoft.Extensions.Hosting.HostBuilderExtensions.RunCommandLineApplicationAsync[TApp](IHostBuilder hostBuilder, String[] args, CancellationToken cancellationToken)
at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
at Microsoft.Extensions.Hosting.HostBuilderExtensions.RunCommandLineApplicationAsync[TApp](IHostBuilder hostBuilder, String[] args, CancellationToken cancellationToken)
at Indi.UpdateIndex.WebJob.Program.Main(String[] args)
```

I have tried downgrading the referenced package to 2.2.5 but that version has some issues.

This does highlight an issue where dotnet-script dependencies conflict with the .csx nuget dependencies, however I figure this is a harmless upgrade that allows me to proceed in the short term