### PR TITLE
Replaced NewtonSoft package with System.Text.Json

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Gapotchenko.FX" Version="2021.1.5" />
     <PackageReference Include="Gapotchenko.FX.Reflection.Loader" Version="2021.2.11" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
     <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />

--- a/src/Dotnet.Script.Core/Versioning/VersionProvider.cs
+++ b/src/Dotnet.Script.Core/Versioning/VersionProvider.cs
@@ -2,9 +2,9 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Dotnet.Script.DependencyModel.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace Dotnet.Script.Core.Versioning
 {
@@ -34,8 +34,8 @@ namespace Dotnet.Script.Core.Versioning
 
             VersionInfo ParseTagName(string json)
             {
-                JObject jsonResult = JObject.Parse(json);
-                return new VersionInfo(jsonResult.SelectToken("tag_name").Value<string>(), isResolved:true);
+                JsonDocument jsonResult = JsonDocument.Parse(json);
+                return new VersionInfo(jsonResult.RootElement.GetProperty("tag_name").GetString(), isResolved:true);
             }
         }
 


### PR DESCRIPTION
This removes the `Newtonsoft.Json 12.0.3` dependency that causes issues when using other packages that reference the newer `13.0.1` version of Newtonsoft (see #443 for the same issue with the older Newtonsoft 11.0/12.0 conflict).

I've replaced `Newtonsoft.Json` completely with `System.Text.Json 5.0.0`.  
Unfortunately this results in a bit of ugly code in the `Dotnet.Script.Core.Scaffolder` class to update a JSON property, as this version of `System.Text.Json` doesn't allow manipulation of the JSON DOM - I've had to manually re-write the  JSON.

The impending `6.0.0` version (currently in [RC](https://www.nuget.org/packages/System.Text.Json/6.0.0-rc.2.21480.5)) will resolve that, as it has writable DOM support - making it possible for this code to be much simpler (much like the Newtonsoft version). I'll update this again once that version is out of beta (it still supports both `.NETStandard 2.0` and `.NETCoreApp 3.1`).