### PR TITLE
Allow arrow keys and history to work on linux based systems

### DIFF
--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -62,7 +62,15 @@ namespace Dotnet.Script.Core
 
         public virtual string ReadLine()
         {
-            return In == null ? RL.Read() : In.ReadLine();
+            bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+            string result = (In == null || !isWindows) ? RL.Read() : In.ReadLine();
+
+            if (!isWindows)
+            {
+              RL.AddHistory (result);
+            }
+
+            return result;
         }
 
         public ScriptConsole(TextWriter output, TextReader input, TextWriter error)


### PR DESCRIPTION
I've attempted to test this on Linux (archlinux) and macOS with both dotnet 3.1 and 6.0, and I'm able to use arrow keys to navigate the next.  I've also added history functionality to work in these environments.