### PR TITLE
Correct order of `dotnet script register` command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The OSX/Linux shebang directive should be **#!/usr/bin/env dotnet-script**
 Console.WriteLine("Hello world");
 ```
 
-On Windows, you can run **dotnet register script** to achieve a similar behaviour. This register dotnet-script in the Windows registry as the tool to process .csx files.
+On Windows, you can run `dotnet script register` to achieve a similar behaviour. This registers dotnet-script in the Windows registry as the tool to process .csx files.
 
 You can pass arguments to control your script execution more.
 


### PR DESCRIPTION
## Description

Corrects documentation of the `dotnet-script register` command introduced by #431.

Since this is invoking dotnet-script's register command, it should be `dotnet script register` or `dotnet-script regster` instead of `dotnet register script`.

I also corrected a grammatical error on the same line.

## Verification

On my local machine with dotnet-script installed at version 1.3.1, I get the following output:

```
>dotnet-script --version
1.3.1

>dotnet register script
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET program, but dotnet-register does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.

>dotnet script register
...[Registered]
```