### PR TITLE
Added '--cache-path' command line option

### DIFF
--- a/src/Dotnet.Script.Core/Commands/ExecuteCodeCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteCodeCommand.cs
@@ -22,7 +22,7 @@ namespace Dotnet.Script.Core.Commands
         {
             var sourceText = SourceText.From(options.Code);
             var context = new ScriptContext(sourceText, options.WorkingDirectory ?? Directory.GetCurrentDirectory(), options.Arguments, null, options.OptimizationLevel, ScriptMode.Eval, options.PackageSources);
-            var compiler = new ScriptCompiler(_logFactory, !options.NoCache)
+            var compiler = new ScriptCompiler(_logFactory, options.CachePath, !options.NoCache)
             {
 #if NETCOREAPP
                 AssemblyLoadContext = options.AssemblyLoadContext

--- a/src/Dotnet.Script.Core/Commands/ExecuteCodeCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteCodeCommandOptions.cs
@@ -7,12 +7,13 @@ namespace Dotnet.Script.Core.Commands
 {
     public class ExecuteCodeCommandOptions
     {
-        public ExecuteCodeCommandOptions(string code, string workingDirectory, string[] arguments, OptimizationLevel optimizationLevel, bool noCache, string[] packageSources)
+        public ExecuteCodeCommandOptions(string code, string workingDirectory, string[] arguments, OptimizationLevel optimizationLevel, string cachePath, bool noCache, string[] packageSources)
         {
             Code = code;
             WorkingDirectory = workingDirectory;
             Arguments = arguments;
             OptimizationLevel = optimizationLevel;
+			CachePath = cachePath;
             NoCache = noCache;
             PackageSources = packageSources;
         }
@@ -21,6 +22,7 @@ namespace Dotnet.Script.Core.Commands
         public string WorkingDirectory { get; }
         public string[] Arguments { get; }
         public OptimizationLevel OptimizationLevel { get; }
+        public string CachePath { get; }
         public bool NoCache { get; }
         public string[] PackageSources { get; }
 

--- a/src/Dotnet.Script.Core/Commands/ExecuteInteractiveCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteInteractiveCommand.cs
@@ -18,7 +18,7 @@ namespace Dotnet.Script.Core.Commands
 
         public async Task<int> Execute(ExecuteInteractiveCommandOptions options)
         {
-            var compiler = new ScriptCompiler(_logFactory, useRestoreCache: false)
+            var compiler = new ScriptCompiler(_logFactory, options.CachePath, useRestoreCache: false)
             {
 #if NETCOREAPP
                 AssemblyLoadContext = options.AssemblyLoadContext

--- a/src/Dotnet.Script.Core/Commands/ExecuteInteractiveCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteInteractiveCommandOptions.cs
@@ -6,16 +6,18 @@ namespace Dotnet.Script.Core.Commands
 {
     public class ExecuteInteractiveCommandOptions
     {
-        public ExecuteInteractiveCommandOptions(ScriptFile scriptFile, string[] arguments, string[] packageSources)
+        public ExecuteInteractiveCommandOptions(ScriptFile scriptFile, string[] arguments, string[] packageSources, string cachePath)
         {
             ScriptFile = scriptFile;
             Arguments = arguments;
             PackageSources = packageSources;
+            CachePath = cachePath;
         }
 
         public ScriptFile ScriptFile { get; }
         public string[] Arguments { get; }
         public string[] PackageSources { get; }
+        public string CachePath { get; }
 
 #if NETCOREAPP
 #nullable enable

--- a/src/Dotnet.Script.Core/Commands/ExecuteLibraryCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteLibraryCommand.cs
@@ -25,7 +25,7 @@ namespace Dotnet.Script.Core.Commands
             }
 
             var absoluteFilePath = options.LibraryPath.GetRootedPath();
-            var compiler = new ScriptCompiler(_logFactory, !options.NoCache)
+            var compiler = new ScriptCompiler(_logFactory, options.CachePath, !options.NoCache)
             {
 #if NETCOREAPP
                 AssemblyLoadContext = options.AssemblyLoadContext

--- a/src/Dotnet.Script.Core/Commands/ExecuteLibraryCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteLibraryCommandOptions.cs
@@ -6,15 +6,17 @@ namespace Dotnet.Script.Core.Commands
 {
     public class ExecuteLibraryCommandOptions
     {
-        public ExecuteLibraryCommandOptions(string libraryPath, string[] arguments, bool noCache)
+        public ExecuteLibraryCommandOptions(string libraryPath, string[] arguments, string cachePath, bool noCache)
         {
             LibraryPath = libraryPath;
             Arguments = arguments;
+            CachePath = cachePath;
             NoCache = noCache;
         }
 
         public string LibraryPath { get; }
         public string[] Arguments { get; }
+        public string CachePath { get; }
         public bool NoCache { get; }
 
 #if NETCOREAPP

--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommandOptions.cs
@@ -7,13 +7,14 @@ namespace Dotnet.Script.Core.Commands
 {
     public class ExecuteScriptCommandOptions
     {
-        public ExecuteScriptCommandOptions(ScriptFile file, string[] arguments, OptimizationLevel optimizationLevel, string[] packageSources, bool isInteractive ,bool noCache)
+        public ExecuteScriptCommandOptions(ScriptFile file, string[] arguments, OptimizationLevel optimizationLevel, string[] packageSources, bool isInteractive, string cachePath, bool noCache)
         {
             File = file;
             Arguments = arguments;
             OptimizationLevel = optimizationLevel;
             PackageSources = packageSources;
             IsInteractive = isInteractive;
+            CachePath = cachePath;
             NoCache = noCache;
         }
 
@@ -22,6 +23,7 @@ namespace Dotnet.Script.Core.Commands
         public OptimizationLevel OptimizationLevel { get; }
         public string[] PackageSources { get; }
         public bool IsInteractive { get; }
+        public string CachePath { get; }
         public bool NoCache { get; }
 
 #if NETCOREAPP

--- a/src/Dotnet.Script.Core/Commands/PublishCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/PublishCommand.cs
@@ -33,14 +33,14 @@ namespace Dotnet.Script.Core.Commands
                 (options.PublishType == PublishType.Library ? Path.Combine(Path.GetDirectoryName(absoluteFilePath), "publish") : Path.Combine(Path.GetDirectoryName(absoluteFilePath), "publish", options.RuntimeIdentifier));
 
             var absolutePublishDirectory = publishDirectory.GetRootedPath();
-            var compiler = new ScriptCompiler(_logFactory, !options.NoCache)
+            var compiler = new ScriptCompiler(_logFactory, options.CachePath, !options.NoCache)
             {
 #if NETCOREAPP
                 AssemblyLoadContext = options.AssemblyLoadContext
 #endif
             };
             var scriptEmitter = new ScriptEmitter(_scriptConsole, compiler);
-            var publisher = new ScriptPublisher(_logFactory, scriptEmitter);
+            var publisher = new ScriptPublisher(_logFactory, scriptEmitter, options.CachePath);
             var code = absoluteFilePath.ToSourceText();
             var context = new ScriptContext(code, absolutePublishDirectory, Enumerable.Empty<string>(), absoluteFilePath, options.OptimizationLevel, packageSources: options.PackageSources);
 

--- a/src/Dotnet.Script.Core/Commands/PublishCommandOptions.cs
+++ b/src/Dotnet.Script.Core/Commands/PublishCommandOptions.cs
@@ -8,7 +8,7 @@ namespace Dotnet.Script.Core.Commands
 {
     public class PublishCommandOptions
     {
-        public PublishCommandOptions(ScriptFile file, string outputDirectory, string libraryName, PublishType publishType, OptimizationLevel optimizationLevel, string[] packageSources, string runtimeIdentifier, bool noCache)
+        public PublishCommandOptions(ScriptFile file, string outputDirectory, string libraryName, PublishType publishType, OptimizationLevel optimizationLevel, string[] packageSources, string runtimeIdentifier, string cachePath, bool noCache)
         {
             File = file;
             OutputDirectory = outputDirectory;
@@ -17,6 +17,7 @@ namespace Dotnet.Script.Core.Commands
             OptimizationLevel = optimizationLevel;
             PackageSources = packageSources;
             RuntimeIdentifier = runtimeIdentifier ?? ScriptEnvironment.Default.RuntimeIdentifier;
+            CachePath = cachePath;
             NoCache = noCache;
         }
 
@@ -27,6 +28,7 @@ namespace Dotnet.Script.Core.Commands
         public OptimizationLevel OptimizationLevel { get; }
         public string[] PackageSources { get; }
         public string RuntimeIdentifier { get; }
+        public string CachePath { get; }
         public bool NoCache { get; }
 
 #if NETCOREAPP

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.6.1</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>1.6.1</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <Authors>filipw</Authors>
     <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>

--- a/src/Dotnet.Script.Core/ScriptCompiler.cs
+++ b/src/Dotnet.Script.Core/ScriptCompiler.cs
@@ -63,8 +63,8 @@ namespace Dotnet.Script.Core
 
         public RuntimeDependencyResolver RuntimeDependencyResolver { get; }
 
-        public ScriptCompiler(LogFactory logFactory, bool useRestoreCache)
-            : this(logFactory, new RuntimeDependencyResolver(logFactory, useRestoreCache))
+        public ScriptCompiler(LogFactory logFactory, string cachePath, bool useRestoreCache)
+            : this(logFactory, new RuntimeDependencyResolver(logFactory, cachePath, useRestoreCache))
         {
 
         }

--- a/src/Dotnet.Script.Core/ScriptPublisher.cs
+++ b/src/Dotnet.Script.Core/ScriptPublisher.cs
@@ -26,10 +26,10 @@ namespace Dotnet.Script.Core
             _scriptEnvironment = ScriptEnvironment.Default;
         }
 
-        public ScriptPublisher(LogFactory logFactory, ScriptEmitter scriptEmitter)
+        public ScriptPublisher(LogFactory logFactory, ScriptEmitter scriptEmitter, string cachePath)
             : this
             (
-                new ScriptProjectProvider(logFactory),
+                new ScriptProjectProvider(logFactory, cachePath),
                 scriptEmitter,
                 ScriptConsole.Default
             )
@@ -43,7 +43,7 @@ namespace Dotnet.Script.Core
 
             assemblyFileName = assemblyFileName ?? Path.GetFileNameWithoutExtension(context.FilePath);
             var scriptAssemblyPath = CreateScriptAssembly<TReturn, THost>(context, context.WorkingDirectory, assemblyFileName);
-            var tempProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), ScriptEnvironment.Default.TargetFramework);
+            var tempProjectPath = _scriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), ScriptEnvironment.Default.TargetFramework);
             var tempProjectDirecory = Path.GetDirectoryName(tempProjectPath);
 
             var sourceProjectAssetsPath = Path.Combine(tempProjectDirecory, "obj", "project.assets.json");
@@ -55,7 +55,7 @@ namespace Dotnet.Script.Core
             File.Copy(sourceNugetPropsPath, destinationNugetPropsPath, overwrite: true);
 
             // only display published if we aren't auto publishing to temp folder
-            if (!scriptAssemblyPath.StartsWith(FileUtils.GetTempPath()))
+            if (!_scriptProjectProvider.IsTempPath(scriptAssemblyPath))
             {
                 _scriptConsole.WriteSuccess($"Published {context.FilePath} to {scriptAssemblyPath}");
             }
@@ -71,8 +71,8 @@ namespace Dotnet.Script.Core
             executableFileName ??= Path.GetFileNameWithoutExtension(context.FilePath);
             const string AssemblyName = "scriptAssembly";
 
-            var tempProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), _scriptEnvironment.TargetFramework);
-            var renamedProjectPath = ScriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), _scriptEnvironment.TargetFramework, executableFileName);
+            var tempProjectPath = _scriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), _scriptEnvironment.TargetFramework);
+            var renamedProjectPath = _scriptProjectProvider.GetPathToProjectFile(Path.GetDirectoryName(context.FilePath), _scriptEnvironment.TargetFramework, executableFileName);
             var tempProjectDirectory = Path.GetDirectoryName(tempProjectPath);
 
             var scriptAssemblyPath = CreateScriptAssembly<TReturn, THost>(context, tempProjectDirectory, AssemblyName);

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/dotnet-script/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/dotnet-script/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>1.6.1</Version>
+    <Version>1.7.0</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Compilation/CompilationDependencyResolver.cs
@@ -18,7 +18,7 @@ namespace Dotnet.Script.DependencyModel.Compilation
 
         private readonly IRestorer _restorer;
 
-        public CompilationDependencyResolver(LogFactory logFactory) : this(new ScriptProjectProvider(logFactory), new ScriptDependencyContextReader(logFactory), new CompilationReferencesReader(logFactory), logFactory)
+        public CompilationDependencyResolver(LogFactory logFactory, string cachePath) : this(new ScriptProjectProvider(logFactory, cachePath), new ScriptDependencyContextReader(logFactory), new CompilationReferencesReader(logFactory), logFactory)
         {
         }
 

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/dotnet-script/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../dotnet-script.snk</AssemblyOriginatorKeyFile>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/dotnet-script/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>1.6.1</Version>
+    <Version>1.7.0</Version>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../dotnet-script.snk</AssemblyOriginatorKeyFile>

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -10,9 +10,9 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 {
     public static class FileUtils
     {
-        public static string CreateTempFolder(string targetDirectory, string targetFramework)
+        public static string CreateTempFolder(string targetDirectory, string cachePath, string targetFramework)
         {
-            string pathToProjectDirectory = Path.Combine(GetPathToScriptTempFolder(targetDirectory), targetFramework);
+            string pathToProjectDirectory = Path.Combine(GetPathToScriptTempFolder(targetDirectory, cachePath), targetFramework);
 
             if (!Directory.Exists(pathToProjectDirectory))
             {
@@ -22,14 +22,18 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
             return pathToProjectDirectory;
         }
 
-        public static string GetPathToScriptTempFolder(string targetDirectory)
+        public static string GetPathToScriptTempFolder(string targetDirectory, string cachePath)
         {
             if (!Path.IsPathRooted(targetDirectory))
             {
                 throw new ArgumentOutOfRangeException(nameof(targetDirectory), "Must be a root path");
             }
 
-            var tempDirectory = GetTempPath();
+            var tempDirectory =
+                string.IsNullOrEmpty(cachePath) ? GetTempPath() :
+                Path.IsPathRooted(cachePath) ? cachePath :
+                Path.Combine(Directory.GetCurrentDirectory(), cachePath);
+
             var pathRoot = Path.GetPathRoot(targetDirectory);
             var targetDirectoryWithoutRoot = targetDirectory.Substring(pathRoot.Length);
             if (pathRoot.Length > 0 && ScriptEnvironment.Default.IsWindows)

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
@@ -142,7 +142,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
         public bool IsTempPath(string path)
         {
-            return path.StartsWith(FileUtils.GetTempPath()) || path.StartsWith(_cachePath);
+            return path.StartsWith(FileUtils.GetTempPath()) || (!string.IsNullOrEmpty(_cachePath) && path.StartsWith(_cachePath));
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/ScriptProjectProvider.cs
@@ -11,17 +11,19 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         private readonly ScriptParser _scriptParser;
         private readonly ScriptFilesResolver _scriptFilesResolver;
         private readonly ScriptEnvironment _scriptEnvironment;
+        private readonly string _cachePath;
         private readonly Logger _logger;
 
-        private ScriptProjectProvider(ScriptParser scriptParser, ScriptFilesResolver scriptFilesResolver, LogFactory logFactory, ScriptEnvironment scriptEnvironment)
+        private ScriptProjectProvider(ScriptParser scriptParser, ScriptFilesResolver scriptFilesResolver, LogFactory logFactory, string cachePath, ScriptEnvironment scriptEnvironment)
         {
             _logger = logFactory.CreateLogger<ScriptProjectProvider>();
+            _cachePath = cachePath;
             _scriptParser = scriptParser;
             _scriptFilesResolver = scriptFilesResolver;
             _scriptEnvironment = scriptEnvironment;
         }
 
-        public ScriptProjectProvider(LogFactory logFactory) : this(new ScriptParser(logFactory), new ScriptFilesResolver(), logFactory, ScriptEnvironment.Default)
+        public ScriptProjectProvider(LogFactory logFactory, string cachePath) : this(new ScriptParser(logFactory), new ScriptFilesResolver(), logFactory, cachePath, ScriptEnvironment.Default)
         {
         }
 
@@ -129,13 +131,18 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         }
 
 
-        public static string GetPathToProjectFile(string targetDirectory, string targetFramework, string projectName = null)
+        public string GetPathToProjectFile(string targetDirectory, string targetFramework, string projectName = null)
         {
             projectName ??= "script";
             var projectFileName = projectName + ".csproj";
-            var pathToProjectDirectory = FileUtils.CreateTempFolder(targetDirectory, targetFramework);
+            var pathToProjectDirectory = FileUtils.CreateTempFolder(targetDirectory, _cachePath, targetFramework);
             var pathToProjectFile = Path.Combine(pathToProjectDirectory, projectFileName);
             return pathToProjectFile;
+        }
+
+        public bool IsTempPath(string path)
+        {
+            return path.StartsWith(FileUtils.GetTempPath()) || path.StartsWith(_cachePath);
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
+++ b/src/Dotnet.Script.DependencyModel/Runtime/RuntimeDependencyResolver.cs
@@ -24,7 +24,7 @@ namespace Dotnet.Script.DependencyModel.Runtime
             _restorer = CreateRestorer(logFactory, useRestoreCache);
         }
 
-        public RuntimeDependencyResolver(LogFactory logFactory, bool useRestoreCache) : this(new ScriptProjectProvider(logFactory), logFactory, useRestoreCache)
+        public RuntimeDependencyResolver(LogFactory logFactory, string cachePath, bool useRestoreCache) : this(new ScriptProjectProvider(logFactory, cachePath), logFactory, useRestoreCache)
         {
         }
 

--- a/src/Dotnet.Script.Desktop.Tests/CompilationDepenencyTests.cs
+++ b/src/Dotnet.Script.Desktop.Tests/CompilationDepenencyTests.cs
@@ -28,7 +28,7 @@ namespace Dotnet.Script.Desktop.Tests
 
         private CompilationDependencyResolver CreateResolver()
         {
-            var resolver = new CompilationDependencyResolver(TestOutputHelper.CreateTestLogFactory());
+            var resolver = new CompilationDependencyResolver(TestOutputHelper.CreateTestLogFactory(), cachePath: null);
             return resolver;
         }
     }

--- a/src/Dotnet.Script.Shared.Tests/InteractiveRunnerTestsBase.cs
+++ b/src/Dotnet.Script.Shared.Tests/InteractiveRunnerTestsBase.cs
@@ -39,7 +39,7 @@ namespace Dotnet.Script.Shared.Tests
 
             var logFactory = TestOutputHelper.CreateTestLogFactory();
 
-            var compiler = new ScriptCompiler(logFactory, useRestoreCache: false);
+            var compiler = new ScriptCompiler(logFactory, cachePath: null, useRestoreCache: false);
             var runner = new InteractiveRunner(compiler, logFactory, console, Array.Empty<string>());
             return new InteractiveTestContext(console, runner);
         }

--- a/src/Dotnet.Script.Shared.Tests/TestPathUtils.cs
+++ b/src/Dotnet.Script.Shared.Tests/TestPathUtils.cs
@@ -16,7 +16,7 @@ namespace Dotnet.Script.Shared.Tests
 
         public static string GetPathToTempFolder(string path)
         {
-            return DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(path);
+            return DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(path, cachePath: null);
         }
 
         public static string GetPathToScriptPackages(string fixture)

--- a/src/Dotnet.Script.Tests/Commands/ExecuteInteractiveCommandTests.cs
+++ b/src/Dotnet.Script.Tests/Commands/ExecuteInteractiveCommandTests.cs
@@ -38,7 +38,7 @@ namespace Dotnet.Script.Tests.Commands
             };
 
             var ctx = GetExecuteInteractiveCommand(commands);
-            await ctx.Command.Execute(new ExecuteInteractiveCommandOptions(null, null, null));
+            await ctx.Command.Execute(new ExecuteInteractiveCommandOptions(null, null, null, null));
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("2", result);
@@ -56,7 +56,7 @@ namespace Dotnet.Script.Tests.Commands
             };
 
             var ctx = GetExecuteInteractiveCommand(commands);
-            await ctx.Command.Execute(new ExecuteInteractiveCommandOptions(new ScriptFile(pathToFixture), null, null));
+            await ctx.Command.Execute(new ExecuteInteractiveCommandOptions(new ScriptFile(pathToFixture), null, null, null));
 
             var result = ctx.Console.Out.ToString();
             Assert.Contains("500", result);

--- a/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
+++ b/src/Dotnet.Script.Tests/CompilationDependencyResolverTests.cs
@@ -84,7 +84,7 @@ namespace Dotnet.Script.Tests
 
         private CompilationDependencyResolver CreateResolver()
         {
-            var resolver = new CompilationDependencyResolver(TestOutputHelper.CreateTestLogFactory());
+            var resolver = new CompilationDependencyResolver(TestOutputHelper.CreateTestLogFactory(), null);
             return resolver;
         }
     }

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -151,7 +151,7 @@ namespace Dotnet.Script.Tests
 
         private static string GetPathToExecutionCache(string pathToScript)
         {
-            var pathToTempFolder = Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript);
+            var pathToTempFolder = Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript, cachePath: null);
             var pathToExecutionCache = Path.Combine(pathToTempFolder, "execution-cache");
             return pathToExecutionCache;
         }

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -1,4 +1,4 @@
-using Dotnet.Script.Shared.Tests;
+﻿using Dotnet.Script.Shared.Tests;
 using System;
 using System.IO;
 using Xunit;
@@ -131,6 +131,34 @@ namespace Dotnet.Script.Tests
             Assert.Contains(idScriptB, thirdResultOfScriptB.Output);
             Assert.Contains(idScriptB2, thirdResultOfScriptB.Output);
             Assert.False(thirdResultOfScriptB.Cached);
+        }
+
+        [Fact]
+        public void ShouldUseCachePathWhenProvided()
+        {
+            using var scriptFolder = new DisposableFolder();
+            var pathToScript = Path.Combine(scriptFolder.Path, "script.csx");
+
+            var executionPathA = DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript, cachePath: null);
+            Assert.True(Path.IsPathFullyQualified(executionPathA));
+            Assert.Contains("script.csx", executionPathA);
+
+            var fullCachePath = Path.Combine(scriptFolder.Path, "AlternateCachePath");
+            var fullCachePathNoRoot = fullCachePath.Substring(Path.GetPathRoot(fullCachePath).Length);
+            Assert.True(Path.IsPathFullyQualified(fullCachePath));
+
+            var executionPathB = DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript, cachePath: fullCachePath);
+            Assert.True(Path.IsPathFullyQualified(executionPathB));
+            Assert.Contains("script.csx", executionPathB);
+            Assert.Contains(fullCachePathNoRoot, executionPathB);
+
+            var relativeCachePath = Path.Combine("Relative", "CachePath");
+            Assert.False(Path.IsPathRooted(relativeCachePath));
+
+            var executionPathC = DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript, cachePath: relativeCachePath);
+            Assert.True(Path.IsPathFullyQualified(executionPathC));
+            Assert.Contains("script.csx", executionPathC);
+            Assert.Contains(relativeCachePath, executionPathC);
         }
 
         private (string output, string hash) Execute(string pathToScript)

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -1,6 +1,7 @@
 ﻿using Dotnet.Script.Shared.Tests;
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,19 +23,28 @@ namespace Dotnet.Script.Tests
             using var scriptFolder = new DisposableFolder();
             var pathToScript = Path.Combine(scriptFolder.Path, "main.csx");
 
-            WriteScript(pathToScript, "WriteLine(42);");
-            var (output, hash) = Execute(pathToScript);
-            Assert.Contains("42", output);
-            Assert.NotNull(hash);
+            var cachePaths = new string[]
+            {
+                null,
+                Path.Combine(scriptFolder.Path, "AlternateCachePath"),
+                Path.Combine("Relative", "AlternateCachePath"),
+            };
 
-            WriteScript(pathToScript, "WriteLine(42);");
-            var secondResult = Execute(pathToScript);
-            Assert.Contains("42", secondResult.output);
-            Assert.NotNull(secondResult.hash);
+            foreach (var cachePath in cachePaths)
+            {
+                WriteScript(pathToScript, "WriteLine(42);");
+                var (output, hash) = Execute(pathToScript, cachePath);
+                Assert.Contains("42", output);
+                Assert.NotNull(hash);
 
-            Assert.Equal(hash, secondResult.hash);
+                WriteScript(pathToScript, "WriteLine(42);");
+                var secondResult = Execute(pathToScript, cachePath);
+                Assert.Contains("42", secondResult.output);
+                Assert.NotNull(secondResult.hash);
+
+                Assert.Equal(hash, secondResult.hash);
+            }
         }
-
 
         [Fact]
         public void ShouldUpdateHashWhenSourceChanges()
@@ -42,17 +52,27 @@ namespace Dotnet.Script.Tests
             using var scriptFolder = new DisposableFolder();
             var pathToScript = Path.Combine(scriptFolder.Path, "main.csx");
 
-            WriteScript(pathToScript, "WriteLine(42);");
-            var (output, hash) = Execute(pathToScript);
-            Assert.Contains("42", output);
-            Assert.NotNull(hash);
+            var cachePaths = new string[]
+            {
+                null,
+                Path.Combine(scriptFolder.Path, "AlternateCachePath"),
+                Path.Combine("Relative", "AlternateCachePath"),
+            };
 
-            WriteScript(pathToScript, "WriteLine(84);");
-            var secondResult = Execute(pathToScript);
-            Assert.Contains("84", secondResult.output);
-            Assert.NotNull(secondResult.hash);
+            foreach (var cachePath in cachePaths)
+            {
+                WriteScript(pathToScript, "WriteLine(42);");
+                var (output, hash) = Execute(pathToScript, cachePath);
+                Assert.Contains("42", output);
+                Assert.NotNull(hash);
 
-            Assert.NotEqual(hash, secondResult.hash);
+                WriteScript(pathToScript, "WriteLine(84);");
+                var secondResult = Execute(pathToScript, cachePath);
+                Assert.Contains("84", secondResult.output);
+                Assert.NotNull(secondResult.hash);
+
+                Assert.NotEqual(hash, secondResult.hash);
+            }
         }
 
         [Fact]
@@ -63,10 +83,20 @@ namespace Dotnet.Script.Tests
 
             WriteScript(pathToScript, "#r \"nuget:AutoMapper, *\"", "WriteLine(42);");
 
-            var (output, hash) = Execute(pathToScript);
-            Assert.Contains("42", output);
+            var cachePaths = new string[]
+            {
+                null,
+                Path.Combine(scriptFolder.Path, "AlternateCachePath"),
+                Path.Combine("Relative", "AlternateCachePath"),
+            };
 
-            Assert.Null(hash);
+            foreach (var cachePath in cachePaths)
+            {
+                var (output, hash) = Execute(pathToScript, cachePath);
+                Assert.Contains("42", output);
+
+                Assert.Null(hash);
+            }
         }
 
         [Fact]
@@ -75,20 +105,40 @@ namespace Dotnet.Script.Tests
             using var scriptFolder = new DisposableFolder();
             var pathToScript = Path.Combine(scriptFolder.Path, "main.csx");
 
-            WriteScript(pathToScript, "#r \"nuget:LightInject, 5.2.1\"", "WriteLine(42);");
-            ScriptTestRunner.Default.Execute($"{pathToScript} --nocache");
-            var pathToExecutionCache = GetPathToExecutionCache(pathToScript);
-            Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.dll")));
-            Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.pdb")));
+            var cachePaths = new string[]
+            {
+                null,
+                Path.Combine(scriptFolder.Path, "AlternateCachePath"),
+                Path.Combine("Relative", "AlternateCachePath"),
+            };
+
+            foreach (var cachePath in cachePaths)
+            {
+                WriteScript(pathToScript, "#r \"nuget:LightInject, 5.2.1\"", "WriteLine(42);");
+                ExecuteScript(pathToScript, noCache: true, cachePath: cachePath);
+                var pathToExecutionCache = GetPathToExecutionCache(pathToScript, cachePath);
+                Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.dll")));
+                Assert.True(File.Exists(Path.Combine(pathToExecutionCache, "LightInject.pdb")));
+            }
         }
 
         [Fact]
         public void ShouldCacheScriptsFromSameFolderIndividually()
         {
-            static (string Output, bool Cached) Execute(string pathToScript)
+            static (string Output, bool Cached, string SavedWhere) Execute(string pathToScript, string cachePath)
             {
-                var (output, exitCode) = ScriptTestRunner.Default.Execute($"{pathToScript} --debug");
-                return (Output: output, Cached: output.Contains("Using cached compilation"));
+                var result = ExecuteScript(pathToScript, debug: true, cachePath: cachePath);
+
+                var isCached = result.Output.Contains("Using cached compilation");
+                var matchWhere = isCached
+                    ? Regex.Match(result.Output, "Using cached compilation: (.*)")
+                    : Regex.Match(result.Output, "Project file saved to (.*)");
+
+                return (
+                    Output: result.Output,
+                    Cached: isCached,
+                    SavedWhere: matchWhere.Success ? matchWhere.Groups[1].Value : string.Empty
+                );
             }
 
             using var scriptFolder = new DisposableFolder();
@@ -102,35 +152,58 @@ namespace Dotnet.Script.Tests
             var idScriptB = Guid.NewGuid().ToString();
             File.AppendAllText(pathToScriptB, $@"WriteLine(""{idScriptB}"");");
 
+            var cachePaths = new string[]
+            {
+                null,
+                Path.Combine(scriptFolder.Path, "AlternateCachePath"),
+                Path.Combine("Relative", "AlternateCachePath"),
+            };
 
-            var firstResultOfScriptA = Execute(pathToScriptA);
-            Assert.Contains(idScriptA, firstResultOfScriptA.Output);
-            Assert.False(firstResultOfScriptA.Cached);
+            foreach (var cachePath in cachePaths)
+            {
+                var firstResultOfScriptA = Execute(pathToScriptA, cachePath);
+                Assert.Contains(idScriptA, firstResultOfScriptA.Output);
+                Assert.False(firstResultOfScriptA.Cached);
 
-            var firstResultOfScriptB = Execute(pathToScriptB);
-            Assert.Contains(idScriptB, firstResultOfScriptB.Output);
-            Assert.False(firstResultOfScriptB.Cached);
+                var firstResultOfScriptB = Execute(pathToScriptB, cachePath);
+                Assert.Contains(idScriptB, firstResultOfScriptB.Output);
+                Assert.False(firstResultOfScriptB.Cached);
 
 
-            var secondResultOfScriptA = Execute(pathToScriptA);
-            Assert.Contains(idScriptA, secondResultOfScriptA.Output);
-            Assert.True(secondResultOfScriptA.Cached);
+                var secondResultOfScriptA = Execute(pathToScriptA, cachePath);
+                Assert.Contains(idScriptA, secondResultOfScriptA.Output);
+                Assert.True(secondResultOfScriptA.Cached);
 
-            var secondResultOfScriptB = Execute(pathToScriptB);
-            Assert.Contains(idScriptB, secondResultOfScriptB.Output);
-            Assert.True(secondResultOfScriptB.Cached);
+                var secondResultOfScriptB = Execute(pathToScriptB, cachePath);
+                Assert.Contains(idScriptB, secondResultOfScriptB.Output);
+                Assert.True(secondResultOfScriptB.Cached);
 
-            var idScriptB2 = Guid.NewGuid().ToString();
-            File.AppendAllText(pathToScriptB, $@"WriteLine(""{idScriptB2}"");");
+                var idScriptB2 = Guid.NewGuid().ToString();
+                File.AppendAllText(pathToScriptB, $@"WriteLine(""{idScriptB2}"");");
 
-            var thirdResultOfScriptA = Execute(pathToScriptA);
-            Assert.Contains(idScriptA, thirdResultOfScriptA.Output);
-            Assert.True(thirdResultOfScriptA.Cached);
+                var thirdResultOfScriptA = Execute(pathToScriptA, cachePath);
+                Assert.Contains(idScriptA, thirdResultOfScriptA.Output);
+                Assert.True(thirdResultOfScriptA.Cached);
 
-            var thirdResultOfScriptB = Execute(pathToScriptB);
-            Assert.Contains(idScriptB, thirdResultOfScriptB.Output);
-            Assert.Contains(idScriptB2, thirdResultOfScriptB.Output);
-            Assert.False(thirdResultOfScriptB.Cached);
+                var thirdResultOfScriptB = Execute(pathToScriptB, cachePath);
+                Assert.Contains(idScriptB, thirdResultOfScriptB.Output);
+                Assert.Contains(idScriptB2, thirdResultOfScriptB.Output);
+                Assert.False(thirdResultOfScriptB.Cached);
+
+                if (cachePath != null)
+                {
+                    var cachePathWithoutRoot = Path.IsPathRooted(cachePath)
+                        ? cachePath.Substring(Path.GetPathRoot(cachePath).Length)
+                        : cachePath;
+
+                    Assert.Contains(cachePathWithoutRoot, firstResultOfScriptA.SavedWhere);
+                    Assert.Contains(cachePathWithoutRoot, firstResultOfScriptB.SavedWhere);
+                    Assert.Contains(cachePathWithoutRoot, secondResultOfScriptA.SavedWhere);
+                    Assert.Contains(cachePathWithoutRoot, secondResultOfScriptB.SavedWhere);
+                    Assert.Contains(cachePathWithoutRoot, thirdResultOfScriptA.SavedWhere);
+                    Assert.Contains(cachePathWithoutRoot, thirdResultOfScriptB.SavedWhere);
+                }
+            }
         }
 
         [Fact]
@@ -161,12 +234,12 @@ namespace Dotnet.Script.Tests
             Assert.Contains(relativeCachePath, executionPathC);
         }
 
-        private (string output, string hash) Execute(string pathToScript)
+        private (string output, string hash) Execute(string pathToScript, string cachePath)
         {
-            var result = ScriptTestRunner.Default.Execute(pathToScript);
+            var result = ExecuteScript(pathToScript, cachePath: cachePath);
             testOutputHelper.WriteLine(result.Output);
             Assert.Equal(0, result.ExitCode);
-            string pathToExecutionCache = GetPathToExecutionCache(pathToScript);
+            string pathToExecutionCache = GetPathToExecutionCache(pathToScript, cachePath);
             var pathToCacheFile = Path.Combine(pathToExecutionCache, "script.sha256");
             string cachedhash = null;
             if (File.Exists(pathToCacheFile))
@@ -177,9 +250,9 @@ namespace Dotnet.Script.Tests
             return (result.Output, cachedhash);
         }
 
-        private static string GetPathToExecutionCache(string pathToScript)
+        private static string GetPathToExecutionCache(string pathToScript, string cachePath)
         {
-            var pathToTempFolder = Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript, cachePath: null);
+            var pathToTempFolder = Dotnet.Script.DependencyModel.ProjectSystem.FileUtils.GetPathToScriptTempFolder(pathToScript, cachePath);
             var pathToExecutionCache = Path.Combine(pathToTempFolder, "execution-cache");
             return pathToExecutionCache;
         }
@@ -187,6 +260,16 @@ namespace Dotnet.Script.Tests
         private static void WriteScript(string path, params string[] lines)
         {
             File.WriteAllLines(path, lines);
+        }
+
+        private static ProcessResult ExecuteScript(string pathToScript, bool debug = false, bool noCache = false, string cachePath = null)
+        {
+            var args = pathToScript +
+                (debug ? " --debug" : string.Empty) +
+                (noCache ? " --nocache" : string.Empty) +
+                (cachePath != null ? $" --cache-path {cachePath}" : string.Empty);
+
+            return ScriptTestRunner.Default.Execute(args);
         }
     }
 }

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -112,7 +112,7 @@ namespace Dotnet.Script.Tests
 
         private RuntimeDependencyResolver CreateRuntimeDependencyResolver()
         {
-            var resolver = new RuntimeDependencyResolver(TestOutputHelper.CreateTestLogFactory(), useRestoreCache: false);
+            var resolver = new RuntimeDependencyResolver(TestOutputHelper.CreateTestLogFactory(), cachePath: null, useRestoreCache: false);
             return resolver;
         }
 

--- a/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptProjectProviderTests.cs
@@ -25,7 +25,7 @@ namespace Dotnet.Script.Tests
         public void ShouldLogProjectFileContent()
         {
             StringBuilder log = new StringBuilder();
-            var provider = new ScriptProjectProvider(type => ((level, message, exception) => log.AppendLine(message)));
+            var provider = new ScriptProjectProvider(type => ((level, message, exception) => log.AppendLine(message)), null);
 
             provider.CreateProject(TestPathUtils.GetPathToTestFixtureFolder("HelloWorld"), _scriptEnvironment.TargetFramework, true);
             var output = log.ToString();
@@ -36,7 +36,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldUseSpecifiedSdk()
         {
-            var provider = new ScriptProjectProvider(TestOutputHelper.CreateTestLogFactory());
+            var provider = new ScriptProjectProvider(TestOutputHelper.CreateTestLogFactory(), null);
             var projectFileInfo = provider.CreateProject(TestPathUtils.GetPathToTestFixtureFolder("WebApi"), _scriptEnvironment.TargetFramework, true);
             Assert.Equal("Microsoft.NET.Sdk.Web", XDocument.Load(projectFileInfo.Path).Descendants("Project").Single().Attributes("Sdk").Single().Value);
         }

--- a/src/Dotnet.Script.Tests/ScriptRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptRunnerTests.cs
@@ -25,7 +25,7 @@ namespace Dotnet.Script.Tests
         private static ScriptRunner CreateScriptRunner()
         {
             var logFactory = TestOutputHelper.CreateTestLogFactory();
-            var scriptCompiler = new ScriptCompiler(logFactory, false);
+            var scriptCompiler = new ScriptCompiler(logFactory, null, false);
             
             return new ScriptRunner(scriptCompiler, logFactory, ScriptConsole.Default);
         }

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>1.6.1</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <Authors>filipw</Authors>
     <PackageId>Dotnet.Script</PackageId>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.6.1</VersionPrefix>
     <Authors>filipw</Authors>
     <PackageId>Dotnet.Script</PackageId>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>


### PR DESCRIPTION
Added a new command-line option "--cache-path" (or "-p") to allow users to specify the temporary directory used to build the script. This is equivalent to the 'DOTNET_SCRIPT_CACHE_LOCATION' environment variable but is far more convenient when scripts are run as part of MSBuild.  In particular, parallel runs of a script can specify different cache paths preventing the "script.csproj is in use" error that can happen. (Re: issues #507, #596, #540)

For example, 
```xml
    <Exec
      Command="dotnet-script --cache-path $(OutDir) PostBuildStep.csx -- $(TargetPath)"
      WorkingDirectory="$(ProjectDir)"
    />
```