### PR TITLE
fix: correct occured to occurred typo in build.sh line 11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ if [ ! -d "$DOTNET_SCRIPT" ]; then
     curl -L https://github.com/dotnet-script/dotnet-script/releases/download/$currentVersion/dotnet-script.$currentVersion.zip > "$SCRIPT_DIR/build/dotnet-script.zip"
     unzip -o "$SCRIPT_DIR/build/dotnet-script.zip" -d "$SCRIPT_DIR/build/"
     if [ $? -ne 0 ]; then
-        echo "An error occured while downloading dotnet-script"
+        echo "An error occurred while downloading dotnet-script"
         exit 1
     fi
 fi


### PR DESCRIPTION
Corrects the typo `occured` -> `occurred` in the error message at line 11 of build.sh.
